### PR TITLE
Catch and display upload errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3 as backend-dev
+FROM python:3.7 as backend-dev
 ENV PYTHONUNBUFFERED=1
 RUN useradd -m -d /opt/spacedock -s /bin/bash spacedock
 RUN pip3 install --upgrade pip setuptools wheel pip-licenses

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -548,7 +548,7 @@ def create_list():
         return { 'error': True, 'reason': 'Fields exceed maximum permissible length.' }, 400
     mod_list = ModList(name=name,
                        user=current_user,
-                       game_id=game_id)
+                       game_id=game)
     db.add(mod_list)
     db.commit()
     return { 'url': url_for("lists.view_list", list_id=mod_list.id, list_name=mod_list.name) }
@@ -598,7 +598,10 @@ def create_mod():
     if not game_version_id:
         return {'error': True, 'reason': 'Game version does not exist.'}, 400
     # Save zipball
-    (full_path, relative_path) = _save_mod_zipball(mod_name, friendly_version, zipball)
+    try:
+        (full_path, relative_path) = _save_mod_zipball(mod_name, friendly_version, zipball)
+    except IOError:
+        return {'error': True, 'reason': 'Failed to save zip file.'}, 500
     if not zipfile.is_zipfile(full_path):
         return {'error': True, 'reason': 'This is not a valid zip file.'}, 400
     version = ModVersion(friendly_version=friendly_version,
@@ -658,7 +661,11 @@ def update_mod(mod_id):
             return {'error': True,
                     'reason': 'We already have this version. '
                               'Did you mistype the version number?'}, 400
-    (full_path, relative_path) = _save_mod_zipball(mod.name, friendly_version, zipball)
+    # Save zipball
+    try:
+        (full_path, relative_path) = _save_mod_zipball(mod.name, friendly_version, zipball)
+    except IOError:
+        return {'error': True, 'reason': 'Failed to save zip file.'}, 500
     if not zipfile.is_zipfile(full_path):
         return {'error': True, 'reason': 'This is not a valid zip file.'}, 400
     version = ModVersion(friendly_version=friendly_version,

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - the build process
-FROM node:10.16 as build-deps
+FROM node:10 as build-deps
 WORKDIR /usr/src/app
 ADD package.json ./
 ADD package-lock.json ./
@@ -11,7 +11,7 @@ ADD build.js ./
 RUN npm run build
 
 # Stage 2 - the environment
-FROM nginx:1.17.2
+FROM nginx:1.17
 WORKDIR /var/www/static
 ADD static/css/ ./
 ADD static/js/ ./


### PR DESCRIPTION
## Problem
Currently most of the errors you can encounter while/after uploading mods are "swallowed".
These are for example problems saving a zipball due to the reoccurring storage problem, an invalid zipfile, internal server errors and so on.
What happens now is that error messages are actually returned by the server/api, but the client/frontend is not able to display them (or better, throws an exception trying to display them), and thus the frontend stays in an incomplete state, where the user can't see what actually happens or already happened behind the scenes. It appears to load infinitely, as often reported in the forums.

## Solution
The JavaScript code is re-ordered to
first check if there's a valid JSON response by the server,
  a) if yes, check if result.error is false
	a.a) if yes, everything's fine! Upload succeeded, redirect to the main mod page.
    a.b) if no, take the supplied error message and show it.
  b) if no valid JSON is given, this means that it's probably an connection error  to the server or the backend threw an error handling the upload request.
We check the returned status code and show a more or less appropriate message.

It should no longer load to infinity after errors, instead a message should be shown, and the user can act based on it (in the best case, they inform us...)

---

I also extended the upload backend code a bit to catch `IOError`s when trying to save the zip file and return a more direct message.
I hope this is the one that is returned when the samba storage locks up again.

---

The Dockerfiles were version-locked down to the patch level, and were often already pretty outdated. I removed the patch part, so that they auto-update a little bit, within the given minor version.
Doesn't affect prod/beta/alpha, since we don't use the Docker containers there, so only local dev envs.