### PR TITLE
Use only one postgres container, because of port weirdness

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,15 +1,10 @@
 version: '2'
 services:
-  data:
+  db:
     restart: always
     image: postgres:latest
     volumes:
       - /var/lib/postgresql
-  db:
-    restart: always
-    image: postgres:latest
-    volumes_from:
-      - data
     depends_on:
       - data
     environment:


### PR DESCRIPTION
There were weird port issues in docker that caused the port to be closed and nginx to give out a 502. Seems that using only one postgres container fixes this.