### PR TITLE
Fix default game fallback in _restore_game_info

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -650,7 +650,7 @@ def update_mod(mod_id):
         # SMILIE: this doesn't account for "external" API use --> return a json error
         return {'error': True, 'reason': 'All fields are required.'}, 400
     game_version_id = db.query(GameVersion.id) \
-        .filter(GameVersion.game_id == Mod.game_id) \
+        .filter(GameVersion.game_id == mod.game_id) \
         .filter(GameVersion.friendly_version == game_version) \
         .first()
     if not game_version_id:

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -37,14 +37,14 @@ def _get_mod_game_info(mod_id):
 
 def _restore_game_info():
     game_id = session.get('gameid')
-    if game_id:
-        game = Game.query.filter(Game.active == True, Game.id == game_id).order_by(desc(Game.id)).first()
-    else:
-        # Default to KSP
-        game = Game.query.filter(Game.active == True, Game.short == 'kerbal-space-program').order_by(desc(Game.id)).first()
 
-    set_game_info(game)
-    return game
+    if game_id:
+        game = Game.query.filter(Game.active == True, Game.id == game_id).one()
+        # Make sure it's fully set in the session cookie.
+        set_game_info(game)
+        return game
+
+    return None
 
 
 @mods.route("/random")
@@ -62,7 +62,7 @@ def random_mod():
 
 @mods.route("/mod/<int:mod_id>/<path:mod_name>/update")
 def update(mod_id, mod_name):
-    mod = Mod.query.filter(Mod.id == mod_id).first()
+    mod = Mod.query.filter(Mod.id == mod_id).one()
     if not mod:
         abort(404)
     check_mod_editable(mod)
@@ -236,8 +236,7 @@ def edit_mod(mod_id, mod_name):
 def create_mod():
     ga = _restore_game_info()
     games = Game.query.filter(Game.active == True).order_by(desc(Game.id)).all()
-    game_versions = GameVersion.query.filter(GameVersion.game_id == ga.id).order_by(desc(GameVersion.id)).all()
-    return render_template("create.html", game_versions=game_versions, games=games, ga=ga)
+    return render_template("create.html", games=games, ga=ga)
 
 
 @mods.route("/mod/<int:mod_id>/stats/downloads", defaults={'mod_name': None})

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -36,12 +36,15 @@ def _get_mod_game_info(mod_id):
 
 
 def _restore_game_info():
-    game_id = session.get('gameid') or 'kerbal-space-program'
-    ga = Game.query.filter(Game.id == game_id).order_by(desc(Game.id)).first()
-    if not ga:
-        abort(404)
-    set_game_info(ga)
-    return ga
+    game_id = session.get('gameid')
+    if game_id:
+        game = Game.query.filter(Game.active == True, Game.id == game_id).order_by(desc(Game.id)).first()
+    else:
+        # Default to KSP
+        game = Game.query.filter(Game.active == True, Game.short == 'kerbal-space-program').order_by(desc(Game.id)).first()
+
+    set_game_info(game)
+    return game
 
 
 @mods.route("/random")
@@ -59,20 +62,19 @@ def random_mod():
 
 @mods.route("/mod/<int:mod_id>/<path:mod_name>/update")
 def update(mod_id, mod_name):
-    ga = _restore_game_info()
-    mod = Mod.query.filter(Mod.id == mod_id, Mod.game_id == ga.id).first()
+    mod = Mod.query.filter(Mod.id == mod_id).first()
     if not mod:
         abort(404)
     check_mod_editable(mod)
     game_versions = GameVersion.query.filter(GameVersion.game_id == mod.game_id).order_by(desc(GameVersion.id)).all()
-    return render_template("update.html", mod=mod, game_versions=game_versions, ga=ga)
+    return render_template("update.html", mod=mod, game_versions=game_versions)
 
 
 @mods.route("/mod/<int:mod_id>.rss", defaults={'mod_name': None})
 @mods.route("/mod/<int:mod_id>/<path:mod_name>.rss")
 def mod_rss(mod_id, mod_name):
-    mod, game = _get_mod_game_info(mod_id)
-    return render_template("rss-mod.xml", mod=mod, ga=game)
+    mod, _ = _get_mod_game_info(mod_id)
+    return render_template("rss-mod.xml", mod=mod)
 
 
 @mods.route("/mod/<int:mod_id>", defaults={'mod_name': None})
@@ -235,7 +237,7 @@ def create_mod():
     ga = _restore_game_info()
     games = Game.query.filter(Game.active == True).order_by(desc(Game.id)).all()
     game_versions = GameVersion.query.filter(GameVersion.game_id == ga.id).order_by(desc(GameVersion.id)).all()
-    return render_template("create.html", game_versions=game_versions, game=games, ga=ga)
+    return render_template("create.html", game_versions=game_versions, games=games, ga=ga)
 
 
 @mods.route("/mod/<int:mod_id>/stats/downloads", defaults={'mod_name': None})

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -202,6 +202,7 @@ def check_mod_editable(mod, abort_response=401):
         abort(abort_response)
     return False
 
+
 def get_version_size(f):
     if not os.path.isfile(f): return None
 

--- a/frontend/coffee/create.coffee
+++ b/frontend/coffee/create.coffee
@@ -26,6 +26,7 @@ document.getElementById('submit').addEventListener('click', () ->
     error('mod-short-description') if shortDescription == ''
     error('mod-license') if license == ''
     error('mod-version') if version == ''
+    error('game') if game == null
     if zipFile == null
         valid = false
 

--- a/templates/create.html
+++ b/templates/create.html
@@ -30,7 +30,7 @@
             <h2 class="control-label">What game is it for?</h2>
 
             <select id="mod-game" class="chosen-select">
-                {% for g in game %}
+                {% for g in games %}
 
                 <option data-slug="{{ g.short }}" value="{{g.id}}" {% if g.id == ga.id %}selected{% endif %}>{{g.name}}</option>
                 {% endfor %}

--- a/templates/create.html
+++ b/templates/create.html
@@ -30,9 +30,9 @@
             <h2 class="control-label">What game is it for?</h2>
 
             <select id="mod-game" class="chosen-select">
+                {% if not ga %}<option selected disabled hidden style='display: none' value=''></option>{% endif %}
                 {% for g in games %}
-
-                <option data-slug="{{ g.short }}" value="{{g.id}}" {% if g.id == ga.id %}selected{% endif %}>{{g.name}}</option>
+                <option data-slug="{{ g.short }}" value="{{g.id}}" {% if  ga and g.id == ga.id %}selected{% endif %}>{{g.name}}</option>
                 {% endfor %}
             </select>
         </div>
@@ -146,7 +146,8 @@
                 var gamename = $("#mod-game option:selected").text();
                 var slug = $("#mod-game option:selected").attr("data-slug");
                 var gid = $("#mod-game option:selected").attr("value");
-                $(".gamename").html(gamename).attr("href", "/" + slug);
+                // TODO: don't hardcode the production game id here.
+                //       Do we have a game.ckan_enabled property?
                 if (gid != "3102") { //if not ksp then hide ckan checkbox
                     $(".ckan").hide();
                 } else {
@@ -154,7 +155,27 @@
                 }
             }
 
-            updategame();
+            function updategameversions(gameid) {
+                $.ajax({
+                    method: "GET",
+                    url: "/api/" + gameid + "/versions",
+                    success: function (msg) {
+                        $("#mod-game-version option").remove();
+                        $.each(msg, function (el, data) {
+                            $('<option value="' + data.id + '">' + data.friendly_version + '</option>').appendTo("#mod-game-version");
+                        });
+                        $("#mod-game-version").trigger("chosen:updated");
+                    }
+                });
+            }
+
+            // Check if there's a game preselected, if yes, get the game versions for it.
+            const preselected = $("#mod-game option:selected").attr("value");
+            if (preselected != null) {
+                updategame();
+                updategameversions(preselected);
+            }
+
             $("#mod-game-version").chosen({
                 max_selected_options: 1,
                 no_results_text: "No Options found",
@@ -171,17 +192,7 @@
             });
             $("#mod-game").chosen({width: '100%'}).change(function () {
                 updategame();
-                $.ajax({
-                    method: "GET",
-                    url: "/api/" + $(this).val() + "/versions",
-                    success: function (msg) {
-                        $("#mod-game-version option").remove();
-                        $.each(msg, function (el, data) {
-                            $('<option value="' + data.id + '">' + data.friendly_version + '</option>').appendTo("#mod-game-version");
-                        });
-                        $("#mod-game-version").trigger("chosen:updated");
-                    }
-                });
+                updategameversions($(this).val())
             });
             var licsel = $("#mod-license option:selected").html();
             if (licsel === "Other") {


### PR DESCRIPTION
## Problem
Noticed the following error in the syslog when navigating to the mod update upload page on alpha:
```
 2020-05-22 11:02:31,965 ERROR Backend:30011 Exception on /mod/3/Test download path/update [GET]
 Traceback (most recent call last):
   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1283, in _execute_context
     self.dialect.do_execute(
   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
     cursor.execute(statement, parameters)
 psycopg2.errors.InvalidTextRepresentation: invalid input syntax for integer: "kerbal-space-program"
 LINE 3: WHERE game.id = 'kerbal-space-program' ORDER BY game.id DESC...

<some more messages and lines and stuff>

   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/blueprints/mods.py", line 62, in update
     ga = _restore_game_info()
   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/blueprints/mods.py", line 40, in _restore_game_info
     ga = Game.query.filter(Game.id == game_id).order_by(desc(Game.id)).first()
```

If users have no game assigned to their current session, `_restore_game_info()` tries to default to KSP.
However, it assigns the game's `short` instead of the `id` to the `game_id` variable, and then the DB throws a type error.

The return value hasn't been used in `update.html`, and in `create.html` only for setting the default selection I think.

## Changes
`_restore_game_info()` is now changed to properly fallback to KSP (based on the short).

The call to `_restore_game_info()` is removed from `update()` since it isn't needed, the game is also no longer passed to the template.

In `api.update_mod` a query filter has been changed to compare against `mod.game_id` instead of `Mod.game_id`. Not sure why this even worked, I guess SQLAlchemy has some special logic for comparing to classes/table columns, and just tests if the columns are of the same type or something.

The `game` parameter for `create.html` has been renamed to `games`, since it's a list of games, not a single one.