### PR TITLE
Fixes for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:latest
 MAINTAINER frikfry@gmail.com # Someone let me know an appropriate email for the project
 
 # Needed to fix pip install of requirements due to strange char encoding issue.
@@ -7,11 +7,11 @@ ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get clean
 RUN apt-get update
-RUN apt-get install -y curl
+RUN apt-get install -y sudo curl
 # This needs to be broken up because curl isn't available at the start and we need curl to install nodejs
-RUN curl -sL https://deb.nodesource.com/setup | sudo bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
 # Don't need to apt-get update first because the script above does it for us.
-RUN apt-get install -y supervisor libffi-dev nodejs vim postgresql-client libpq-dev python-pip python-dev python3-dev build-essential
+RUN apt-get install -y supervisor libffi-dev nodejs vim netcat postgresql-client default-libmysqlclient-dev libpq-dev python-pip python-dev python3-dev build-essential
 RUN pip install --upgrade pip
 RUN pip install virtualenv
 
@@ -20,7 +20,7 @@ RUN mkdir -p /opt/spacedock
 WORKDIR /opt/spacedock
 
 # Install coffee-script
-RUN npm install --global coffee-script
+RUN npm install --global coffeescript
 
 # Breaking up the installing of requirements like this so that it gets cached by docker
 COPY requirements.txt /opt/spacedock/requirements.txt

--- a/config.ini.example
+++ b/config.ini.example
@@ -53,7 +53,7 @@ error-to=
 error-from=
 
 # SQL connection string
-connection-string=postgresql://postgres:somewhatsecretpassword@db/kerbalstuff
+connection-string=postgresql://postgres:somewhatsecretpassword@db/spacedock
 
 # Redis connection string
 # http://docs.celeryproject.org/en/3.0/getting-started/brokers/redis.html

--- a/db_initialize.py
+++ b/db_initialize.py
@@ -12,7 +12,7 @@ command.upgrade(alembic_cfg, "head")
 if not User.query.filter(User.username.ilike("admin")).first():
     admin = User("admin", "admin@example.com", "development")
     admin.admin = True
-    user.public = True
+    admin.public = True
     admin.confirmation = None
     db.add(admin)
     db.commit()

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,13 +1,13 @@
-version: '2'
+version: '3'
 services:
   db:
     restart: always
     image: postgres:latest
     volumes:
-      - /var/lib/postgresql
+      - spacedock-db:/var/lib/postgresql
     environment:
       - POSTGRES_PASSWORD=somewhatsecretpassword
-      - POSTGRES_DB=kerbalstuff
+      - POSTGRES_DB=spacedock
   redis:
     restart: always
     image: redis:latest
@@ -34,3 +34,6 @@ services:
       - spacedock
     links:
       - spacedock
+
+volumes:
+  spacedock-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
-version: '2'
+version: '3'
 services:
   db:
     image: postgres:latest
     container_name: db
     volumes:
-      - /var/lib/postgresql
+      - spacedock-db:/var/lib/postgresql
     environment:
       - POSTGRES_PASSWORD=somewhatsecretpassword
-      - POSTGRES_DB=kerbalstuff
+      - POSTGRES_DB=spacedock
   redis:
     image: redis:latest
     container_name: redis
@@ -26,3 +26,6 @@ services:
     depends_on:
       - db
       - redis
+
+volumes:
+  spacedock-db:

--- a/docker/start_celery.sh
+++ b/docker/start_celery.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-$(cd dirname $0/..; C_FORCE_ROOT=true /venv/spacedock/bin/celery -A KerbalStuff.celery worker --loglevel=info)
+cd $(dirname $0/)
+C_FORCE_ROOT=true /venv/spacedock/bin/celery -A KerbalStuff.celery worker --loglevel=info


### PR DESCRIPTION
Problem
-------
The Docker container is not runnable in the current state.
It is also based on Ubuntu 14.04, which isn't supported any more since this April.

Solution
-------
* Change `FROM ubuntu:14.04` to `FROM ubuntu:latest` to pull the latest LTS (currently 18.04).
* Install `sudo`, `netcat` and `default-libmysqlclient-dev` packages.
* Update NodeJS download source (old one is deprecated)
* Change `coffe-script` to `coffescript`, old npm package is deprecated.
* Some more small adjustments