### PR TITLE
Return mod version creation datetime in API

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -65,6 +65,7 @@ def version_info(mod, version):
         "friendly_version": version.friendly_version,
         "game_version": version.gameversion.friendly_version,
         "id": version.id,
+        "created": version.created.isoformat(),
         "download_path": url_for('mods.download', mod_id=mod.id,
                                  mod_name=mod.name,
                                  version=version.friendly_version),


### PR DESCRIPTION
## Motivation

Mod authors sometimes delete and replace a version of a mod with a new download. If such a version has already been indexed by an external service (such as CKAN's bot), there's no way to know this has happened (ignoring active notifications for the moment).

This can cause problems for CKAN, since it tracks hashes to ensure that the file the user downloads is the same one the CKAN bot indexed. In KSP-CKAN/CKAN#2337 we implemented a strategy that solved this for GitHub using the release creation timestamp, but the same has not been possible for SpaceDock because the timestamp is unknown.

## Changes

Now the mod version API returns a `"created"` property containing the timestamp when that version was created, in ISO8601 format. This value is already part of the `ModVersion` data object:

https://github.com/KSP-SpaceDock/SpaceDock/blob/b4d9d0f54a8ba9752488eee3885a1529e7a8d15e/KerbalStuff/objects.py#L341-L359

The change itself is modeled after a similar property in `game_info`:

https://github.com/KSP-SpaceDock/SpaceDock/blob/b4d9d0f54a8ba9752488eee3885a1529e7a8d15e/KerbalStuff/blueprints/api.py#L80-L92

This will make it possible for the CKAN bot to tell when it has an old out of date download for a mod on SpaceDock.