### PR TITLE
Allow crafts and flags

### DIFF
--- a/templates/create.html
+++ b/templates/create.html
@@ -19,7 +19,7 @@
         <h3>Create a new mod</h3>
         <p>Thanks for helping make {{ site_name }} more awesome!<br/>
         Double check that your mod meets <a href="#" data-toggle="modal" data-target="#mod-guidelines">our guidelines</a>, please.<br/>
-        <span class="intense-text">Craft files and flag packs are NOT mods and will be removed.</span>
+        <span class="intense-text">Craft files should be uploaded to <a href="https://kerbalx.com/" target="_blank">KerbalX</a> instead of SpaceDock.</span>
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Motivation

Currently when you create a mod, you get this message:

![image](https://user-images.githubusercontent.com/1559108/63529220-dddf3280-c4f3-11e9-8271-39ab9719a501.png)

However, the red text does not reflect current intentions; @V1TA5 said this on IRC:

> i think of flag and texture mods not as real mods (for me a mod has to contain code). but i decided to tollerate gfx mods (textures,flags,etc) because its strictly still modifying the game and SD should thus offer hosting for them.

## Changes

Now the red text about craft files and flag packs no longer mentions flags, and indicates that craft files should be uploaded to KerbalX.

(Let's hold off on merging this until we're ready to test the web hook again.)