### PR TITLE
Stop sending spaces in licenses to CKAN

### DIFF
--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -16,7 +16,7 @@ def send_to_ckan(mod):
         'spec_version': 'v1.4',
         'identifier': re.sub(r'\W+', '', mod.name),
         '$kref': '#/ckan/spacedock/' + str(mod.id),
-        'license': mod.license,
+        'license': mod.license.replace(' ', '-'),
         'x_via': 'Automated ' + _cfg('site-name') + ' CKAN submission'
     }
     wd = _cfg("netkan_repo_path")


### PR DESCRIPTION
NetKAN has been receiving a number of SpaceDock pull requests with license strings that don't match what CKAN uses. This happens for the various Creative Commons licenses; SpaceDock uses a space after the CC, while CKAN expects a hyphen.

Latest example here ("CC BY-NC-SA 3.0" vs "CC-BY-NC-SA-3.0"):

- https://github.com/KSP-CKAN/NetKAN/pull/6094
- https://ci.ksp-ckan.org/job/NetKAN/6608/consoleText

This pull request replaces all spaces in a license string to be sent to CKAN with hyphens.