### PR TITLE
Speed up search_mods with flask_caching

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -32,6 +32,7 @@ from .database import db
 from .helpers import is_admin, following_mod, following_user
 from .kerbdown import KerbDown
 from .objects import User
+from .cache import sd_cache
 
 app = Flask(__name__)
 app.jinja_env.filters['firstparagraph'] = firstparagraph
@@ -42,6 +43,7 @@ app.json_encoder = CustomJSONEncoder
 markdown = Markdown(app, safe_mode='remove', extensions=[KerbDown()])
 login_manager = LoginManager()
 login_manager.init_app(app)
+sd_cache.init_app(app)
 
 
 @login_manager.user_loader

--- a/KerbalStuff/cache.py
+++ b/KerbalStuff/cache.py
@@ -1,0 +1,6 @@
+from flask_caching import Cache
+
+sd_cache = Cache(config={
+    'CACHE_TYPE': 'simple',
+    'CACHE_DEFAULT_TIMEOUT': 60,
+})

--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -50,7 +50,7 @@ def weigh_result(result, terms):
 @sd_cache.memoize()
 def search_mods(ga, text, page, limit):
     terms = text.split(' ')
-    query = db.query(Mod).join(Mod.user).join(Mod.versions).join(Mod.game)
+    query = db.query(Mod).join(Mod.user).join(Mod.versions).join(Mod.game).join(Mod.default_version)
     filters = list()
     for term in terms:
         if term.startswith("ver:"):

--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -5,6 +5,7 @@ from sqlalchemy import or_, desc
 
 from .database import db
 from .objects import Mod, ModVersion, User, GameVersion
+from .cache import sd_cache
 
 
 def weigh_result(result, terms):
@@ -46,6 +47,7 @@ def weigh_result(result, terms):
     return score
 
 
+@sd_cache.memoize()
 def search_mods(ga, text, page, limit):
     terms = text.split(' ')
     query = db.query(Mod).join(Mod.user).join(Mod.versions).join(Mod.game)

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -7,6 +7,7 @@ flask
 flask-login
 flask-markdown
 flask-oauthlib
+flask-caching
 future
 jinja2
 markdown


### PR DESCRIPTION
This is an attempt to use Flask's caching module to speed up `search_mods`, which is a core search function used throughout the site. If it is called with the same parameters within 60 seconds (as it often is, for example in `/browse` and `/browse/top` and `/<gameshort>/browse`), the same result will be re-used.

Possibly replaces #275.