### PR TITLE
Removing unnecessary py-bcrypt package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ pep8
 ply
 praw
 psycopg2
-py-bcrypt
 pyScss
 pystache
 pytz


### PR DESCRIPTION
Looks like this was causing pip to install the wrong version of bcrypt on a fresh install, IE Docker.

@godarklight 