### PR TITLE
Proposal idea, send to one recipient at a time

### DIFF
--- a/KerbalStuff/celery.py
+++ b/KerbalStuff/celery.py
@@ -22,8 +22,9 @@ def send_mail(sender, recipients, subject, message, important=False):
     message['X-MC-PreserveRecipients'] = "false"
     message['Subject'] = subject
     message['From'] = sender
-    for group in chunks(recipients, 100):
-        message['To'] = ";".join(group)
+    for single_recipient in recipients:
+        message['To'] = single_recipient
+        group = (single_recipient)
         print("Sending email from {} to {} recipients".format(sender, len(group)))
         smtp.sendmail(sender, group, message.as_string())
     smtp.quit()


### PR DESCRIPTION
One possible solution to the "To" field containing everyone's email addresses and exposing them (privacy issue), issue #68. Changes loop to send to individual recipients, one at a time, instead of chunking in 100s.