### PR TITLE
Fix creation of new mods

### DIFF
--- a/api.md
+++ b/api.md
@@ -389,6 +389,7 @@ Creates a new mod. **Requires authentication**.
         -F" name=Example Mod" \
         -F "short-description=this is your schort description" \
         -F "version=1.0" \
+        -F "game-short-name=kerbal-space-program" \
         -F "game-version=0.24" \
         -F "license=GPLv2" \
         -F "zipball=@ExampleMod.zip" \
@@ -399,7 +400,8 @@ Creates a new mod. **Requires authentication**.
 * `name`: Your new mod's name
 * `short-description`: Short description of your mod
 * `version`: The latest friendly version of your mod
-* `game-version`: The KSP version this is compatible with
+* `game-short-name`: The short name of the game your mod is for. Alternatively specify the id with `game-id`.
+* `game-version`: The game version this is compatible with
 * `license`: Your mod's license
 * `ckan`: If "yes", automatically add your mod to the CKAN index
 * `zipball`: The actual mod's zip file
@@ -433,7 +435,7 @@ Publishes an update to an existing mod. **Requires authentication**.
 
 * `version`: The friendly version number about to be created
 * `changelog`: Markdown changelog
-* `game-version`: The version of KSP this is compatible with
+* `game-version`: The game version this is compatible with
 * `notify-followers`: If "yes", email followers about this update
 * `zipball`: The actual mod's zip file
 

--- a/frontend/coffee/create.coffee
+++ b/frontend/coffee/create.coffee
@@ -58,7 +58,7 @@ document.getElementById('submit').addEventListener('click', () ->
             document.querySelector('.upload-mod p').classList.add('hidden')
             loading = false
     form = new FormData()
-    form.append('game', game)
+    form.append('game-id', game)
     form.append('name', name)
     form.append('short-description', shortDescription)
     form.append('license', license)

--- a/frontend/coffee/create.coffee
+++ b/frontend/coffee/create.coffee
@@ -111,3 +111,67 @@ window.addEventListener('drop', (e) ->
 
 document.getElementById('submit').removeAttribute('disabled')
 $('[data-toggle="tooltip"]').tooltip()
+
+
+updategame = ->
+    gid = $("#mod-game option:selected").attr("value")
+    # TODO: don't hardcode the production game id here.
+    #       Do we have a game.ckan_enabled property?
+    if gid != "3102"
+        # if not ksp then hide ckan checkbox
+        $(".ckan").hide()
+    else
+        $(".ckan").show()
+
+
+updategameversions = (gameid) ->
+    $.ajax(
+        method: "GET",
+        url: "/api/" + gameid + "/versions",
+        success: (msg) ->
+            $("#mod-game-version option").remove()
+            $.each(msg, (el, data) ->
+                $('<option value="' + data.friendly_version + '">' + data.friendly_version + '</option>').appendTo("#mod-game-version")
+            )
+            $("#mod-game-version").trigger("chosen:updated")
+    )
+
+
+# Check if there's a game preselected, if yes, get the game versions for it.
+preselected = $("#mod-game option:selected").attr("value")
+if preselected != null
+    updategame()
+    updategameversions(preselected)
+
+
+$("#mod-game-version").chosen(
+    max_selected_options: 1,
+    no_results_text: "No Options found",
+    width: '100%'
+)
+$("#mod-game").chosen(
+    max_selected_options: 1, no_results_text: "No Options found",
+    width: '100%'
+)
+$("#mod-license").chosen(
+    max_selected_options: 1,
+    no_results_text: "No Options found",
+    width: '100%'
+)
+$("#mod-game").chosen({width: '100%'}).change(() ->
+    updategame()
+    updategameversions($(this).val())
+)
+
+licsel = $("#mod-license option:selected").html()
+if licsel == "Other"
+    $("#mod-other-license").removeClass("hidden").show()
+else
+    $("#mod-other-license").addClass("hidden").hide()
+
+$("#mod-license").chosen({width: '100%'}).change((evt, par) ->
+    if par.selected == "Other"
+        $("#mod-other-license").removeClass("hidden").show()
+    else
+        $("#mod-other-license").addClass("hidden").hide()
+)

--- a/templates/create.html
+++ b/templates/create.html
@@ -32,7 +32,7 @@
             <select id="mod-game" class="chosen-select">
                 {% if not ga %}<option selected disabled hidden style='display: none' value=''></option>{% endif %}
                 {% for g in games %}
-                <option data-slug="{{ g.short }}" value="{{g.id}}" {% if  ga and g.id == ga.id %}selected{% endif %}>{{g.name}}</option>
+                <option data-slug="{{ g.short }}" value="{{g.id}}" {% if ga and g.id == ga.id %}selected{% endif %}>{{g.name}}</option>
                 {% endfor %}
             </select>
         </div>
@@ -138,73 +138,4 @@
     <script src="/static/marked.js"></script>
     <script src="/static/chosen.jquery.min.js"></script>
     <script src="/static/create.js"></script>
-    <script language="javascript">
-        $(document).ready(function () {
-            function updategame() {
-                var gamename = $("#mod-game option:selected").text();
-                var slug = $("#mod-game option:selected").attr("data-slug");
-                var gid = $("#mod-game option:selected").attr("value");
-                // TODO: don't hardcode the production game id here.
-                //       Do we have a game.ckan_enabled property?
-                if (gid != "3102") { //if not ksp then hide ckan checkbox
-                    $(".ckan").hide();
-                } else {
-                    $(".ckan").show();
-                }
-            }
-
-            function updategameversions(gameid) {
-                $.ajax({
-                    method: "GET",
-                    url: "/api/" + gameid + "/versions",
-                    success: function (msg) {
-                        $("#mod-game-version option").remove();
-                        $.each(msg, function (el, data) {
-                            $('<option value="' + data.friendly_version + '">' + data.friendly_version + '</option>').appendTo("#mod-game-version");
-                        });
-                        $("#mod-game-version").trigger("chosen:updated");
-                    }
-                });
-            }
-
-            // Check if there's a game preselected, if yes, get the game versions for it.
-            const preselected = $("#mod-game option:selected").attr("value");
-            if (preselected != null) {
-                updategame();
-                updategameversions(preselected);
-            }
-
-            $("#mod-game-version").chosen({
-                max_selected_options: 1,
-                no_results_text: "No Options found",
-                width: '100%'
-            });
-            $("#mod-game").chosen({
-                max_selected_options: 1, no_results_text: "No Options found",
-                width: '100%'
-            });
-            $("#mod-license").chosen({
-                max_selected_options: 1,
-                no_results_text: "No Options found",
-                width: '100%'
-            });
-            $("#mod-game").chosen({width: '100%'}).change(function () {
-                updategame();
-                updategameversions($(this).val())
-            });
-            var licsel = $("#mod-license option:selected").html();
-            if (licsel === "Other") {
-                $("#mod-other-license").removeClass("hidden").show();
-            } else {
-                $("#mod-other-license").addClass("hidden").hide();
-            }
-            $("#mod-license").chosen({width: '100%'}).change(function (evt, par) {
-                if (par.selected === "Other") {
-                    $("#mod-other-license").removeClass("hidden").show();
-                } else {
-                    $("#mod-other-license").addClass("hidden").hide();
-                }
-            });
-        });
-    </script>
 {% endblock %}

--- a/templates/create.html
+++ b/templates/create.html
@@ -70,9 +70,7 @@
             </div>
             <div class="col-md-5 form-group">
                 <select id="mod-game-version" class="chosen-select">
-                    {% for v in game_versions %}
-                    <option value="{{v.friendly_version}}" {% if loop.first %}selected{% endif %}> {{v.friendly_version}}</option>
-                    {% endfor %}
+                    <!-- Filled via JavaScript -->
                 </select>
             </div>
             <div class="col-md-2 form-group">
@@ -162,7 +160,7 @@
                     success: function (msg) {
                         $("#mod-game-version option").remove();
                         $.each(msg, function (el, data) {
-                            $('<option value="' + data.id + '">' + data.friendly_version + '</option>').appendTo("#mod-game-version");
+                            $('<option value="' + data.friendly_version + '">' + data.friendly_version + '</option>').appendTo("#mod-game-version");
                         });
                         $("#mod-game-version").trigger("chosen:updated");
                     }


### PR DESCRIPTION
## Problem
#264 surfaced a bug which makes creating new mods broken now.

Until #264, we primarily filled the **game version** selector in `create.html` during (server-side) template rendering.
This step assigns `game_version.friendly_version` to the `value` attribute:
https://github.com/KSP-SpaceDock/SpaceDock/blob/e91894465c3a2885531355b9c813493ad93eaca4/templates/create.html#L72-L76

As soon as you switch the selected **game**, some JavaScript code is executed to refill the **game version** selector. However this JS code assigns `game_version.id` to the `value` attribute:
https://github.com/KSP-SpaceDock/SpaceDock/blob/e91894465c3a2885531355b9c813493ad93eaca4/templates/create.html#L179-L181

Since #264, the JS code is also executed once after page load, which results in the id being assigned all the time. The value of the `value` attribute is sent in the XHR request then.

However, the API expects `game_version.friendly_version`. So while until #264 creating mods was only broken when you changed the selected game once (which isn't possible on prod. because we only have one), now it's broken all the time.

## Changes
Now the API expects `game_version.id` in `create_mod()`, and also no longer needs a separate `game-id` form parameter, since we can get it from the `game_version`.

I also changed `update_mod()` and `update.html` to also use the `id` to keep it the same.

I removed some code from `create.html` which I missed to delete in #264. No need to fill the `game_version` selector if we overwrite it in JS anyways.

---

I had the choice between using the `id` everywhere or the `friendly_version`. I went with the `id` because it's always unique and you can derive the game from it.
But I'm also open to use `friendly_version` instead. Feel free to discuss what you think should be used.

A second commit is coming up which moves the embedded JS part into `update.coffee`.