### PR TITLE
Check if mod is published in CKAN triggers

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -618,8 +618,7 @@ def create_mod():
     db.add(mod)
     db.commit()
     set_game_info(game)
-    if mod.ckan:
-        send_to_ckan(mod)
+    send_to_ckan(mod)
     return {
         'url': url_for("mods.mod", mod_id=mod.id, mod_name=mod.name),
         "id": mod.id,
@@ -674,8 +673,7 @@ def update_mod(mod_id):
     db.commit()
     if notify in TRUE_STR:
         send_update_notification(mod, version, current_user)
-    if mod.ckan:
-        notify_ckan(mod, 'update')
+    notify_ckan(mod, 'update')
     return {
         'url': url_for("mods.mod", mod_id=mod.id, mod_name=mod.name),
         'id': version.id

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -218,8 +218,7 @@ def edit_mod(mod_id, mod_name):
         mod.description = description
         if not mod.ckan and ckan:
             mod.ckan = ckan
-            if mod.published:
-                send_to_ckan(mod)
+            send_to_ckan(mod)
         if background and background != '':
             mod.background = background
         try:

--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -6,7 +6,7 @@ from .config import _cfg
 
 
 def send_to_ckan(mod):
-    if mod.ckan and _cfg("create-url"):
+    if mod.ckan and mod.published and _cfg("create-url"):
         site_base_url = _cfg("protocol") + "://" + _cfg("domain")
         _bg_post(_cfg("create-url"), {
             'name': mod.name,
@@ -24,7 +24,7 @@ def send_to_ckan(mod):
 
 
 def notify_ckan(mod, event_type):
-    if mod.ckan and _cfg("notify-url"):
+    if mod.ckan and mod.published and _cfg("notify-url"):
         _bg_post(_cfg("notify-url"), {
             'mod_id': mod.id,
             'event_type': event_type,


### PR DESCRIPTION
## Problem

CKAN is receiving mod indexing requests for unpublished mods, which are then updated at publish. KSP-CKAN/NetKAN#7896:

![image](https://user-images.githubusercontent.com/1559108/81849288-f4169e00-951b-11ea-9104-944e479bf14d.png)

Unpublished mods aren't supposed to be revealed to the world in any way, and CKAN's validation checks won't work until publish.

## Cause

In #231 a `notify_ckan` call in `create_mod` was changed to `send_to_ckan`. `notify_ckan` did not make sense because it only works for mods that are already indexed. However, `send_to_ckan` **still** doesn't make sense because a mod at this point is not published, and all other usages of this function check `mod.published`. `create_mod` as currently written cannot validly trigger _any_ CKAN events. However, in principle it is possible that at some point in the future `create_mod` might also set a mod as published, if such a change was worked on.

## Changes

Now `notify_ckan` and `send_to_ckan` themselves check both `mod.ckan` and `mod.published` internally and only send triggers if both are true, so it will be safe to call either one whenever we want. NetKAN pull requests will now be submitted at publish instead of creation. The code calling these functions no longer checks either of these properties.