### PR TITLE
Create a docker-compose for deployment

### DIFF
--- a/KerbalStuff/config.py
+++ b/KerbalStuff/config.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from distutils.util import strtobool
 
 try:
@@ -12,7 +13,14 @@ config = ConfigParser()
 config.readfp(open('config.ini'))
 env = 'dev'
 
-_cfg = lambda k: config.get(env, k)
+def get_env_var_or_config(section, key):
+    env_var = os.getenv(key.upper().replace('-', '_'))
+    if env_var:
+        return env_var
+    else:
+        return config.get(section, key)
+
+_cfg = lambda k: get_env_var_or_config(env, k)
 _cfgi = lambda k: int(_cfg(k))
 _cfgb = lambda k: strtobool(_cfg(k)) == 1
 

--- a/app.py
+++ b/app.py
@@ -10,9 +10,8 @@ app.static_folder = os.path.join(os.getcwd(), "static")
 
 
 def prepare():
-    if os.path.exists(app.static_folder):
-        rmtree(app.static_folder)
-    os.makedirs(app.static_folder)
+    rmtree(app.static_folder, ignore_errors=True)
+    os.makedirs(app.static_folder, exist_ok=True)
     compiler = scss.Scss(scss_opts={
         'style': 'compressed' if not app.debug else None
     }, search_paths=[

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -12,7 +12,7 @@ services:
     image: redis:latest
     container_name: redis
   spacedock:
-    build: .
+    image: spacedock.info:5550/spacedock:latest
     container_name: spacedock
     environment:
       - USE_GUNICORN=true
@@ -28,7 +28,7 @@ services:
       - db
       - redis
   nginx:
-    build: docker/nginx/
+    image: spacedock.info:5550/nginx:latest
     container_name: nginx
     ports:
       - "80"

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,17 +1,27 @@
 version: '2'
 services:
-  db:
+  data:
+    restart: always
     image: postgres:latest
-    container_name: db
     volumes:
       - /var/lib/postgresql
+  db:
+    restart: always
+    image: postgres:latest
+    container_name: db
+    volumes_from:
+      - data
+    depends_on:
+      - data
     environment:
       - POSTGRES_PASSWORD=somewhatsecretpassword
       - POSTGRES_DB=kerbalstuff
   redis:
+    restart: always
     image: redis:latest
     container_name: redis
   spacedock:
+    restart: always
     image: spacedock.info:5550/spacedock:latest
     container_name: spacedock
     environment:
@@ -28,10 +38,11 @@ services:
       - db
       - redis
   nginx:
+    restart: always
     image: spacedock.info:5550/nginx:latest
     container_name: nginx
     ports:
-      - "80"
+      - "22045:80"
     volumes_from:
       - spacedock
     volumes:

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -8,7 +8,6 @@ services:
   db:
     restart: always
     image: postgres:latest
-    container_name: db
     volumes_from:
       - data
     depends_on:
@@ -19,11 +18,9 @@ services:
   redis:
     restart: always
     image: redis:latest
-    container_name: redis
   spacedock:
     restart: always
     image: spacedock.info:5550/spacedock:latest
-    container_name: spacedock
     environment:
       - USE_GUNICORN=true
     volumes:
@@ -37,7 +34,6 @@ services:
   nginx:
     restart: always
     image: spacedock.info:5550/nginx:latest
-    container_name: nginx
     ports:
       - "127.0.0.1:22045:80"
     volumes_from:

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -34,9 +34,6 @@ services:
     links:
       - db
       - redis
-    depends_on:
-      - db
-      - redis
   nginx:
     restart: always
     image: spacedock.info:5550/nginx:latest
@@ -46,6 +43,4 @@ services:
     volumes_from:
       - spacedock
     links:
-      - spacedock
-    depends_on:
       - spacedock

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,0 +1,42 @@
+version: '2'
+services:
+  db:
+    image: postgres:latest
+    container_name: db
+    volumes:
+      - /var/lib/postgresql
+    environment:
+      - POSTGRES_PASSWORD=somewhatsecretpassword
+      - POSTGRES_DB=kerbalstuff
+  redis:
+    image: redis:latest
+    container_name: redis
+  spacedock:
+    build: .
+    container_name: spacedock
+    environment:
+      - USE_GUNICORN=true
+    volumes:
+      - /opt/spacedock/static
+      - /opt/spacedock/storage
+    expose:
+      - "5000"
+    links:
+      - db
+      - redis
+    depends_on:
+      - db
+      - redis
+  nginx:
+    build: docker/nginx/
+    container_name: nginx
+    ports:
+      - "80"
+    volumes_from:
+      - spacedock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - spacedock
+    depends_on:
+      - spacedock

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -45,8 +45,6 @@ services:
       - "22045:80"
     volumes_from:
       - spacedock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
     links:
       - spacedock
     depends_on:

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -42,7 +42,7 @@ services:
     image: spacedock.info:5550/nginx:latest
     container_name: nginx
     ports:
-      - "22045:80"
+      - "127.0.0.1:22045:80"
     volumes_from:
       - spacedock
     links:

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -21,6 +21,7 @@ services:
   spacedock:
     restart: always
     image: spacedock.info:5550/spacedock:latest
+    env_file: deployment_settings.cfg
     environment:
       - USE_GUNICORN=true
     volumes:

--- a/docker/deployment_settings.cfg.example
+++ b/docker/deployment_settings.cfg.example
@@ -1,0 +1,43 @@
+# Anything set in this file will override the corresponding entry in config.ini
+# Key names are UPPERCASE and replace dashes with underscores
+# Ex: site-name=Spacedock Dev becomes SITE_NAME=Spacedock Dev
+# Copy or link this file into the same directory as the docker-compose-deploy.yml file as 'deployment_settings.cfg', with your changes
+SITE_NAME=
+SUPPORT_MAIL=
+SOURCE_CODE=
+IRC_CHANNEL=
+DONATION_LINK=
+SHOW_DONATION_HEADER=
+PROTOCOL=
+DOMAIN=
+DEBUG_STATIC_RECOMPILE=
+SECRET_KEY=
+USE_X_ACCEL=
+REGISTRATION=
+DEBUG_HOST=
+DEBUG_PORT=
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_TLS=
+ERROR_TO=
+ERROR_FROM=
+CONNECTION_STRING=
+REDIS_CONNECTION=
+STORAGE=
+HOOK_IPS=
+HOOK_REPOSITORY=
+HOOK_BRANCH=
+RESTART_COMMAND=
+GH_OAUTH_ID=
+GH_OAUTH_SECRET=
+GOOGLE_OAUTH_ID=
+GOOGLE_OAUTH_SECRET=
+PROJECT_WONDERFUL_ID=
+GOOGLE_ANALYTICS_ID=
+GOOGLE_ANALYTICS_DOMAIN=
+DISQUS_ID=
+NETKAN_REPO_PATH=
+GITHUB_USER=
+GITHUB_PASS=

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM tutum/nginx
+MAINTAINER frikfry@gmail.com
+RUN rm /etc/nginx/sites-enabled/default
+ADD sites-enabled/ /etc/nginx/sites-enabled

--- a/docker/nginx/sites-enabled/spacedock.conf
+++ b/docker/nginx/sites-enabled/spacedock.conf
@@ -1,0 +1,21 @@
+server {
+
+    listen 80;
+    server_name example.org;
+    charset utf-8;
+
+    location /static {
+        alias /opt/spacedock/static;
+    }
+
+    location /content {
+        alias /opt/spacedock/storage;
+    }
+
+    location / {
+        proxy_pass http://spacedock:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/docker/nginx/sites-enabled/spacedock.conf
+++ b/docker/nginx/sites-enabled/spacedock.conf
@@ -1,7 +1,7 @@
 server {
 
-    listen 80;
-    server_name example.org;
+    listen 80 default_server;
+    server_name _;
     charset utf-8;
 
     location /static {


### PR DESCRIPTION
To make this deploy onto a server, you'd need some sort of proxy serving passing connections to the nginx container on 22075. The nginx container will take care of serving /content and /static and will pass everything else onto the spacedock container.

To get this to be deployed, you'd have to run (assuming inside a Jenkins job):
```
docker build --file $WORKSPACE/Dockerfile --tag spacedock.info:5550/spacedock:$GIT_COMMIT --tag spacedock.info:5550/spacedock:latest $WORKSPACE
docker build --file $WORKSPACE/docker/nginx/Dockerfile --tag spacedock.info:5550/nginx:$GIT_COMMIT --tag spacedock.info:5550/nginx:latest $WORKSPACE/docker/nginx

docker push spacedock.info:5550/spacedock
docker push spacedock.info:5550/nginx

docker-compose --file $WORKSPACE/docker-compose-deploy.yml --project-name spacedock up -d
```

Additional setup on the host would require that the user doing the deployment be logged into the spacedock repository. VITAS can be prompted for the credentials.
```
docker login --username <username> --email <your-email> spacedock.info:5550
```