### PR TITLE
API: Set UTC TZ for all datetimes, prune whitespace

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -2,7 +2,7 @@ import math
 import os
 import time
 import zipfile
-from datetime import datetime, timezone
+from datetime import datetime
 from functools import wraps
 
 import bcrypt
@@ -74,7 +74,7 @@ def version_info(mod, version):
         "friendly_version": version.friendly_version,
         "game_version": version.gameversion.friendly_version,
         "id": version.id,
-        "created": version.created.astimezone(timezone.utc).isoformat(),
+        "created": version.created,
         "download_path": url_for('mods.download', mod_id=mod.id,
                                  mod_name=mod.name,
                                  version=version.friendly_version),
@@ -96,7 +96,7 @@ def game_info(game):
         "publisher_id": game.publisher_id,
         "short_description": game.short_description,
         "description": game.description,
-        "created": game.created.isoformat(),
+        "created": game.created,
         "background": game.background,
         "bg_offset_x": game.bgOffsetX,
         "bg_offset_y": game.bgOffsetY,

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -111,7 +111,7 @@ def adminrequired(f):
 
 
 def json_response(obj, status=None):
-    data = json.dumps(obj, cls=CustomJSONEncoder)
+    data = json.dumps(obj, cls=CustomJSONEncoder, separators=(',', ':'))
     return Response(data, status=status, mimetype='application/json')
 
 

--- a/KerbalStuff/custom_json.py
+++ b/KerbalStuff/custom_json.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask.json import JSONEncoder
 
@@ -6,7 +6,7 @@ from flask.json import JSONEncoder
 class CustomJSONEncoder(JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
-            return obj.isoformat()
+            return obj.astimezone(timezone.utc).isoformat()
         try:
             return list(obj)
         except TypeError:


### PR DESCRIPTION
## Background / Motivations

The API already uses a custom JSON encoder to format datetimes that are included in response dicts. Instead of taking advantage of this and adding timezone data in #265, we formatted one specific datetime to a string before the custom encoder has a chance to do its work. There are other datetimes in the API; some are formatted by the custom encoder, some have their own custom encoding code (which does the same thing). Ideally they should all use the same format, in a UTC time zone.

The API output puts spaces after commas and colons, which isn't necessary for machine-readable data, makes it look less professional, and wastes a tiny amount of network bandwidth.

- https://beta.spacedock.info/api/mod/2

GitHub by way of comparison doesn't use extra spaces in its API:

- https://api.github.com/rate_limit

## Changes

- Now the API timezone change from #265 is moved to `CustomJSONEncoder.default`, and all API code returning datetimes that I was able to find is updated to leave them unformatted so the encoder can format them. This will ensure that all datetimes in the API are sent with a UTC time zone.
- Now the JSON output doesn't put unnecessary spaces after colons or commas. This will shrink all requests by a few bytes.