### PR TITLE
Add password change option for users

### DIFF
--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -60,7 +60,7 @@ def profile(username):
         profile.twitterUsername = request.form.get('twitter')
         profile.forumUsername = request.form.get('ksp-forum-user')
         # Due to the Forum update, and the fact that IPS4 doesn't have an API like
-        # vBullentin, we are removing this until we can adress it.
+        # vBulletin, we are removing this until we can adress it.
         # TODO(Thomas): Find a way to get the id of the User.
         # result = getForumId(profile.forumUsername)
         # if not result:

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -69,6 +69,9 @@ def wrap_mod(mod):
 
 
 def with_session(f):
+    """Automatically commits to the database, and rolls back if the process throws an error.
+
+    """
     @wraps(f)
     def go(*args, **kw):
         try:

--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -11,7 +11,7 @@ from .config import _cfg, _cfgd
 def send_confirmation(user, followMod=None):
     with open("emails/confirm-account") as f:
         if followMod is not None:
-            message = chevron.render(f.read(), {'user': user, 'site-name': _cfg('site-name'), "domain": _cfg("domain"),
+            message = chevron.render(f.read(), {'user': user, 'site_name': _cfg('site-name'), "domain": _cfg("domain"),
                                                 'confirmation': user.confirmation + "?f=" + followMod})
         else:
             message = html.unescape(
@@ -21,13 +21,21 @@ def send_confirmation(user, followMod=None):
                     important=True)
 
 
-def send_reset(user):
+def send_password_reset(user):
     with open("emails/password-reset") as f:
         message = html.unescape(
-            chevron.render(f.read(), {'user': user, 'site-name': _cfg('site-name'), "domain": _cfg("domain"),
+            chevron.render(f.read(), {'user': user, 'site_name': _cfg('site-name'), "domain": _cfg("domain"),
                                       'confirmation': user.passwordReset}))
     send_mail.delay(_cfg('support-mail'), [user.email], "Reset your password on " + _cfg('site-name'), message,
                     important=True)
+
+
+def send_password_changed(user):
+    with open("emails/password-changed") as f:
+        message = html.unescape(
+            chevron.render(f.read(), {'user': user, 'site_name': _cfg('site-name'), "domain": _cfg("domain")}))
+    send_mail.delay(_cfg('support-mail'), [user.email], f'Your password on {_cfg("site-name")} has been changed',
+                    message, important=True)
 
 
 def send_mod_locked(mod, user):
@@ -51,7 +59,7 @@ def send_mod_locked(mod, user):
 def send_grant_notice(mod, user):
     with open("emails/grant-notice") as f:
         message = html.unescape(
-            chevron.render(f.read(), {'user': user, 'site-name': _cfg('site-name'), "domain": _cfg("domain"),
+            chevron.render(f.read(), {'user': user, 'site_name': _cfg('site-name'), "domain": _cfg("domain"),
                                       'mod': mod, 'url': url_for('mods.mod', mod_id=mod.id, mod_name=mod.name)}))
     send_mail.delay(_cfg('support-mail'), [user.email], "You've been asked to co-author a mod on " + _cfg('site-name'),
                     message, important=True)
@@ -72,7 +80,7 @@ def send_update_notification(mod, version, user):
         message = html.unescape(chevron.render(f.read(), {
             'mod': mod,
             'user': user,
-            'site-name': _cfg('site-name'),
+            'site_name': _cfg('site-name'),
             'domain': _cfg("domain"),
             'latest': version,
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
@@ -97,7 +105,6 @@ def send_autoupdate_notification(mod):
         message = html.unescape(chevron.render(f.read(), {
             'mod': mod,
             'domain': _cfg("domain"),
-            'site-name': _cfg('site-name'),
             'latest': mod.default_version,
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
             'changelog': changelog

--- a/emails/password-changed
+++ b/emails/password-changed
@@ -1,0 +1,14 @@
+Hello from {{ site_name }}, {{user.username}}!
+
+Your password on {{ site_name }} has been changed.
+
+
+If this wasn't you, please contact us by replying to this e-mail, or via one of the following channels:
+
+{{#support_channels}}
+  * {{name}}: {{channel_url}}
+{{/support_channels}}
+
+
+Greetings
+Your {{site_name}} Team

--- a/emails/password-reset
+++ b/emails/password-reset
@@ -1,4 +1,6 @@
-Hello from {{ site_name }}, {{user.username}}! Someone, probably you, has asked us to reset the password on your account. If that was indeed you, click this link to proceed:
+Hello from {{ site_name }}, {{user.username}}!
+
+Someone, probably you, has asked us to reset the password on your account. If that was indeed you, click this link to proceed:
 
 https://{{domain}}/reset/{{user.username}}/{{confirmation}}
 

--- a/frontend/coffee/profile.coffee
+++ b/frontend/coffee/profile.coffee
@@ -1,3 +1,4 @@
+# Background Uploading
 window.upload_bg = (files, box) ->
     file = files[0]
     p = document.createElement('p')
@@ -31,3 +32,63 @@ window.upload_bg = (files, box) ->
     formdata = new FormData()
     formdata.append('image', file)
     xhr.send(formdata)
+
+
+# Handling of the change-password-dialog
+$('#password-form').submit((e) ->
+    e.preventDefault()
+
+    # Disable the buttons until we get an response
+    buttons = document.getElementsByClassName('btn-pw-change')
+    for button in buttons
+        button.setAttribute('disabled', '')
+
+    old_password = $('#old-password').val()
+    new_password = $('#new-password').val()
+    new_password_confirm = $('#new-password-confirm').val()
+
+    xhr = new XMLHttpRequest()
+    xhr.open('POST', "/api/user/#{window.username}/change-password")
+    # Triggered after we get an response from the server.
+    # It's in the form {'error': bool, 'reason': string)
+    xhr.onload = () ->
+        result = JSON.parse(this.responseText)
+        error_message_display = $('#error-message')
+
+        if result.error == true
+            error_message_display.html(result.reason)
+            error_message_display.addClass('text-danger')
+            error_message_display.removeClass('hidden')
+            # Re-enable the buttons.
+            for button in buttons
+                button.removeAttribute('disabled')
+        else
+            error_message_display.html('Password changed successfully.')
+            error_message_display.removeClass('text-danger')
+            error_message_display.addClass('text-success')
+            error_message_display.removeClass('hidden')
+            # .modal('hide') doesn't work. Let's reload the page instead.
+            # Delay it a bit to give the user a chance to read the response message.
+            setTimeout((() -> window.location = window.location), 1000)
+
+    form = new FormData()
+    form.append('old-password', old_password)
+    form.append('new-password', new_password)
+    form.append('new-password-confirm', new_password_confirm)
+    xhr.send(form)
+)
+
+
+resetPasswordModalDialog = () ->
+    $('#password-form').trigger('reset')
+    error_message_display = $('#error-message')
+    error_message_display.html('')
+    error_message_display.removeClass('text-danger')
+    error_message_display.removeClass('text-success')
+    error_message_display.addClass('hidden')
+
+    buttons = document.getElementsByClassName('btn-pw-change')
+    for button in buttons
+        button.removeAttribute('disabled')
+
+$('#change-password').on('hidden.bs.modal', resetPasswordModalDialog)

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -106,7 +106,7 @@
 
                 <div class="col-md-6">
                     <h3 style="margin: 0; padding: 0; padding-bottom: 5px;">Your description <small><a target="_blank" href="/markdown">Markdown</a> supported</small></h3>
-        <link rel="stylesheet" href="/static/editor.css">
+                    <link rel="stylesheet" href="/static/editor.css">
                     <textarea name="description"
                         class="form-control input-block-level"
                         placeholder="Public description"
@@ -120,8 +120,21 @@
 {%if not hide_login %}
 <div class="container lead">
     <div class="row">
+        <div class="col-md-12">
+            <h2 title="change-password">Change Password</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <a class="btn btn-default" href="#" data-toggle="modal" data-target="#change-password" role="button">Click to change password</a>
+        </div>
+    </div>
+</div>
+
+<div class="container lead">
+    <div class="row">
         <div class="col-md-8">
-            <h1 title="Login">Connected Accounts</h1>
+            <h2 title="Login">Connected Accounts</h2>
         </div>
 
     </div>
@@ -203,6 +216,42 @@
     </div>
 </div>
 {% endfor %}
+<div class="modal fade" id="change-password" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+              <h4 class="modal-title" id="myModalLabel">Change Password</h4>
+            </div>
+            <form action="#" id="password-form">
+                <div class="modal-body">
+                    <p>You can change your password here.</p>
+                    <div class="form-group">
+                        <label for="old-password">Current password</label>
+                        <input type="password" id="old-password" placeholder="Enter old password" class="form-control"
+                               name="old-password">
+                    </div>
+                    <div class="form-group">
+                        <label for="new-password">New password</label>
+                        <input type="password" id="new-password" placeholder="Enter new password" class="form-control"
+                               name="new-password" minlength="5" autocomplete="off">
+                    </div>
+                    <div class="form-group">
+                        <label for="new-password-confirm">Confirm new password</label>
+                        <input type="password" id="new-password-confirm" placeholder="Repeat new password" class="form-control"
+                               name="new-password-confirm" minlength="5" autocomplete="off">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <p>If you don't remember your current password, click <a href="{{ url_for('accounts.forgot_password') }}">here to reset it</a>.</p>
+                    <p id="error-message" class="hidden"></p>
+                    <a href="#" class="btn btn-default btn-pw-change" data-dismiss="modal">Cancel</a>
+                    <input type="submit" id="change-password-submit" class="btn btn-primary btn-pw-change" value="Change password">
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock %}
 {% block scripts %}
     <script>


### PR DESCRIPTION
## Motivation
SpaceDock is lacking a good way to change passwords. You can reset your password via `/forgot-password`, but we are not linking to it anywhere for one, and it's not something users would go to if they simply want to change it (and still now their old one).

## Changes
There's a new API route `change_password` at `/api/user/<username>/change-password`. It requires the old password as well as the new password x2 as POST parameters.
It checks if the old password is correct, if the user for whom the password shall be changed is the one trying to do it, and whether the new passwords follow a few simple rules, now centrally defined in `accounts.check_password_criteria()` (it is also used by `register()` and `reset_password()`).
If it fulfills all the criteria, the new password is set in the database and we send a notification email.
Afterwards it returns a JSON response similar to the others we return in the API:
`{'error': <bool>, 'reason': <string>}`

&nbsp;
On the frontend side of things there's now a new button on the profile edit page:
![image](https://user-images.githubusercontent.com/28812678/83201544-fd238400-a145-11ea-89e2-2f71d47f0aa4.png)
If you know a better place, I'm open for suggestions.
It opens a modal dialog:
![image](https://user-images.githubusercontent.com/28812678/83201570-12001780-a146-11ea-8b9c-0c38195994da.png)

When you click `Change Password`, an XHR is sent to the API endpoint mentioned above. There's no additional client-side validation, instead if the input doesn't match the criteria, the message returned from it is displayed above the buttons:
![image](https://user-images.githubusercontent.com/28812678/83201818-9f436c00-a146-11ea-8b44-ec0ca344caf9.png)

If the process is successful, the profile page is reloaded (could't get the modal to hide, `.modal('hide')` doesn't work for whatever reason).

&nbsp;
`email.py` needed chaning all occurences of `site-name` to `site_name` (since they are referenced as the second one in the email templates).
I guess pystache was more tolerant, but chevron needs hyphens and underscores to match in the supplied dict and the template.

Fixes #214.