### PR TITLE
Restore sponsor button on GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: spacedock # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
## Problem
The following commits were somehow merged to master after we forked alpha + beta.
```
$ git log --no-merges upstream/old-master ^upstream/master
commit e537e2217f0a64f812aa8c80c21b088fb289fba6
Author: VITAS <github.v@52k.de>
Date:   Sun Jul 28 17:13:15 2019 +0200

Update FUNDING.yml

commit 705ef6c1fb46fd1d24c483bac0fcfd68acf8cc34
Author: VITAS <github.v@52k.de>
Date:   Sun Jul 28 17:11:37 2019 +0200

Update FUNDING.yml

commit cfd519bfce9b4eb40c59d4b87ec8f292a174e34a
Author: VITAS <github.v@52k.de>
Date:   Sun Jul 28 15:49:38 2019 +0200

Set theme jekyll-theme-minimal

commit 83b1d4830656ad7b98dc376238906c4e167b4ca7
Author: VITAS <github.v@52k.de>
Date:   Sun Jul 28 15:48:20 2019 +0200

Create FUNDING.yml
```

The `FUNDING.yml` changes (83b1d4830656ad7b98dc376238906c4e167b4ca7 705ef6c1fb46fd1d24c483bac0fcfd68acf8cc34 e537e2217f0a64f812aa8c80c21b088fb289fba6) are to display a sponsor button on GitHub that links to the SpaceDock Patreon page (more information [here](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository).
The `jekyll-theme-minimal` change (cfd519bfce9b4eb40c59d4b87ec8f292a174e34a) has set the theme for https://ksp-spacedock.github.io/SpaceDock/ .

There were also some differing merge commits, but the underlying commits themselves are already in alpha+beta+master.

## Changes
I restored the funding button (and squashed the three commits).
I'd like the GitHub pages config file to be in the `.github` directory, but I'm not sure if this is possible and can't find anything in the docs. Since the page is also likely not used much (it's just a copy of our README.md), I decided to leave it out. We can always ttry to restore it later.