### PR TITLE
Send UTC TZ for mod creation timestamps

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -74,7 +74,7 @@ def version_info(mod, version):
         "friendly_version": version.friendly_version,
         "game_version": version.gameversion.friendly_version,
         "id": version.id,
-        "created": version.created.replace(tzinfo=timezone.utc).isoformat(),
+        "created": version.created.astimezone(timezone.utc).isoformat(),
         "download_path": url_for('mods.download', mod_id=mod.id,
                                  mod_name=mod.name,
                                  version=version.friendly_version),

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -3,7 +3,7 @@ import math
 import os
 import time
 import zipfile
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 
 import bcrypt
@@ -74,7 +74,7 @@ def version_info(mod, version):
         "friendly_version": version.friendly_version,
         "game_version": version.gameversion.friendly_version,
         "id": version.id,
-        "created": version.created.isoformat(),
+        "created": version.created.replace(tzinfo=timezone.utc).isoformat(),
         "download_path": url_for('mods.download', mod_id=mod.id,
                                  mod_name=mod.name,
                                  version=version.friendly_version),


### PR DESCRIPTION
## Problem

As noted in Discord during review of KSP-CKAN/CKAN#3059, the timestamps from #195 don't indicate timezones. Technically this means they're in "local" time, whatever that means for a server/client interaction.

## Cause

We just return `created` from the database, which is generated by `datetime.now`, which does not include the timezone:

https://github.com/KSP-SpaceDock/SpaceDock/blob/0e5f6c5f9d64fd071d14bbd722ca8e938e90b0bb/KerbalStuff/objects.py#L230

It's not clear whether the timezone can be saved to the db anyway, though. At least one comment on StackExchange suggested it couldn't. So we can add it at load instead.

## Changes

Now we set the TZ to UTC.