### PR TITLE
Gracefully handle missing config

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -26,7 +26,7 @@ from .blueprints.mods import mods
 from .blueprints.profile import profiles
 from .celery import update_from_github
 from .common import firstparagraph, remainingparagraphs, json_output, wrap_mod, dumb_object
-from .config import _cfg, _cfgb, _cfgl
+from .config import _cfg, _cfgb, _cfgd
 from .custom_json import CustomJSONEncoder
 from .database import db
 from .helpers import is_admin, following_mod, following_user
@@ -255,7 +255,7 @@ def inject():
         'site_name': _cfg('site-name'),
         'support_mail': _cfg('support-mail'),
         'source_code': _cfg('source-code'),
-        'support_channels': _cfgl('support-channels'),
+        'support_channels': _cfgd('support-channels'),
         'donation_link': _cfg('donation-link'),
         'donation_header_link': _cfgb('donation-header-link') if not dismissed_donation else False,
         'registration': _cfgb('registration')

--- a/KerbalStuff/config.py
+++ b/KerbalStuff/config.py
@@ -22,19 +22,19 @@ def _cfg(k):
     return get_env_var_or_config(env, k)
 
 
-def _cfgi(k):
+def _cfgi(k, default = 0):
     val = _cfg(k)
-    return int(val) if val is not None else 0
+    return int(val) if val is not None else default
 
 
-def _cfgb(k):
+def _cfgb(k, default = False):
     val = _cfg(k)
-    return strtobool(val) == 1 if val is not None else False
+    return strtobool(val) == 1 if val is not None else default
 
 
-def _cfgl(k):
+def _cfgl(k, default = {}):
     val = _cfg(k)
-    return ast.literal_eval(val) if val is not None else {}
+    return ast.literal_eval(val) if val is not None else default
 
 
 logging.config.fileConfig('logging.ini', disable_existing_loggers=True)

--- a/KerbalStuff/config.py
+++ b/KerbalStuff/config.py
@@ -32,7 +32,9 @@ def _cfgb(k, default = False):
     return strtobool(val) == 1 if val is not None else default
 
 
-def _cfgl(k, default = {}):
+def _cfgd(k, default = None):
+    if default is None:
+        default = {}
     val = _cfg(k)
     return ast.literal_eval(val) if val is not None else default
 

--- a/KerbalStuff/config.py
+++ b/KerbalStuff/config.py
@@ -15,13 +15,27 @@ def get_env_var_or_config(section, key):
     if env_var:
         return env_var
     else:
-        return config.get(section, key)
+        return config.get(section, key, fallback=None)
 
 
-_cfg = lambda k: get_env_var_or_config(env, k)
-_cfgi = lambda k: int(_cfg(k))
-_cfgb = lambda k: strtobool(_cfg(k)) == 1
-_cfgl = lambda k: ast.literal_eval(_cfg(k))
+def _cfg(k):
+    return get_env_var_or_config(env, k)
+
+
+def _cfgi(k):
+    val = _cfg(k)
+    return int(val) if val is not None else 0
+
+
+def _cfgb(k):
+    val = _cfg(k)
+    return strtobool(val) == 1 if val is not None else False
+
+
+def _cfgl(k):
+    val = _cfg(k)
+    return ast.literal_eval(val) if val is not None else {}
+
 
 logging.config.fileConfig('logging.ini', disable_existing_loggers=True)
 site_logger = logging.getLogger(_cfg('site-name'))


### PR DESCRIPTION
## Problem

After #234 got pulled to alpha, the server started returning status 500 errors:

```
Aug 28 10:58:11 sd6 gunicorn[16884]: 2019-08-28 10:58:11,198 ERROR Backend:16891 Exception on / [GET]
Aug 28 10:58:11 sd6 gunicorn[16884]: Traceback (most recent call last):
Aug 28 10:58:11 sd6 gunicorn[16884]:   File "/usr/lib/python3.6/configparser.py", line 789, in get
Aug 28 10:58:11 sd6 gunicorn[16884]:     value = d[option]
Aug 28 10:58:11 sd6 gunicorn[16884]:   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.6/collections/__init__.py"
Aug 28 10:58:11 sd6 gunicorn[16884]:     return self.__missing__(key)            # support subclasses that define __missing__
Aug 28 10:58:11 sd6 gunicorn[16884]:   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.6/collections/__init__.py"
Aug 28 10:58:11 sd6 gunicorn[16884]:     raise KeyError(key)
Aug 28 10:58:11 sd6 gunicorn[16884]: KeyError: 'support-channels'
```

## Cause

That PR defined a new setting in `config.ini`, `support-channels`. The configuration management code in `config.py` throws an exception if we attempt to access an undefined setting. `support-channels` was added to `config.ini.example`, but it was not present in `config.ini` when the server auto-restarted itself.

This is a major headache for upgrades. In effect we have to keep a list of new config settings that need to be defined and then add them before pulling/restarting.

## Changes

Now if a config setting isn't set, instead of throwing an exception:

- `_cfg` will return `None`
- `_cfgi` will return `0`
- `_cfgb` will return `False`
- `_cfgl` will return `{}` (an empty associative array)

If these defaults are not appropriate for a particular setting, they can be overridden with a new `default` parameter to `_cfgi`, `_cfgb`, and `_cfgl`.

This should make the migration process for new settings smoother. Note that code calling these functions may still need to consider whether to add special handling for the default values; that's outside the scope of this PR, but at least now it will be possible since the core accessors won't crash.