### PR TITLE
Rework the admin area

### DIFF
--- a/templates/admin-blog.html
+++ b/templates/admin-blog.html
@@ -1,0 +1,19 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="blog">
+    <div class="container admin-container space-left-right">
+        <h3>New Blog Post</h3>
+        <form role="form" action="{{ url_for("blog.post_blog")}}" method="POST">
+            <div class="form-group">
+                <label for="post-title">Title</label>
+                <input type="text" class="form-control" id="post-title" name="post-title" placeholder="Title">
+            </div>
+            <div class="form-group">
+                <label for="post-body">Body <small class="text-muted"><a target="_blank" href="/markdown">Markdown</a> supported</small></label>
+                <textarea name="post-body" id="post-body" class="form-control input-block-level" rows=10></textarea>
+            </div>
+            <input type="submit" class="btn btn-primary btn-block" value="Publish">
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin-blog.html
+++ b/templates/admin-blog.html
@@ -16,4 +16,7 @@
         </form>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-blog').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-email.html
+++ b/templates/admin-email.html
@@ -1,0 +1,26 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="email">
+    <div class="container admin-container space-left-right">
+        <h3>Email Everyone</h3>
+        <form role="form" action="{{ url_for("admin.email") }}" method="POST">
+            <p>This will send an email to loads of people, be careful.</p>
+            <div class="checkbox">
+                <label for="modders-only">
+                    <input type="checkbox" name="modders-only" id="modders-only" style="position: relative; top: -3px">
+                    Email published modders only
+                </label>
+            </div>
+            <div class="form-group">
+                <label for="subject">Subject</label>
+                <input type="text" class="form-control" id="subject" name="subject" placeholder="Subject">
+            </div>
+            <div class="form-group">
+                <label for="body">Body</label>
+                <textarea name="body" id="body" class="form-control input-block-level" rows=10></textarea>
+            </div>
+            <input type="submit" class="btn btn-primary btn-block" value="Send">
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin-email.html
+++ b/templates/admin-email.html
@@ -23,4 +23,7 @@
         </form>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-email').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-game-versions.html
+++ b/templates/admin-game-versions.html
@@ -3,34 +3,8 @@
 <div class="tab-pane active" id="gameversions">
     <div class="container admin-container space-left-right">
         <div class="row">
-            <div class="col-sm-8">
-                <ul style="padding-left: 0">
-                    <!-- previous page -->
-                    {% if page != 1 %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.game_versions', page=page - 1) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <!-- next page -->
-                    {% if page != total_pages %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.game_versions', page=page + 1) }}">Next</a></li>
-                    {% endif %}
-
-                    <!-- all page numbers -->
-                    {% for page_num in range(1, total_pages + 1) %}
-                        {% if page_num != page %}
-                            <li style="display:inline">
-                                <a href="{{ url_for('admin.game_versions', page=page_num) }}">{{ page_num }}</a>
-                            </li>
-                        {% else %}
-                            <li class="active" style="display:inline">
-                                <a href="#">{{ page_num }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div>
+            {% set base_url = 'admin.game_versions' %}
+            {% include 'admin-page-nav.html' %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.game_versions", page=1) }}" method="GET">
                     <div class="form-group">

--- a/templates/admin-game-versions.html
+++ b/templates/admin-game-versions.html
@@ -1,0 +1,87 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="gameversions">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            <div class="col-sm-8">
+                <ul style="padding-left: 0">
+                    <!-- previous page -->
+                    {% if page != 1 %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.game_versions', page=page - 1) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <!-- next page -->
+                    {% if page != total_pages %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.game_versions', page=page + 1) }}">Next</a></li>
+                    {% endif %}
+
+                    <!-- all page numbers -->
+                    {% for page_num in range(1, total_pages + 1) %}
+                        {% if page_num != page %}
+                            <li style="display:inline">
+                                <a href="{{ url_for('admin.game_versions', page=page_num) }}">{{ page_num }}</a>
+                            </li>
+                        {% else %}
+                            <li class="active" style="display:inline">
+                                <a href="#">{{ page_num }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="col-sm-4">
+                <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.game_versions", page=1) }}" method="GET">
+                    <div class="form-group">
+                        <label for="game-version-search">Search games:</label>
+                        <input id="game-version-search" type="text" class="form-control search-box" name="query" {% if query %}value="{{ query }}"{% else %}placeholder="Search game versions..."{% endif %}>
+                    </div>
+                </form>
+            </div>
+        </div>
+        {% if game_version_count == 0 %}
+        <h3>Versions</h3>
+        <p>You have not added any Versions. Modders will not be able to create mods until you add at least one.</p>
+        {% else %}
+        <div class="row table-responsive bootstrap-table space-left-right">
+            <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
+                 <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Game</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                {% for v in game_versions %}
+                <tr>
+                    <td>{{ v.friendly_version }}</td>
+                    <td>{{ v.game.name }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+        <form role="form" action="{{ url_for("admin.create_version") }}" method="POST">
+            <div class="row">
+                <div class="col-md-5">
+                    <input type="text" id="friendly_version" name="friendly_version" class="form-control input-block-level" placeholder="Version name...">
+                </div>
+
+                <div class="col-md-5">
+                    <select id="ganame" name="ganame" class="chosen-select">
+                        {% for g in games %}
+                        <option value="{{g.id}}" {% if loop.first %}selected{% endif %}>{{g.name}}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <input type="submit" class="btn btn-primary btn-block" value="Add Version">
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin-game-versions.html
+++ b/templates/admin-game-versions.html
@@ -58,4 +58,7 @@
         </form>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-game-versions').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-games.html
+++ b/templates/admin-games.html
@@ -78,4 +78,7 @@
         </form>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-games').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-games.html
+++ b/templates/admin-games.html
@@ -3,34 +3,8 @@
 <div class="tab-pane active" id="games">
     <div class="container admin-container space-left-right">
         <div class="row">
-            <div class="col-sm-8">
-                <ul style="padding-left: 0">
-                    <!-- previous page -->
-                    {% if page != 1 %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.games', page=page - 1) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <!-- next page -->
-                    {% if page != total_pages %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.games', page=page + 1) }}">Next</a></li>
-                    {% endif %}
-
-                    <!-- all page numbers -->
-                    {% for page_num in range(1, total_pages + 1) %}
-                        {% if page_num != page %}
-                            <li style="display:inline">
-                                <a href="{{ url_for('admin.games', page=page_num) }}">{{ page_num }}</a>
-                            </li>
-                        {% else %}
-                            <li class="active" style="display:inline">
-                                <a href="#">{{ page_num }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div>
+            {% set base_url = 'admin.games' %}
+            {% include 'admin-page-nav.html' %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.games", page=1) }}" method="GET">
                     <div class="form-group">

--- a/templates/admin-games.html
+++ b/templates/admin-games.html
@@ -1,0 +1,107 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="games">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            <div class="col-sm-8">
+                <ul style="padding-left: 0">
+                    <!-- previous page -->
+                    {% if page != 1 %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.games', page=page - 1) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <!-- next page -->
+                    {% if page != total_pages %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.games', page=page + 1) }}">Next</a></li>
+                    {% endif %}
+
+                    <!-- all page numbers -->
+                    {% for page_num in range(1, total_pages + 1) %}
+                        {% if page_num != page %}
+                            <li style="display:inline">
+                                <a href="{{ url_for('admin.games', page=page_num) }}">{{ page_num }}</a>
+                            </li>
+                        {% else %}
+                            <li class="active" style="display:inline">
+                                <a href="#">{{ page_num }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="col-sm-4">
+                <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.games", page=1) }}" method="GET">
+                    <div class="form-group">
+                        <label for="game-search">Search games:</label>
+                        <input id="game-search" type="text" class="form-control search-box" name="query" {% if query %}value="{{ query }}" {% else %}placeholder="Search games..."{% endif %}>
+                    </div>
+                </form>
+            </div>
+        </div>
+        {% if game_count == 0 %}
+        <h3>Games</h3>
+        <p>You have not added any Games. Modders will not be able to create mods until you add at least one.</p>
+        {% else %}
+        <div class="row table-responsive bootstrap-table space-left-right">
+            <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Short Name</th>
+                    <th>Created</th>
+                    <th>Short Description</th>
+                    <th>Description</th>
+                    <th>Link</th>
+                    <th>Release Date</th>
+                    <th>File Formats</th>
+                    <th>Rating</th>
+                    <th>Active</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                {% for g in games %}
+                <tr>
+                    <td>{{ g.name }}</td>
+                    <td>{{ g.short }}</td>
+                    <td>{{ g.created }}</td>
+                    <td>{{ g.short_description }}</td>
+                    <td>{{ g.description }}</td>
+                    <td><a href="{{ g.link }}" target="_BLANK">{{ g.link }}</a></td>
+                    <td>{{ g.releasedate }}</td>
+                    <td>{{ g.fileformats }}</td>
+                    <td>{{ g.rating }}</td>
+                    <td>{{ g.active }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+        <form role="form" action="{{ url_for("admin.create_game") }}" method="POST">
+            <div class="row">
+                <div class="col-md-4">
+                    <input type="text" id="gname" name="gname" class="form-control input-block-level" placeholder="Game name...">
+                </div>
+                <div class="col-md-3">
+                    <input type="text" id="sname" name="sname" class="form-control input-block-level" placeholder="Short name (for URL)...">
+                </div>
+                <div class="col-md-3">
+                    {# TODO not working, something with this jQuery sh* I think #}
+                    <select id="pname" name="pname" class="chosen-select">
+                        {% for p in publishers %}
+                        <option value="{{p.id}}" {% if loop.first %}selected{% endif %}>{{p.name}}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="col-md-2">
+                    <input type="submit" class="btn btn-primary btn-block" value="Add Game">
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin-links.html
+++ b/templates/admin-links.html
@@ -1,0 +1,44 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="links">
+    <div class = "table-responsive bootstrap-table space-left-right">
+        <table class = "table" data-toggle="table" data-pagination="true" 	data-striped="true" data-search="true" trimOnSearch="true"  searchAlign="left" >
+
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Link</th>
+            </tr>
+            </thead>
+
+            <tbody>
+            <tr>
+                <td><a href="https://spacedock.info" target="_BLANK">SpaceDock</a></td>
+                <td><a href="https://spacedock.info" target="_BLANK">https://spacedock.info</a></td>
+            </tr>
+            <tr>
+                <td><a href="https://alpha.spacedock.info" target="_BLANK">SpaceDock Alpha</a></td>
+                <td><a href="https://alpha.spacedock.info" target="_BLANK">https://alpha.spacedock.info</a></td>
+            </tr>
+            <tr>
+                <td><a href="https://beta.spacedock.info" target="_BLANK">SpaceDock Beta</a></td>
+                <td><a href="https://beta.spacedock.info" target="_BLANK">https://beta.spacedock.info</a></td>
+            </tr>
+            <tr>
+                <td><a href="https://stats.52k.de" target="_BLANK">Web statistics</a></td>
+                <td><a href="https://stats.52k.de" target="_BLANK">https://stats.52k.de</a></td>
+            </tr>
+            <tr>
+                <td><a href="https://www.patreon.com/spacedock?ty=p" target="_BLANK">Patreon (Donations)</a></td>
+                <td><a href="https://www.patreon.com/spacedock?ty=p" target="_BLANK">https://www.patreon.com/spacedock?ty=p</a></td>
+            </tr>
+            <tr>
+                <td><a href="https://forum.kerbalspaceprogram.com/index.php?/topic/132186-spacedockinfo-dev-thread-the-kerbalstuff-replacement-site-fully-operational/&page=1" target="_BLANK">KSP Forum Thread</a></td>
+                <td><a href="https://forum.kerbalspaceprogram.com/index.php?/topic/132186-spacedockinfo-dev-thread-the-kerbalstuff-replacement-site-fully-operational/&page=1" target="_BLANK">Too Long (copy from link)</a></td>
+            </tr>
+            </tbody>
+
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin-links.html
+++ b/templates/admin-links.html
@@ -41,4 +41,7 @@
         </table>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-links').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-page-nav.html
+++ b/templates/admin-page-nav.html
@@ -1,0 +1,37 @@
+<div class="col-sm-8">
+    <nav aria-label="Page navigation">
+        <ul class="pagination" style="padding-left: 0">
+            <!-- first page -->
+            {% if page != 1 %}
+            <li style="display:inline">
+                <a href="{{ url_for(base_url, page=1) }}" aria-label="First"><span aria-hidden="true">&laquo;</span></a>
+            </li>
+            <!-- previous page -->
+            <li style="display:inline">
+                <a href="{{ url_for(base_url, page=page - 1) }}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a>
+            </li>
+            {% endif %}
+            <!-- all page numbers -->
+            {% for page_num in range([1, page - 3] | max, [total_pages + 1, page + 7] | min) %}
+                {% if page_num != page %}
+                    <li style="display:inline">
+                        <a href="{{ url_for(base_url, page=page_num) }}">{{ page_num }}</a>
+                    </li>
+                {% else %}
+                    <li class="active" style="display:inline">
+                        <a href="#">{{ page_num }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+            <!-- next page -->
+            {% if page != total_pages %}
+            <li style="display:inline">
+                <a href="{{ url_for(base_url, page=page + 1) }}" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a>
+            </li>
+            <li style="display:inline">
+                <a href="{{ url_for(base_url, page=total_pages) }}" aria-label="Last"><span aria-hidden="true">&raquo;</span></a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+</div>

--- a/templates/admin-publishers.html
+++ b/templates/admin-publishers.html
@@ -56,4 +56,7 @@
         </form>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-publishers').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-publishers.html
+++ b/templates/admin-publishers.html
@@ -1,0 +1,85 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="publishers">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            <div class="col-sm-8">
+                <ul style="padding-left: 0">
+                    <!-- previous page -->
+                    {% if page != 1 %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.publishers', page=page - 1) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <!-- next page -->
+                    {% if page != total_pages %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.publishers', page=page + 1) }}">Next</a></li>
+                    {% endif %}
+
+                    <!-- all page numbers -->
+                    {% for page_num in range(1, total_pages + 1) %}
+                        {% if page_num != page %}
+                            <li style="display:inline">
+                                <a href="{{ url_for('admin.publishers', page=page_num) }}">{{ page_num }}</a>
+                            </li>
+                        {% else %}
+                            <li class="active" style="display:inline">
+                                <a href="#">{{ page_num }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="col-sm-4">
+                <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.publishers", page=1) }}" method="GET">
+                    <div class="form-group">
+                        <label for="publisher-search">Search publishers:</label>
+                        <input id="publisher-search" type="text" class="form-control search-box" name="query" {% if query %}value="{{ query }}"{% else %}placeholder="Search publishers..."{% endif %}>
+                    </div>
+                </form>
+            </div>
+        </div>
+        {% if publisher_count == 0 %}
+        <h3>Publishers</h3>
+        <p>You have not added any publishers. Modders will not be able to create mods until you add at least one.</p>
+        {% else %}
+        <div class="row table-responsive bootstrap-table space-left-right">
+            <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Created</th>
+                    <th>Short Description</th>
+                    <th>Description</th>
+                    <th>Link</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                {% for p in publishers %}
+                <tr>
+                    <td>{{ p.name }}</td>
+                    <td>{{ p.created }}</td>
+                    <td>{{ p.short_description }}</td>
+                    <td>{{ p.description }}</td>
+                    <td><a href="{{ p.link }}" target="_BLANK">{{ p.link }}</a></td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+        <form role="form" action="{{ url_for("admin.create_publisher") }}" method="POST">
+            <div class="row">
+                <div class="col-md-4">
+                    <input type="text" id="publisher_name" name="pname" class="form-control input-block-level" placeholder="Publisher name...">
+                </div>
+                <div class="col-md-2">
+                    <input type="submit" class="btn btn-primary btn-block" value="Add Publisher">
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin-publishers.html
+++ b/templates/admin-publishers.html
@@ -3,34 +3,8 @@
 <div class="tab-pane active" id="publishers">
     <div class="container admin-container space-left-right">
         <div class="row">
-            <div class="col-sm-8">
-                <ul style="padding-left: 0">
-                    <!-- previous page -->
-                    {% if page != 1 %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.publishers', page=page - 1) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <!-- next page -->
-                    {% if page != total_pages %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.publishers', page=page + 1) }}">Next</a></li>
-                    {% endif %}
-
-                    <!-- all page numbers -->
-                    {% for page_num in range(1, total_pages + 1) %}
-                        {% if page_num != page %}
-                            <li style="display:inline">
-                                <a href="{{ url_for('admin.publishers', page=page_num) }}">{{ page_num }}</a>
-                            </li>
-                        {% else %}
-                            <li class="active" style="display:inline">
-                                <a href="#">{{ page_num }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div>
+            {% set base_url = 'admin.publishers' %}
+            {% include 'admin-page-nav.html' %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.publishers", page=1) }}" method="GET">
                     <div class="form-group">

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -3,34 +3,8 @@
 <div class="tab-pane active" id="users">
     <div class="container admin-container space-left-right">
         <div class="row">
-            <div class="col-sm-8">
-                <ul style="padding-left: 0">
-                    <!-- previous page -->
-                    {% if page != 1 %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.users', page=page - 1) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <!-- next page -->
-                    {% if page != total_pages %}
-                    <li style="display:inline">
-                        <a href="{{ url_for('admin.users', page=page + 1) }}">Next</a></li>
-                    {% endif %}
-
-                    <!-- all page numbers -->
-                    {% for page_num in range(1, total_pages + 1) %}
-                        {% if page_num != page %}
-                            <li style="display:inline">
-                                <a href="{{ url_for('admin.users', page=page_num) }}">{{ page_num }}</a>
-                            </li>
-                        {% else %}
-                            <li class="active" style="display:inline">
-                                <a href="#">{{ page_num }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div>
+            {% set base_url = 'admin.users' %}
+            {% include 'admin-page-nav.html' %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.users", page=1) }}" method="GET">
                     <div class="form-group">

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -51,4 +51,7 @@
         </div>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById('adm-link-users').classList.add('active')
+</script>
 {% endblock %}

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -1,0 +1,80 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="users">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            <div class="col-sm-8">
+                <ul style="padding-left: 0">
+                    <!-- previous page -->
+                    {% if page != 1 %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.users', page=page - 1) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <!-- next page -->
+                    {% if page != total_pages %}
+                    <li style="display:inline">
+                        <a href="{{ url_for('admin.users', page=page + 1) }}">Next</a></li>
+                    {% endif %}
+
+                    <!-- all page numbers -->
+                    {% for page_num in range(1, total_pages + 1) %}
+                        {% if page_num != page %}
+                            <li style="display:inline">
+                                <a href="{{ url_for('admin.users', page=page_num) }}">{{ page_num }}</a>
+                            </li>
+                        {% else %}
+                            <li class="active" style="display:inline">
+                                <a href="#">{{ page_num }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="col-sm-4">
+                <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.users", page=1) }}" method="GET">
+                    <div class="form-group">
+                        <label for="user-search">Search users:</label>
+                        <input id="user-search" type="text" class="form-control search-box" name="query" {% if query %}value="{{ query }}"{% else %}placeholder="Search users..."{% endif %}>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <div class="row table-responsive bootstrap-table space-left-right">
+            <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
+                <thead>
+                <tr>
+                    <th>Username</th>
+                    <th>Created</th>
+                    <th>E-Mail</th>
+                    <th>Forums</th>
+                    <th>IRC</th>
+                    <th>Twitter</th>
+                    <th>Reddit</th>
+                    <th>Location</th>
+                    <th>Description</th>
+                    <th>Public</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                {% for user in users %}
+                <tr>
+                    <td><a href="{{ url_for("profile.view_profile", username=user.username) }}">{{ user.username }}</a></td>
+                    <td>{{ user.created }}</td>
+                    <td>{{ user.email }}</td>
+                    <td>{{ user.forumUsername }}</td>
+                    <td>{{ user.ircNick }}</td>
+                    <td>{{ user.twitterUsername }}</td>
+                    <td>{{ user.redditUsername }}</td>
+                    <td>{{ user.location }}</td>
+                    <td>{{ user.description }}</td>
+                    <td>{{ user.public }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -11,26 +11,22 @@
         <h1>Admin Stuff</h1>
     </div>
 </div>
-<div class="container">
-    <div id="content">
-        <div class="centered admin-nav box">
-            <ul class="nav nav-pills nav-justified">
-                <li><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
-                <li><a href="{{ url_for("admin.blog") }}">Blog</a></li>
-                <li><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
-                <li><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
-                <li><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
-                <li><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
-                <li><a href="{{ url_for("admin.links") }}">Links</a></li>
-            </ul>
-        </div>
-        <div id="my-tab-content" class="tab-content">
-            {% block admin_content %}{% endblock %}
-        </div>
+<div id="content">
+    <div class="centered admin-nav box panel panel-default" style="margin: 2.5mm">
+        <ul class="nav nav-pills nav-justified panel-content">
+            <li id="adm-link-users"><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
+            <li id="adm-link-blog"><a href="{{ url_for("admin.blog") }}">Blog</a></li>
+            <li id="adm-link-publishers"><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
+            <li id="adm-link-games"><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
+            <li id="adm-link-game-versions"><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
+            <li id="adm-link-email"><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
+            <li id="adm-link-links"><a href="{{ url_for("admin.links") }}">Links</a></li>
+        </ul>
     </div>
-
-
-</div>
+    <div class="tab-content">
+        {% block admin_content %}{% endblock %}
+    </div>
+    </div>
 {% endblock %}
 {% block scripts %}
     <!-- Latest compiled and minified JavaScript -->

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -13,20 +13,16 @@
 </div>
 <div class="container">
     <div id="content">
-        <div class="container centered">
-            <div id="admin-nav" class="row">
-                <div class="col-lg-12">
-                    <ul class="nav nav-pills nav-justified">
-                        <li><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
-                        <li><a href="{{ url_for("admin.blog") }}">Blog</a></li>
-                        <li><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
-                        <li><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
-                        <li><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
-                        <li><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
-                        <li><a href="{{ url_for("admin.links") }}">Links</a></li>
-                    </ul>
-                </div>
-            </div>
+        <div class="centered admin-nav box">
+            <ul class="nav nav-pills nav-justified">
+                <li><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
+                <li><a href="{{ url_for("admin.blog") }}">Blog</a></li>
+                <li><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
+                <li><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
+                <li><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
+                <li><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
+                <li><a href="{{ url_for("admin.links") }}">Links</a></li>
+            </ul>
         </div>
         <div id="my-tab-content" class="tab-content">
             {% block admin_content %}{% endblock %}
@@ -47,7 +43,6 @@
     <script src="/static/editor.js"></script>
     <script src="/static/marked.js"></script>
     <script type="text/javascript">
-    {# TODO jQuery seems to have a different name? #}
         jQuery(document).ready(function ($) {
             $('#tabs').tab();
         });

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -12,333 +12,24 @@
     </div>
 </div>
 <div class="container">
-
-    <!-------->
     <div id="content">
-        <ul id="tabs" class="nav nav-tabs space-left-right" data-tabs="tabs">
-            <li class="active"><a href="#users" data-toggle="tab">Users</a></li>
-            <li><a href="#blog" data-toggle="tab">Blog</a></li>
-            <li><a href="#publishers" data-toggle="tab">Publishers</a></li>
-            <li><a href="#games" data-toggle="tab">Games</a></li>
-            <li><a href="#gameversion" data-toggle="tab">Game Versions</a></li>
-            <li><a href="#email" data-toggle="tab">E-Mail</a></li>
-            <li><a href="#links" data-toggle="tab">Links</a></li>
-        </ul>
+        <div class="container centered">
+            <div id="admin-nav" class="row">
+                <div class="col-lg-12">
+                    <ul class="nav nav-pills nav-justified">
+                        <li><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
+                        <li><a href="{{ url_for("admin.blog") }}">Blog</a></li>
+                        <li><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
+                        <li><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
+                        <li><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
+                        <li><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
+                        <li><a href="{{ url_for("admin.links") }}">Links</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
         <div id="my-tab-content" class="tab-content">
-            <div class="tab-pane active" id="users">
-                <div class="container admin-container space-left-right">
-                    <br />
-                    <p>There are {{ users }} users and {{ mods }} mods.</p>
-                </div>
-
-
-                    <div class = "table-responsive bootstrap-table space-left-right">
-                        <table class = "table" data-toggle="table" data-pagination="true" 	data-striped="true" data-search="true" trimOnSearch="true"  searchAlign="left" >
-
-
-
-                            <thead>
-                            <tr>
-                                <th>Username</th>
-                                <th>Created</th>
-                                <th>E-Mail</th>
-                                <th>Forums</th>
-                                <th>IRC</th>
-                                <th>Twitter</th>
-                                <th>Reddit</th>
-                                <th>Location</th>
-                                <th>Description</th>
-                                <th>Public</th>
-                            </tr>
-                            </thead>
-
-                            <tbody>
-                            {% for user in usrs %}
-                            <tr>
-                                <td><a href="/profile/{{ user.username }}">{{ user.username }}</a></td>
-                                <td>{{ user.created }}</td>
-                                <td>{{ user.email }}</td>
-                                <td>{{ user.forumUsername }}</td>
-                                <td>{{ user.ircNick }}</td>
-                                <td>{{ user.twitterUsername }}</td>
-                                <td>{{ user.redditUsername }}</td>
-                                <td>{{ user.location }}</td>
-                                <td>{{ user.description }}</td>
-                                <td>{{ user.public }}</td>
-                            </tr>
-                            {% endfor %}
-                            </tbody>
-
-                        </table>
-                    </div>
-
-            </div>
-            <div class="tab-pane" id="blog">
-                <div class="container admin-container space-left-right">
-                    <h3>New Blog Post</h3>
-                    <form role="form" action="/blog/post" method="POST">
-                        <div class="form-group">
-                            <label for="post-title">Title</label>
-                            <input type="text" class="form-control" id="post-title" name="post-title" placeholder="Title">
-                        </div>
-                        <div class="form-group">
-                            <label for="post-body">Body <small class="text-muted"><a target="_blank" href="/markdown">Markdown</a> supported</small></label>
-                            <textarea name="post-body" id="post-body" class="form-control input-block-level" rows=10></textarea>
-                        </div>
-                        <input type="submit" class="btn btn-primary btn-block" value="Publish">
-                    </form>
-                </div>
-            </div>
-            <div class="tab-pane" id="publishers">
-                <div class="container admin-container space-left-right">
-                    {% if len(publishers) == 0 %}
-                    <h3>Publishers</h3>
-                    <p>You have not added any publishers. Modders will not be able to create mods until you add at least one.</p>
-                    {% else %}
-                    <div class = "table-responsive bootstrap-table space-left-right">
-                        <table class = "table" data-toggle="table" data-pagination="true" 	data-striped="true" data-search="true" trimOnSearch="true"  searchAlign="left" >
-
-
-
-
-                            <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Created</th>
-                                <th>Short Description</th>
-                                <th>Description</th>
-                                <th>Link</th>
-                            </tr>
-                            </thead>
-
-                            <tbody>
-                            {% for p in publishers %}
-                            <tr>
-                                <td>{{ p.name }}</td>
-                                <td>{{ p.created }}</td>
-                                <td>{{ p.short_description }}</td>
-                                <td>{{ p.description }}</td>
-                                <td><a href="{{ p.link }}" target="_BLANK">{{ p.link }}</a></td>
-                            </tr>
-                            {% endfor %}
-                            </tbody>
-
-                        </table>
-                    </div>
-                    {% endif %}
-                    <form role="form" action="/publishers/create" method="POST">
-                        <div class="row">
-                            <div class="col-md-4">
-                                <input type="text" id="publisher_name" name="pname" class="form-control input-block-level" placeholder="Publisher name...">
-                            </div>
-                            <div class="col-md-2">
-                                <input type="submit" class="btn btn-primary btn-block" value="Add Publisher">
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="tab-pane" id="games">
-                <div class="container admin-container space-left-right">
-                    {% if len(games) == 0 %}
-                    <h3>Games</h3>
-                    <p>You have not added any Games. Modders will not be able to create mods until you add at least one.</p>
-                    {% else %}
-                    <div class = "table-responsive bootstrap-table space-left-right">
-                        <table class = "table" data-toggle="table" data-pagination="true" 	data-striped="true" data-search="true" trimOnSearch="true"  searchAlign="left" >
-
-
-
-
-                            <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Short Name</th>
-                                <th>Created</th>
-                                <th>Short Description</th>
-                                <th>Description</th>
-                                <th>Link</th>
-                                <th>Release Date</th>
-                                <th>File Formats</th>
-                                <th>Rating</th>
-                                <th>Active</th>
-                            </tr>
-                            </thead>
-
-                            <tbody>
-                            {% for g in games %}
-                            <tr>
-                                <td>{{ g.name }}</td>
-                                <td>{{ g.short }}</td>
-                                <td>{{ g.created }}</td>
-                                <td>{{ g.short_description }}</td>
-                                <td>{{ g.description }}</td>
-                                <td><a href="{{ g.link }}" target="_BLANK">{{ g.link }}</a></td>
-                                <td>{{ g.releasedate }}</td>
-                                <td>{{ g.fileformats }}</td>
-                                <td>{{ g.rating }}</td>
-                                <td>{{ g.active }}</td>
-                            </tr>
-                            {% endfor %}
-                            </tbody>
-
-                        </table>
-                    </div>
-                    {% endif %}
-
-                    <form role="form" action="/games/create" method="POST">
-                        <div class="row">
-                            <div class="col-md-4">
-                                <input type="text" id="gname" name="gname" class="form-control input-block-level" placeholder="Game name...">
-                            </div>
-                            <div class="col-md-3">
-                                <input type="text" id="sname" name="sname" class="form-control input-block-level" placeholder="Short name (for URL)...">
-                            </div>
-                            <div class="col-md-3">
-                                <select id="pname" name="pname" class="chosen-select">
-                                    {% for p in publishers %}
-                                    <option value="{{p.id}}" {% if loop.first %}selected{% endif %}>{{p.name}}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-
-                            <div class="col-md-2">
-                                <input type="submit" class="btn btn-primary btn-block" value="Add Game">
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="tab-pane" id="gameversion">
-                <div class="container admin-container space-left-right">
-                    {% if len(versions) == 0 %}
-                    <h3>Versions</h3>
-                    <p>You have not added any Versions. Modders will not be able to create mods until you add at least one.</p>
-                    {% else %}
-                    <div class = "table-responsive bootstrap-table space-left-right">
-                        <table class = "table" data-toggle="table" data-pagination="true" 	data-striped="true" data-search="true" trimOnSearch="true"  searchAlign="left" >
-
-
-
-
-                            <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Game</th>
-                            </tr>
-                            </thead>
-
-                            <tbody>
-                            {% for v in versions %}
-                            <tr>
-                                <td>{{ v.friendly_version }}</td>
-                                <td>{{ v.game.name }}</td>
-                            </tr>
-                            {% endfor %}
-                            </tbody>
-
-                        </table>
-                    </div>
-                    {% endif %}
-
-                    <form role="form" action="/versions/create" method="POST">
-                        <div class="row">
-                            <div class="col-md-5">
-                                <input type="text" id="friendly_version" name="friendly_version" class="form-control input-block-level" placeholder="Version name...">
-                            </div>
-
-                            <div class="col-md-5">
-                                <select id="ganame" name="ganame" class="chosen-select">
-                                    {% for g in games %}
-                                    <option value="{{g.id}}" {% if loop.first %}selected{% endif %}>{{g.name}}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="col-md-2">
-                                <input type="submit" class="btn btn-primary btn-block" value="Add Version">
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="tab-pane" id="email">
-                <div class="container admin-container space-left-right">
-                    <h3>Email Everyone</h3>
-                    <form role="form" action="/admin/email" method="POST">
-                        <p>This will send an email to loads of people, be careful.</p>
-                        <div class="checkbox">
-                            <label for="modders-only">
-                                <input type="checkbox" name="modders-only" id="modders-only" style="position: relative; top: -3px">
-                                Email published modders only
-                            </label>
-                        </div>
-                        <div class="form-group">
-                            <label for="subject">Subject</label>
-                            <input type="text" class="form-control" id="subject" name="subject" placeholder="Subject">
-                        </div>
-                        <div class="form-group">
-                            <label for="body">Body</label>
-                            <textarea name="body" id="body" class="form-control input-block-level" rows=10></textarea>
-                        </div>
-                        <input type="submit" class="btn btn-primary btn-block" value="Send">
-                    </form>
-                </div>
-            </div>
-            <div class="tab-pane" id="links">
-                    <div class = "table-responsive bootstrap-table space-left-right">
-                        <table class = "table" data-toggle="table" data-pagination="true" 	data-striped="true" data-search="true" trimOnSearch="true"  searchAlign="left" >
-
-                            <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Link</th>
-                            </tr>
-                            </thead>
-
-                            <tbody>
-
-                            <tr>
-                                <td><a href="http://dev.spacedock.info" target="_BLANK">SpaceDock DEV</a></td>
-                                <td><a href="http://dev.spacedock.info" target="_BLANK">http://dev.spacedock.info</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://bh.spacedock.info/main" target="_BLANK">SpaceDock Bloodhound (Ticket&Wiki)</a></td>
-                                <td><a href="http://bh.spacedock.info/main" target="_BLANK">http://bh.spacedock.info/main</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://stats.52k.de" target="_BLANK">Web statistics</a></td>
-                                <td><a href="http://stats.52k.de" target="_BLANK">http://stats.52k.de</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://mon.spacedock.info" target="_BLANK">Monitoring</a></td>
-                                <td><a href="http://mon.spacedock.info" target="_BLANK">http://mon.spacedock.info/</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://s3n1.52k.de" target="_BLANK">Webmail</a></td>
-                                <td><a href="http://s3n1.52k.de" target="_BLANK">http://s3n1.52k.de</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="https://www.patreon.com/spacedock?ty=p" target="_BLANK">Patreon (Donations)</a></td>
-                                <td><a href="https://www.patreon.com/spacedock?ty=p" target="_BLANK">https://www.patreon.com/spacedock?ty=p</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://forum.kerbalspaceprogram.com/index.php?/topic/132186-spacedockinfo-dev-thread-the-kerbalstuff-replacement-site-fully-operational/&page=1" target="_BLANK">KSP Forum Thread</a></td>
-                                <td><a href="http://forum.kerbalspaceprogram.com/index.php?/topic/132186-spacedockinfo-dev-thread-the-kerbalstuff-replacement-site-fully-operational/&page=1" target="_BLANK">Too Long (copy from link)</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://s3n1.52k.de/otrs/" target="_BLANK">OTRS (support mail)</a></td>
-                                <td><a href="http://s3n1.52k.de/otrs/" target="_BLANK">http://s3n1.52k.de/otrs/</a></td>
-                            </tr>
-                            <tr>
-                                <td><a href="http://git.spacedock.info/user/login" target="_BLANK">private git repo for SD</a></td>
-                                <td><a href="http://git.spacedock.info/user/login" target="_BLANK">http://git.spacedock.info/user/login</a></td>
-                            </tr>
-
-                            </tbody>
-
-                        </table>
-                    </div>
-            </div>
+            {% block admin_content %}{% endblock %}
         </div>
     </div>
 
@@ -356,6 +47,7 @@
     <script src="/static/editor.js"></script>
     <script src="/static/marked.js"></script>
     <script type="text/javascript">
+    {# TODO jQuery seems to have a different name? #}
         jQuery(document).ready(function ($) {
             $('#tabs').tab();
         });
@@ -366,5 +58,4 @@
         editor = new Editor();
         editor.render();
     </script>
-
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -135,7 +135,7 @@
                                 </li>
                                 {% if admin %}
                                 <li>
-                                    <a href="{{ url_for("admin.backend") }}">
+                                    <a href="{{ url_for("admin.admin_main") }}">
                                         <span class="glyphicon glyphicon-fire"></span> Admin Stuff
                                     </a>
                                 </li>


### PR DESCRIPTION
## Problem
The admin page is currently unusable on production, because it requests **all** users and tries to paginate them client-side.
This kills every browser out there.

## Changes
The admin page, which has been a one-page app with multiple tabs, is broken up in multiple pages, one for each previous tab:
```
@admin.route("/admin/users/<int:page>")
@admin.route("/admin/blog")
@admin.route("/admin/publishers/<int:page>")
@admin.route("/admin/games/<int:page>")
@admin.route("/admin/gameversions/<int:page>")
@admin.route("/admin/email", methods=['GET', 'POST'])
@admin.route("/admin/links")
```

All tables (except the one for links) are now paginated server-side. (This would have been way easier if we used flask-sqlalchemy...)
The number of items per page is hardcoded to 10, I think it would also be possible to make this an option for clients, but I wanted to keep it simple for now.
Above the table is a list with links to the pages, and a search box.
The search boxes send GETs with the `?query=...` parameter.

I created some extra functions to simplify the filtering/searching.
They are also somewhat "recursive" now, that means if you are on `/admin/gameversions` and search for `squad`, it'll recurse through the games each version belongs to and then through the publisher set for each game, and the admin will see the list of game versions that are from games published by Squad.
This took a lot of time to get right, still not entirely sure if it does it's job correctly, but I hope so.

I also purged some of the seemingly non-functional links from the `links` page.