### PR TITLE
Work around over-eager adblockers hiding stuff they shouldn't hide

### DIFF
--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -59,16 +59,16 @@ link.addEventListener('click', (e) ->
     e.preventDefault()
     xhr = new XMLHttpRequest()
     follow = false
-    if e.target.classList.contains('follow-button')
+    if e.target.classList.contains('follow-mod-button')
         xhr.open('POST', "/mod/#{e.target.dataset.mod}/follow")
-        e.target.classList.remove('follow-button')
-        e.target.classList.add('unfollow-button')
+        e.target.classList.remove('follow-mod-button')
+        e.target.classList.add('unfollow-mod-button')
         e.target.textContent = 'Unfollow'
         follow = true
     else
         xhr.open('POST', "/mod/#{e.target.dataset.mod}/unfollow")
-        e.target.classList.remove('unfollow-button')
-        e.target.classList.add('follow-button')
+        e.target.classList.remove('unfollow-mod-button')
+        e.target.classList.add('follow-mod-button')
         e.target.textContent = 'Follow'
     xhr.onload = () ->
         try
@@ -77,7 +77,7 @@ link.addEventListener('click', (e) ->
         catch
             window.location.href = '/register'
     xhr.send()
-, false) for link in document.querySelectorAll('.follow-button, .unfollow-button')
+, false) for link in document.querySelectorAll('.follow-mod-button, .unfollow-mod-button')
 
 link.addEventListener('click', (e) ->
     e.preventDefault()

--- a/templates/featured-mod-box.html
+++ b/templates/featured-mod-box.html
@@ -47,9 +47,9 @@
                 </div>
                 <div class="col-md-6" style="padding-right: 4px;">
                     {% if following_mod(mod) %}
-                    <a href="#" class="unfollow-button btn btn-block btn-primary" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
+                    <a href="#" class="unfollow-mod-button btn btn-block btn-primary" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
                     {% else %}
-                    <a href="#" class="follow-button btn btn-block btn-primary" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
+                    <a href="#" class="follow-mod-button btn btn-block btn-primary" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
                     {% endif %}
                 </div>
             </div>

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -62,9 +62,9 @@
         {% if user %}
         <div class="col-md-2">
             {% if following_mod(mod) %}
-            <a href="#" class="unfollow-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
+            <a href="#" class="unfollow-mod-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
             {% else %}
-            <a href="#" class="follow-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
+            <a href="#" class="follow-mod-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
             {% endif %}
         </div>
         {% endif %}

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -63,9 +63,9 @@
         <div class="row">
             <div class="col-md-4">
                 {% if following_mod(mod) %}
-                <a href="#" class="unfollow-button btn btn-block btn-lg btn-success" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
+                <a href="#" class="unfollow-mod-button btn btn-block btn-lg btn-success" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
                 {% else %}
-                <a href="#" class="follow-button btn btn-block btn-lg btn-success" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
+                <a href="#" class="follow-mod-button btn btn-block btn-lg btn-success" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
                 {% endif %}
             </div>
             <div class="col-md-8">


### PR DESCRIPTION
## Problem
A forum user reported problems seeing the follow button on the mod page.
In a PM they said they are using Adblock Plus on Firefox.
Downloading the extension and activating the `Block social media icons tracking` option confirmed the problem:
![Missing follow button](https://user-images.githubusercontent.com/28812678/82580200-23b64d80-9b8f-11ea-8d90-c1807192a37a.png)
![ABP debug reporting the removal of the button](https://user-images.githubusercontent.com/28812678/82579850-adb1e680-9b8e-11ea-9a63-597881f6f0d3.png)

ABP uses a list called ["Fanboy's Social Blocking List"](https://easylist-downloads.adblockplus.org/fanboy-social.txt) if the `Block social media icons tracking` is activated. That one includes filters that probably cause a lot of false positives, and in our case it's `##.follow-button` that triggers.

## Changes
Rename the `.follow-button` class to `.follow-mod-button` (and `.unfollow-button` to `.unfollow-mod-button` to stay consistent).
Local testing shows that it brings the follow button back.

VITAS mentioned there were also reports of the download button missing, but I can't reproduce that one. We'll have to wait for further reports for that.