### PR TITLE
Make support server/channel links in footer dynamic

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -26,7 +26,7 @@ from .blueprints.mods import mods
 from .blueprints.profile import profiles
 from .celery import update_from_github
 from .common import firstparagraph, remainingparagraphs, json_output, wrap_mod, dumb_object
-from .config import _cfg, _cfgb
+from .config import _cfg, _cfgb, _cfgl
 from .custom_json import CustomJSONEncoder
 from .database import db
 from .helpers import is_admin, following_mod, following_user
@@ -255,7 +255,7 @@ def inject():
         'site_name': _cfg('site-name'),
         'support_mail': _cfg('support-mail'),
         'source_code': _cfg('source-code'),
-        'irc_channel': _cfg('irc-channel'),
+        'support_channels': _cfgl('support-channels'),
         'donation_link': _cfg('donation-link'),
         'donation_header_link': _cfgb('donation-header-link') if not dismissed_donation else False,
         'registration': _cfgb('registration')

--- a/KerbalStuff/config.py
+++ b/KerbalStuff/config.py
@@ -1,3 +1,4 @@
+import ast
 import logging.config
 import os
 from configparser import ConfigParser
@@ -20,6 +21,7 @@ def get_env_var_or_config(section, key):
 _cfg = lambda k: get_env_var_or_config(env, k)
 _cfgi = lambda k: int(_cfg(k))
 _cfgb = lambda k: strtobool(_cfg(k)) == 1
+_cfgl = lambda k: ast.literal_eval(_cfg(k))
 
 logging.config.fileConfig('logging.ini', disable_existing_loggers=True)
 site_logger = logging.getLogger(_cfg('site-name'))

--- a/config.ini.example
+++ b/config.ini.example
@@ -12,8 +12,8 @@ activation-mail=
 # Where the source code of your page is hosted. If you have forked and
 # edited the code, change this. Otherwise don't.
 source-code=https://github.com/KSP-SpaceDock/KerbalStuff
-# If you have an IRC Channel for providing support, you may add the adress here.
-irc-channel=http://webchat.esper.net/?channels=spacedock
+# Put all support channels in here, like Riot, Discord or IRC.
+support-channels={ "Riot" : "https://im.52k.de/", "Discord" : "https://discord.gg/htPQYqC", "IRC" : "http://webchat.esper.net/?channels=spacedock" }
 # If you have a donation link, you may add the address here.
 donation-link=https://www.patreon.com/user?u=2903335&ty=p
 # If you have a donation link and want it displayed below the header, set this to 'true'

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -41,7 +41,7 @@
         <!-- Piwik -->
           {% if admin %}
           	{% set VisitorType = 'Admin' %}
-          {% else %}	
+          {% else %}
           	{% if not user %}
 				{% set VisitorType = 'Guest' %}
             {% else %}
@@ -54,7 +54,7 @@
           	{% set SearchResultCount = 0 %}
           {% endif %}
         <noscript><p><img src="//stats.52k.de/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
-        <!-- End Piwik Code -->     
+        <!-- End Piwik Code -->
     </head>
     <body class="{% if user %}logged-in{% endif %}">
         {% block nav %}
@@ -181,12 +181,13 @@
                             <li><a href="{{ source_code }}">Source Code</a></li>
                             <li><a href="{{ source_code }}/blob/master/api.md">API</a></li>
                             <li><a href="/privacy">Terms & Privacy</a></li>
-                            <li><a href="/blog">Blog</a></li>
                             <li><a href="mailto:{{ support_mail }}">Support</a></li>
-                            {% if not irc_channel == "" %}
-                            <li><a href="{{ irc_channel }}" target="_blank">IRC</a></li>
+                            {% for key, value in support_channels.items() %}
+                            {% if value %}
+                            <li><a href="{{ value }}" target="_blank">{{ key }}</a></li>
                             {% endif %}
-                            {% if not donation_link == "" %}
+                            {% endfor %}
+                            {% if donation_link %}
                             <li><a href="{{ donation_link }}">Donate</a></li>
                             {% endif %}
                         </ul>


### PR DESCRIPTION
Motivation
---

The footer was missing links to the Discord and Riot channels.
By adding more entries for each link, I realised that it will be a lot better to maintain if there's just one config entry for all of them.
If a new channel comes up, or an old one goes away, there's only a single change needed (well or two, if you count the `config.ini.example`) instead of 3 (4).

Changes
---

This deletes the old `'IRC-channel'` config entry, and instead creates a new one called `support-channels`, which should be a dictionary, where the key is the link text and the value is the link URL.

To parse the dictionary string to a dict object, `ast.literal_eval()` is used. I read somewhere this should be safe, as long as the string is not a few thousand chars long or something.
This method is called via `_cfgl` (for config **l**iteral evaluation), and not exclusive to dictionaries! It can be used for other entries and data types like arrays in the future, too.

In `layout.html` we now loop over the dictionary.

The `Blog` link was removed, since the blog isn't really existing.