### PR TITLE
Show short mod abstract on mod page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.4"
 services:
   db:
     image: postgres:11.4
-    restart: always
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -16,7 +15,6 @@ services:
 
   adminer:
     image: adminer
-    restart: always
     ports:
       - 8080:8080
     networks:
@@ -33,7 +31,6 @@ services:
       context: ./
       target: backend-dev
     user: spacedock
-    restart: always
     environment:
       - FLASK_APP=KerbalStuff.app:app
       - FLASK_RUN_PORT=9999
@@ -77,7 +74,6 @@ services:
   frontend:
     image: spacedock_frontend
     build: frontend
-    restart: always
     ports:
       - 5080:80
       - 5443:443

--- a/frontend/styles/listing.scss
+++ b/frontend/styles/listing.scss
@@ -34,7 +34,6 @@
 }
 
 .item {
-    background-color:#fff;
     position:relative;
     display:block;
     padding:0;

--- a/frontend/styles/stylesheet.scss
+++ b/frontend/styles/stylesheet.scss
@@ -4,6 +4,11 @@ body {
     padding-top: 50px;
 }
 
+.vertical-centered {
+    display: flex;
+    align-items: center;
+}
+
 .centered {
     text-align: center;
 }

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -37,9 +37,10 @@
     {% endif %}
 
     <div class="container lead">
-        <div class="row">
+        <div class="row vertical-centered">
             <div class="col-md-8">
                 <h1 title="{{ mod.name }}">Edit {{ mod.name }}</h1>
+                <input type="text" class="form-control input-block-level" name="short-description" value="{{ mod.short_description }}" placeholder="Short description..." />
             </div>
             <div class="col-md-2">
                 <input type="submit" class="btn btn-primary btn-block" value="Save Changes" />
@@ -49,7 +50,6 @@
             </div>
         </div>
         <link rel="stylesheet" href="/static/editor.css">
-        <div class="space-left-right"><input type="text" class="form-control input-block-level" name="short-description" value="{{ mod.short_description }}" placeholder="Short description..." /></div>
     </div>
 
     <div class="info-list">

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -45,7 +45,7 @@
 </div>
 {% endif %}
 <div class="container lead">
-    <div class="row">
+    <div class="row vertical-centered">
         <div class="col-md-8">
             <h1 title="{{ mod.name }}">
                 {{ mod.name }}
@@ -53,6 +53,7 @@
                 <span class="badge" title="This mod is listed in CKAN.">CKAN</span>
                 {% endif %}
             </h1>
+            <small>{{ mod.short_description }}</small>
         </div>
         <div class="{% if user %}col-md-2{% else %}col-md-4{% endif %}">
             <a  class="btn btn-block btn-lg btn-primary piwik_download" id="download-link-primary"


### PR DESCRIPTION
## Motivation
For commit one (`Don't restart containers in development setup`):
Currently the Docker containers restart themselves if you didn't stop them manually even after PC reboots for example. It was quite funny to realize the SD containers started themselves on my PC everyday after about a week of not touching them.

Fro commit two:
The short mod description is currently not shown on the mod page itself. You can only see it if you hover over the mod card on the mod list page. or if you edit the mod.

## Changes
Commit one:
Change the Docker container restart policy to default (which is "never") in the docker-compose.yml used for development. I think this is the better policy, since if the containers crash, you normally want to investigate what's going on before the containers start automatically again.

Commit two:
Show the short description right under the mod's title. Also center it vertically, since it didn't look good at all without it.

Bootstrap 3 doesn't have a CSS property built in for this (only Bootstrap 4), so I did something myself.
Someone knowing CSS best practices (or more than me (that means basically anything)) is invited to have a look and correct me if I did it the wrong way.

## Pics
### Normal mod page
#### Previously
![grafik](https://user-images.githubusercontent.com/28812678/67873390-afa15300-fb33-11e9-94b1-7b75437aeafb.png)
#### New
Whole page
![grafik](https://user-images.githubusercontent.com/28812678/67872821-cb582980-fb32-11e9-8f7c-c36df9c44b5b.png)
Close-up
![grafik](https://user-images.githubusercontent.com/28812678/67872905-eaef5200-fb32-11e9-9e62-e1bb3c7338ff.png)
Short description
![grafik](https://user-images.githubusercontent.com/28812678/67873024-1eca7780-fb33-11e9-8945-71bb2190697c.png)
Phones
![grafik](https://user-images.githubusercontent.com/28812678/67876541-5d166580-fb38-11e9-8eb9-1f9f31950eef.png)

### Mod editing page
#### Previously
![grafik](https://user-images.githubusercontent.com/28812678/67873348-a0baa080-fb33-11e9-9c20-325a75b21018.png)
#### New
![grafik](https://user-images.githubusercontent.com/28812678/67873097-3dc90980-fb33-11e9-9ad1-bb47a34fb6a9.png)
(The input control does "scroll" the text automatically)

