### PR TITLE
Toggle between flask debug and gunicorn in docker

### DIFF
--- a/README_DOCKERFILE.md
+++ b/README_DOCKERFILE.md
@@ -43,6 +43,13 @@ User Credentials: user:development
 If you want to stop your container without losing any data, you can simply do ```docker-compose stop```.
 Then, to start it back up, do ```docker-compose up```.
 
+## Enabling Gunicorn
+By default, the flask debug server is used to facilitate local development, as it handles serving static files better than gunicorn and has the Werkzeug debugger enabled. To enable using Gunicorn, which is recommended for a production environment, you should set the ```USE_GUNICORN``` environment variable when starting the docker container. Do so either in your user's .bashrc file or on the command-line like below.
+
+```
+USE_GUNICORN=true docker-compose up
+```
+
 ## Odd and Ends
 ```
 docker exec -i -t spacedock bash # Start a bash shell in the spacedock container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
   spacedock:
     build: .
     container_name: spacedock
+    environment:
+      - USE_GUNICORN
     volumes:
       - .:/opt/spacedock
     ports:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -15,4 +15,8 @@ done
 /venv/spacedock/bin/python /opt/spacedock/db_initialize.py
 
 # Start the app
-/venv/spacedock/bin/gunicorn app:app --config /opt/spacedock/docker/gunicorn.py
+if [[ -n "$USE_GUNICORN" ]]; then
+    /venv/spacedock/bin/gunicorn app:app --config /opt/spacedock/docker/gunicorn.py
+else
+    /venv/spacedock/bin/python /opt/spacedock/app.py
+fi


### PR DESCRIPTION
This is needed because Gunicorn workers seem to have a bad habit of not seeing new static files when they are processed on the first request, forcing you to refresh the page twice everytime you make a change there.