### PR TITLE
Fix download_path being saved absolute in the database

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -188,7 +188,7 @@ def _save_mod_zipball(mod_name, friendly_version, zipball):
     if os.path.isfile(file_path):
         os.remove(file_path)
     zipball.save(file_path)
-    return file_path
+    return os.path.join(storage_base, filename)
 
 
 def serialize_mod_list(mods):


### PR DESCRIPTION
## Problem:
For newly uploaded mod releases, the `download_path` also saved in the database is set to the absolute path (`/srv/storage/...`), instead of the relative path inside the `storage_path`.
This path is later used to dynamically generate the links to download mods, and this is leading to 404s due to the wrong path:
`GET https://spacedock.info/content//srv/storage/kspmods/DasSkelett_3/Super_Awesome_Test_Mod/Super_Awesome_Test_Mod-1.5.zip`

This happened somewhere in the big refactor, the path has been combined inline before:
`version = ModVersion(secure_filename(version), game_version_id, os.path.join(base_path, filename))`

## Solution
`_save_mod_zipball()` now returns the relative path again, which is then saved in the database via `ModVersion()`.