### PR TITLE
Don't break profile page if a mod has no default_version

### DIFF
--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -20,7 +20,8 @@ def view_profile(username):
             if not current_user.admin:
                 abort(401)
     mods_created = sorted(user.mods, key=lambda mod: mod.created, reverse=True)
-    if not current_user or current_user.id != user.id:
+    # Remove unpublished mods from the list if it's not the accessing's user's own profile, or it is and admin.
+    if not current_user or (current_user.id != user.id and not current_user.admin):
         mods_created = [mod for mod in mods_created if mod.published]
     mods_followed = sorted(user.following, key=lambda mod: mod.created, reverse=True)
     return render_template("view_profile.html", profile=user, mods_created=mods_created, mods_followed=mods_followed)

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -2,7 +2,9 @@
 <div class="flip-container" ontouchstart="this.classList.toggle('hover');">
 	<div class="changer">
     <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}" style="width: 100%;">
+        {% if mod.default_version %}
         <div class="ksp-update">For {{ mod.default_version.gameversion.friendly_version }}</div>
+        {% endif %}
         {% if following_mod(mod) %}
         <div class="following-mod">Following</div>
         {% endif %}


### PR DESCRIPTION
## Problem
Currently, if for some, theoretically impossible, reason a mod of an author has no `default_version`, viewing their profile results in a 500.
(If the mod is still unpublished, it only results in a 500 for the author)

The cause of the error are the mod boxes, that are accessing `mod.default_version.gameversion` to display the `For ...` message in the corner. If `mod.default_version` is `None`, an exception is thrown.

## Changes
`mod-box.html` checks if `mod.default_version` is `None`, and if so, displays an `-` instead of the KSP version.

Also the flask route is enhanced to also show unpublished mods to admins.

## TODO
There are still many other places left where we are accessing `mod.default_version` without null-checks, for example the mod page itself.
They have to be fixed separately, which is more work.

If we want to allow mods without any releases, we'd have to do this work.
Otherwise, we could try to make the `Mod.default_version_id` column non-nullable. This needs a rather complex data migration to make sure there are no mods with `default_version_id=None` left, but I already have some code for that.

Most important, we have to find out, where `Mod.default_version` can be set to `None` currently and fix that.