### PR TITLE
Fix username in message body for mod updates

### DIFF
--- a/emails/mod-updated
+++ b/emails/mod-updated
@@ -1,4 +1,4 @@
-Hi there! {{ username }} has just published version {{ latest.friendly_version }} of {{ mod.name }} on {{ site_name }}! {{#changelog}}Here are the changes:
+Hi there! {{ user.username }} has just published version {{ latest.friendly_version }} of {{ mod.name }} on {{ site_name }}! {{#changelog}}Here are the changes:
 
 {{ changelog }}
 


### PR DESCRIPTION
Right now the username doesn't display, since the username token isn't formatted properly. Messages arrive reading like:

"Hi there!  has just published version"