### PR TITLE
Fix support channels missing from password-changed email, and others

### DIFF
--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -29,7 +29,7 @@ def game(gameshort):
     new = Mod.query.filter(Mod.published,Mod.game_id == ga.id).order_by(desc(Mod.created)).limit(6)[:6]
     recent = Mod.query.filter(Mod.published,Mod.game_id == ga.id, ModVersion.query.filter(ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated)).limit(6)[:6]
     user_count = User.query.count()
-    mod_count = Mod.query.filter(Mod.game_id == ga.id).count()
+    mod_count = Mod.query.filter(Mod.game_id == ga.id).filter(Mod.published == True).count()
     yours = list()
     if current_user:
         yours = sorted(current_user.following, key=lambda m: m.updated, reverse=True)[:6]

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -396,7 +396,7 @@ def unfeature(mod_id):
 @loginrequired
 def publish(mod_id, mod_name):
     mod, game = _get_mod_game_info(mod_id)
-    if current_user.id != mod.user_id:
+    if current_user.id != mod.user_id and not current_user.admin:
         abort(401)
     if mod.locked:
         abort(403)
@@ -536,6 +536,7 @@ def autoupdate(mod_id):
     check_mod_editable(mod)
     default = mod.default_version
     default.gameversion_id = GameVersion.query.filter(GameVersion.game_id == mod.game_id).order_by(desc(GameVersion.id)).first().id
+    mod.updated = datetime.now()
     send_autoupdate_notification(mod)
     return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name,ga=game))
     notify_ckan(mod, 'version-update')

--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -33,23 +33,25 @@ def send_password_reset(user):
 def send_password_changed(user):
     with open("emails/password-changed") as f:
         message = html.unescape(
-            chevron.render(f.read(), {'user': user, 'site_name': _cfg('site-name'), "domain": _cfg("domain")}))
+            chevron.render(f.read(), {
+                'user': user,
+                'site_name': _cfg('site-name'),
+                "domain": _cfg("domain"),
+                'support_channels': support_channels_to_map()
+            })
+        )
     send_mail.delay(_cfg('support-mail'), [user.email], f'Your password on {_cfg("site-name")} has been changed',
                     message, important=True)
 
 
 def send_mod_locked(mod, user):
-    support_channels = list()
-    for name, url in _cfgd('support-channels').items():
-        support_channels.append({'name': name, 'channel_url': url})
-
     with open('emails/mod-locked') as f:
         message = html.unescape(
             chevron.render(f.read(), {
                 'mod': mod, 'user': user,
                 'url': url_for('mods.mod', mod_id=mod.id, mod_name=mod.name, _external=True),
                 'site_name': _cfg('site-name'),
-                'support_channels': support_channels
+                'support_channels': support_channels_to_map()
             })
         )
         subject = f'Your mod {mod.name} has been locked on {_cfg("site-name")}'
@@ -121,3 +123,10 @@ def send_bulk_email(users, subject, body):
     for u in users:
         targets.append(u)
     send_mail.delay(_cfg('support-mail'), targets, subject, body)
+
+
+def support_channels_to_map():
+    support_channels = list()
+    for name, url in _cfgd('support-channels').items():
+        support_channels.append({'name': name, 'channel_url': url})
+    return support_channels

--- a/templates/admin-links.html
+++ b/templates/admin-links.html
@@ -33,8 +33,8 @@
                 <td><a href="https://www.patreon.com/spacedock?ty=p" target="_BLANK">https://www.patreon.com/spacedock?ty=p</a></td>
             </tr>
             <tr>
-                <td><a href="https://forum.kerbalspaceprogram.com/index.php?/topic/132186-spacedockinfo-dev-thread-the-kerbalstuff-replacement-site-fully-operational/&page=1" target="_BLANK">KSP Forum Thread</a></td>
-                <td><a href="https://forum.kerbalspaceprogram.com/index.php?/topic/132186-spacedockinfo-dev-thread-the-kerbalstuff-replacement-site-fully-operational/&page=1" target="_BLANK">Too Long (copy from link)</a></td>
+                <td><a href="https://forum.kerbalspaceprogram.com/index.php?/topic/170865-spacedockinfo" target="_BLANK">KSP Forum Thread</a></td>
+                <td><a href="https://forum.kerbalspaceprogram.com/index.php?/topic/170865-spacedockinfo" target="_BLANK">https://forum.kerbalspaceprogram.com/index.php?/topic/170865-spacedockinfo</a></td>
             </tr>
             </tbody>
 

--- a/templates/game.html
+++ b/templates/game.html
@@ -45,21 +45,12 @@
     </div>
 </div>
 <div class="container">
-    {% if user %}
     <div class="row">
         {% for feature in featured[:6]  %}
         {% set mod = feature.mod %}
         {% include "mod-box.html" %}
         {% endfor %}
     </div>
-    {% else %}
-    <div class="row">
-        {% for feature in featured[:6]  %}
-        {% set mod = feature.mod %}
-        {% include "mod-box.html" %}
-        {% endfor %}
-    </div>
-    {% endif %}
 </div>
 <div class="well"  style="margin-bottom: 0;margin-top: 2.5mm;">
     <div class="container main-cat">
@@ -117,7 +108,7 @@
             Browse All Mods
             <span class="glyphicon glyphicon-chevron-right"></span>
         </a>
-        <h3>Browse {{ mod_count }} more Mods</h3>
+        <h3>Browse all {{ mod_count }} Mods</h3>
     </div>
 </div>
 <div class="container">


### PR DESCRIPTION
## Motivation
Mostly found while testing beta code. A bunch of smaller fixes and enhancements, see below:

## Changes
1) Don't count unpublished mods on game page.
Closes #240 

2) Fix support channels missing from password-changed email
Forgot to add that parameter in #268. I also moved the transformation from a simple dict to a "map" list with `"name":` and `"channel_url":` in a separate function since we use it twice now.

3) Replace forum thread link on admin page with the current one.
It points to an old, no longer existing thread currently. I also shortened it so it fits on the right side too.

4) Allow admins to publish mods
I think this is handy to have especially with the locking feature from #260

5) Mark mod as recently updated if only the KSP compatibility changed.
Closes #171 

6) Remove unnecessary if-else on game page.
There's a Jinja2 if-else statement in `game.html` which has the same code in both code paths. The if-else is now gone.

&nbsp;
At least 2) and probably also 4) should be merged to beta before we merge beta to master.
I can split it up if you want, but I think the other changes are small enough that they can also go still to beta this round.