### PR TITLE
Fix backend dependencies and CKAN notifications in API

### DIFF
--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -10,7 +10,7 @@ jinja2
 markdown
 oauthlib==2.0.6
 pillow
-psycopg2
+psycopg2-binary
 PyGithub
 pystache
 python-daemon

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -120,16 +120,16 @@
                 {{ profile.description | markdown }}
                 {% if user.admin %}
                 <p>
-                <span class="glyphicon glyphicon-fire"> <span class="text-muted">Email:</span> <a href="mailto:{{ profile.email }}">{{ profile.email }}</a><br />
-                <span class="glyphicon glyphicon-fire"> <span class="text-muted">Confirmed:</span>
+                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Email:</span> <a href="mailto:{{ profile.email }}">{{ profile.email }}</a><br />
+                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Confirmed:</span>
                 {% if profile.confirmation == None %}
                     Yes
                 {%else%}
                     No
                     <a href="/admin/manual-confirmation/{{ profile.id }}">[Confirm Manually]</a>
                 {% endif %}<br />
-                <span class="glyphicon glyphicon-fire"> <span class="text-muted">Public:</span> {% if profile.public %}Yes{% else %}No{% endif %}<br />
-                <span class="glyphicon glyphicon-fire"> <span class="text-muted">Created:</span> {{ profile.created }}
+                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Public:</span> {% if profile.public %}Yes{% else %}No{% endif %}<br />
+                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Created:</span> {{ profile.created }}
                 </p>
                 <a href="/admin/impersonate/{{profile.username}}" class="btn btn-primary" style="margin-bottom: 10px;">
                     <span class="glyphicon glyphicon-fire"></span>


### PR DESCRIPTION
**Depend on psycopg2-binary instead of building it from source:**
---

There is a non-Python dependency for building the package from source, an error is thrown trying to do `pip3 install -r requirements-backend.txt`.
To solve this, use the binary package instead.

**Fix ckan notification in API:**
---

The API _tried_ to always send new mods to ckan after creation, even if not requested by the mod author. Now it checks for the tag before doing so.

Also, it didn't work at all, because `send_to_ckan()` has to be used for new mods. `notify_ckan` is only for updated mods.

Also check whether `mod.ckan` is set before notifying it after updates via the API.

**Add missing closing tags for two spans in view_profile.html:**
---

To be precise, in the administrator code section.