### PR TITLE
Stop using json.dumps for /api/games

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -211,8 +211,7 @@ def games_list():
     results = list()
     for v in Game.query.order_by(desc(Game.name)):
         results.append(game_info(v))
-    # Workaround because CustomJSONEncoder seems to have problems with this
-    return json.dumps(results)
+    return results
 
 
 @api.route("/api/publishers")


### PR DESCRIPTION
The current endpoint, https://alpha.spacedock.info/api/games, returns an HTML page, when it should be returning a JSON file. The publishers endpoint (https://alpha.spacedock.info/api/publishers) doesn't use `json.dumps()` and actually returns a JSON file.

If it's indeed broken like the comment I removed said it was, I suggest we merge this so we can figure out why returning a JSON object is broken for this endpoint.