### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,21 @@
+name: PyTest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: PyTest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install Dependencies
+      run: |
+        pip install -r requirements-backend.txt
+        pip install -r requirements-tests.txt
+    - name: pytest
+      run: |
+        pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ node_modules/
 .idea/
 nbproject/
 pip-selfcheck.json
+
+__pycache__/
+.pytest_cache/

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-flask
+flask-api
+flask-testing

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
 from .test_version import *
+from .test_api_browse import *
+from .test_api_mod import *

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_version import *

--- a/tests/fake_db.py
+++ b/tests/fake_db.py
@@ -1,0 +1,11 @@
+from KerbalStuff.config import config, env
+
+
+# IMPORT THIS FIRST.
+# The config module hard-loads config.ini, and other modules import it directly,
+# so we need to cheat to override it.
+if not config.has_section(env):
+    config.add_section(env)
+config[env]['connection-string'] = 'sqlite:///:memory:'
+
+dummy = ''

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,0 +1,13 @@
+from typing import Generator
+import pytest
+from flask.testing import FlaskClient
+from flask import Response
+
+from tests.fake_db import dummy
+from KerbalStuff.app import app
+
+# FlaskClient requires a type parameter in mypy, but errors out with one at runtime
+@pytest.fixture
+def client() -> Generator['FlaskClient[Response]', None, None]:
+    with app.test_client() as client:
+        yield client

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -4,10 +4,15 @@ from flask.testing import FlaskClient
 from flask import Response
 
 from tests.fake_db import dummy
+from KerbalStuff.database import create_database, create_tables, drop_database, drop_tables
 from KerbalStuff.app import app
 
 # FlaskClient requires a type parameter in mypy, but errors out with one at runtime
 @pytest.fixture
 def client() -> Generator['FlaskClient[Response]', None, None]:
+    # create_database has a meaningless return value, don't assert it
+    create_database()
+    create_tables()
     with app.test_client() as client:
         yield client
+    drop_tables()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,10 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
         description='A mod that we will use to test the API',
         user=User(
             username='TestModAuthor',
+            description='Test author of a test mod',
             email='webmaster@spacedock.info',
+            forumUsername='TestForumUser',
+            public=True,
         ),
         license='MIT',
         game=game,
@@ -54,6 +57,7 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     gameversions_resp = client.get('/api/1/versions')
     mod_resp = client.get('/api/mod/1')
     mod_version_resp = client.get('/api/mod/1/latest')
+    user_resp = client.get('/api/user/TestModAuthor')
 
     # Assert
     assert mod_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
@@ -88,6 +92,12 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     assert mod_version_resp.json['friendly_version'] == '1.0.0.0', 'Version should match'
     assert mod_version_resp.json['game_version'] == '1.2.3', 'Game version should match'
     assert mod_version_resp.json['download_path'] == '/mod/1/Test%20Mod/download/1.0.0.0', 'Download should match'
+
+    assert user_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert user_resp.json['username'] == 'TestModAuthor', 'Username should match'
+    assert user_resp.json['description'] == 'Test author of a test mod', 'Description should match'
+    assert user_resp.json['forumUsername'] == 'TestForumUser', 'Forum name should match'
+    assert user_resp.json['mods'][0]['name'] == 'Test Mod', 'Mod should be returned'
 
 
 @pytest.mark.usefixtures("client")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,67 @@
+from datetime import datetime
+
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
 from flask_api import status
 
 from .fixtures.client import client
+from KerbalStuff.objects import Publisher, Game, GameVersion, User, Mod, ModVersion
+from KerbalStuff.database import db
+
+
+@pytest.mark.usefixtures("client")
+def test_api_mod(client: 'FlaskClient[Response]') -> None:
+    # Arrange
+    game = Game(
+        name='Kerbal Space Program',
+        publisher=Publisher(
+            name='SQUAD',
+        ),
+        short='kerbal-space-program',
+    )
+    mod = Mod(
+        name='Test Mod',
+        short_description='A mod for testing',
+        description='A mod that we will use to test the API',
+        user=User(
+            username='TestModAuthor',
+            email='webmaster@spacedock.info',
+        ),
+        license='MIT',
+        game=game,
+        ckan=False,
+        default_version=ModVersion(
+            friendly_version="1.0.0.0",
+            gameversion=GameVersion(
+                friendly_version='1.2.3',
+                game=game,
+            ),
+            download_path='/tmp/blah.zip',
+            created=datetime.now(),
+        ),
+        published=True,
+    )
+    mod.default_version.mod = mod
+    db.add(game)
+    db.add(mod)
+    db.commit()
+
+    # Act
+    resp = client.get('/api/mod/1')
+
+    # Assert
+    assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert resp.json['name'] == 'Test Mod', 'Name should match'
+    assert resp.json['id'] == 1, 'ID number should match'
+    assert resp.json['short_description'] == 'A mod for testing', 'Short description should match'
+    assert resp.json['description'] == 'A mod that we will use to test the API', 'Short description should match'
+    assert resp.json['author'] == 'TestModAuthor', 'Author should match'
+    assert resp.json['license'] == 'MIT', 'License should match'
+    assert resp.json['downloads'] == 0, 'Should have no downloads'
+    assert resp.json['followers'] == 0, 'Should have no followers'
+    assert resp.json['versions'][0]['friendly_version'] == '1.0.0.0', 'Version should match'
+    assert resp.json['versions'][0]['game_version'] == '1.2.3', 'Version should match'
 
 
 @pytest.mark.usefixtures("client")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,15 +4,10 @@ from flask import Response
 from flask_api import status
 
 from .fixtures.client import client
-from KerbalStuff.database import create_database, create_tables
 
 
 @pytest.mark.usefixtures("client")
 def test_api_browse(client: 'FlaskClient[Response]') -> None:
-    # create_database has a meaningless return value, don't assert it
-    create_database()
-    create_tables()
-
     resp = client.get('/api/browse')
     assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
     assert resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,18 @@
+import pytest
+from flask.testing import FlaskClient
+from flask import Response
+from flask_api import status
+
+from .fixtures.client import client
+from KerbalStuff.database import create_database, create_tables
+
+
+@pytest.mark.usefixtures("client")
+def test_api_browse(client: 'FlaskClient[Response]') -> None:
+    # create_database has a meaningless return value, don't assert it
+    create_database()
+    create_tables()
+
+    resp = client.get('/api/browse')
+    assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,6 +102,23 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
 
 @pytest.mark.usefixtures("client")
 def test_api_browse(client: 'FlaskClient[Response]') -> None:
-    resp = client.get('/api/browse')
-    assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'
+    # Arrange is handled by the fixture
+
+    # Act
+    browse_resp = client.get('/api/browse')
+    new_resp = client.get('/api/browse/new')
+    top_resp = client.get('/api/browse/top')
+    featured_resp = client.get('/api/browse/featured')
+
+    # Assert
+    assert browse_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert browse_resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'
+
+    assert new_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert new_resp.data == b'[]', 'Should return empty list'
+
+    assert top_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert top_resp.data == b'[]', 'Should return empty list'
+
+    assert featured_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert featured_resp.data == b'[]', 'Should return empty list'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,20 +48,46 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     db.commit()
 
     # Act
-    resp = client.get('/api/mod/1')
+    publishers_resp = client.get('/api/publishers')
+    games_resp = client.get('/api/games')
+    kspversions_resp = client.get('/api/kspversions')
+    gameversions_resp = client.get('/api/1/versions')
+    mod_resp = client.get('/api/mod/1')
+    mod_version_resp = client.get('/api/mod/1/latest')
 
     # Assert
-    assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert resp.json['name'] == 'Test Mod', 'Name should match'
-    assert resp.json['id'] == 1, 'ID number should match'
-    assert resp.json['short_description'] == 'A mod for testing', 'Short description should match'
-    assert resp.json['description'] == 'A mod that we will use to test the API', 'Short description should match'
-    assert resp.json['author'] == 'TestModAuthor', 'Author should match'
-    assert resp.json['license'] == 'MIT', 'License should match'
-    assert resp.json['downloads'] == 0, 'Should have no downloads'
-    assert resp.json['followers'] == 0, 'Should have no followers'
-    assert resp.json['versions'][0]['friendly_version'] == '1.0.0.0', 'Version should match'
-    assert resp.json['versions'][0]['game_version'] == '1.2.3', 'Version should match'
+    assert mod_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert mod_resp.json['name'] == 'Test Mod', 'Name should match'
+    assert mod_resp.json['id'] == 1, 'ID number should match'
+    assert mod_resp.json['short_description'] == 'A mod for testing', 'Short description should match'
+    assert mod_resp.json['description'] == 'A mod that we will use to test the API', 'Short description should match'
+    assert mod_resp.json['author'] == 'TestModAuthor', 'Author should match'
+    assert mod_resp.json['license'] == 'MIT', 'License should match'
+    assert mod_resp.json['downloads'] == 0, 'Should have no downloads'
+    assert mod_resp.json['followers'] == 0, 'Should have no followers'
+    assert mod_resp.json['versions'][0]['friendly_version'] == '1.0.0.0', 'Version should match'
+    assert mod_resp.json['versions'][0]['game_version'] == '1.2.3', 'Game version should match'
+
+    assert kspversions_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert kspversions_resp.json[0]['id'] == 1, 'Game version id should match'
+    assert kspversions_resp.json[0]['friendly_version'] == '1.2.3', 'Game version should match'
+
+    assert gameversions_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert gameversions_resp.json[0]['id'] == 1, 'Game version id should match'
+    assert gameversions_resp.json[0]['friendly_version'] == '1.2.3', 'Game version should match'
+
+    assert games_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert games_resp.json[0]['id'] == 1, 'Game id should match'
+    assert games_resp.json[0]['name'] == 'Kerbal Space Program', 'Game name should match'
+
+    assert publishers_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert publishers_resp.json[0]['id'] == 1, 'Publisher id should match'
+    assert publishers_resp.json[0]['name'] == 'SQUAD', 'Publisher name should match'
+
+    assert mod_version_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert mod_version_resp.json['friendly_version'] == '1.0.0.0', 'Version should match'
+    assert mod_version_resp.json['game_version'] == '1.2.3', 'Game version should match'
+    assert mod_version_resp.json['download_path'] == '/mod/1/Test%20Mod/download/1.0.0.0', 'Download should match'
 
 
 @pytest.mark.usefixtures("client")

--- a/tests/test_api_browse.py
+++ b/tests/test_api_browse.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+import pytest
+from flask.testing import FlaskClient
+from flask import Response
+from flask_api import status
+
+from .fixtures.client import client
+from KerbalStuff.objects import Publisher, Game, GameVersion, User, Mod, ModVersion
+from KerbalStuff.database import db
+
+
+@pytest.mark.usefixtures("client")
+def test_api_browse(client: 'FlaskClient[Response]') -> None:
+    # Arrange is handled by the fixture
+
+    # Act
+    browse_resp = client.get('/api/browse')
+    new_resp = client.get('/api/browse/new')
+    top_resp = client.get('/api/browse/top')
+    featured_resp = client.get('/api/browse/featured')
+
+    # Assert
+    assert browse_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert browse_resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'
+
+    assert new_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert new_resp.data == b'[]', 'Should return empty list'
+
+    assert top_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert top_resp.data == b'[]', 'Should return empty list'
+
+    assert featured_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert featured_resp.data == b'[]', 'Should return empty list'

--- a/tests/test_api_mod.py
+++ b/tests/test_api_mod.py
@@ -98,27 +98,3 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     assert user_resp.json['description'] == 'Test author of a test mod', 'Description should match'
     assert user_resp.json['forumUsername'] == 'TestForumUser', 'Forum name should match'
     assert user_resp.json['mods'][0]['name'] == 'Test Mod', 'Mod should be returned'
-
-
-@pytest.mark.usefixtures("client")
-def test_api_browse(client: 'FlaskClient[Response]') -> None:
-    # Arrange is handled by the fixture
-
-    # Act
-    browse_resp = client.get('/api/browse')
-    new_resp = client.get('/api/browse/new')
-    top_resp = client.get('/api/browse/top')
-    featured_resp = client.get('/api/browse/featured')
-
-    # Assert
-    assert browse_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert browse_resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'
-
-    assert new_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert new_resp.data == b'[]', 'Should return empty list'
-
-    assert top_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert top_resp.data == b'[]', 'Should return empty list'
-
-    assert featured_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert featured_resp.data == b'[]', 'Should return empty list'

--- a/tests/test_api_mod.py
+++ b/tests/test_api_mod.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Dict, Any
 
 import pytest
 from flask.testing import FlaskClient
@@ -58,43 +59,79 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     mod_resp = client.get('/api/mod/1')
     mod_version_resp = client.get('/api/mod/1/latest')
     user_resp = client.get('/api/user/TestModAuthor')
+    typeahead_resp = client.get('/api/typeahead/mod?query=Test')
+    search_mod_resp = client.get('/api/search/mod?query=Test&page=1')
+    search_user_resp = client.get('/api/search/user?query=Test&page=0')
 
     # Assert
     assert mod_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert mod_resp.json['name'] == 'Test Mod', 'Name should match'
-    assert mod_resp.json['id'] == 1, 'ID number should match'
-    assert mod_resp.json['short_description'] == 'A mod for testing', 'Short description should match'
+    check_mod(mod_resp.json)
+    # Not returned by all APIs
     assert mod_resp.json['description'] == 'A mod that we will use to test the API', 'Short description should match'
-    assert mod_resp.json['author'] == 'TestModAuthor', 'Author should match'
-    assert mod_resp.json['license'] == 'MIT', 'License should match'
-    assert mod_resp.json['downloads'] == 0, 'Should have no downloads'
-    assert mod_resp.json['followers'] == 0, 'Should have no followers'
-    assert mod_resp.json['versions'][0]['friendly_version'] == '1.0.0.0', 'Version should match'
-    assert mod_resp.json['versions'][0]['game_version'] == '1.2.3', 'Game version should match'
 
     assert kspversions_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert kspversions_resp.json[0]['id'] == 1, 'Game version id should match'
-    assert kspversions_resp.json[0]['friendly_version'] == '1.2.3', 'Game version should match'
+    check_game_version(kspversions_resp.json[0])
 
     assert gameversions_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert gameversions_resp.json[0]['id'] == 1, 'Game version id should match'
-    assert gameversions_resp.json[0]['friendly_version'] == '1.2.3', 'Game version should match'
+    check_game_version(gameversions_resp.json[0])
 
     assert games_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert games_resp.json[0]['id'] == 1, 'Game id should match'
-    assert games_resp.json[0]['name'] == 'Kerbal Space Program', 'Game name should match'
+    check_game(games_resp.json[0])
 
     assert publishers_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert publishers_resp.json[0]['id'] == 1, 'Publisher id should match'
-    assert publishers_resp.json[0]['name'] == 'SQUAD', 'Publisher name should match'
+    check_publisher(publishers_resp.json[0])
 
     assert mod_version_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert mod_version_resp.json['friendly_version'] == '1.0.0.0', 'Version should match'
-    assert mod_version_resp.json['game_version'] == '1.2.3', 'Game version should match'
-    assert mod_version_resp.json['download_path'] == '/mod/1/Test%20Mod/download/1.0.0.0', 'Download should match'
+    check_mod_version(mod_version_resp.json)
 
     assert user_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
-    assert user_resp.json['username'] == 'TestModAuthor', 'Username should match'
-    assert user_resp.json['description'] == 'Test author of a test mod', 'Description should match'
-    assert user_resp.json['forumUsername'] == 'TestForumUser', 'Forum name should match'
-    assert user_resp.json['mods'][0]['name'] == 'Test Mod', 'Mod should be returned'
+    check_user(user_resp.json)
+
+    assert typeahead_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    check_mod(typeahead_resp.json[0])
+
+    assert search_mod_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    check_mod(search_mod_resp.json[0])
+
+    assert search_user_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    check_user(search_user_resp.json[0])
+
+
+def check_publisher(publisher_json: Dict[str, Any]) -> None:
+    assert publisher_json['id'] == 1, 'Publisher id should match'
+    assert publisher_json['name'] == 'SQUAD', 'Publisher name should match'
+
+
+def check_game(game_json: Dict[str, Any]) -> None:
+    assert game_json['id'] == 1, 'Game id should match'
+    assert game_json['name'] == 'Kerbal Space Program', 'Game name should match'
+
+
+def check_game_version(game_version_json: Dict[str, Any]) -> None:
+    assert game_version_json['id'] == 1, 'Game version id should match'
+    assert game_version_json['friendly_version'] == '1.2.3', 'Game version should match'
+
+
+def check_mod(mod_json: Dict[str, Any]) -> None:
+    assert mod_json['name'] == 'Test Mod', 'Name should match'
+    assert mod_json['id'] == 1, 'ID number should match'
+    assert mod_json['short_description'] == 'A mod for testing', 'Short description should match'
+    assert mod_json['author'] == 'TestModAuthor', 'Author should match'
+    assert mod_json['license'] == 'MIT', 'License should match'
+    assert mod_json['downloads'] == 0, 'Should have no downloads'
+    assert mod_json['followers'] == 0, 'Should have no followers'
+    assert mod_json['versions'][0]['friendly_version'] == '1.0.0.0', 'Version should match'
+    assert mod_json['versions'][0]['game_version'] == '1.2.3', 'Game version should match'
+
+
+def check_mod_version(mod_version_json: Dict[str, Any]) -> None:
+    assert mod_version_json['friendly_version'] == '1.0.0.0', 'Version should match'
+    assert mod_version_json['game_version'] == '1.2.3', 'Game version should match'
+    assert mod_version_json['download_path'] == '/mod/1/Test%20Mod/download/1.0.0.0', 'Download should match'
+
+
+def check_user(user_json: Dict[str, Any]) -> None:
+    assert user_json['username'] == 'TestModAuthor', 'Username should match'
+    assert user_json['description'] == 'Test author of a test mod', 'Description should match'
+    assert user_json['forumUsername'] == 'TestForumUser', 'Forum name should match'
+    assert user_json['mods'][0]['name'] == 'Test Mod', 'Mod should be returned'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,7 +8,12 @@ from .fixtures.client import client
 
 @pytest.mark.usefixtures("client")
 def test_version(client: 'FlaskClient[Response]') -> None:
+    # Arrange is handled by the fixture
+
+    # Act
     resp = client.get('/version')
+
+    # Assert
     assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
     assert resp.data.startswith(b'commit'), 'Response should start with "commit"'
     assert b'\nAuthor: ' in resp.data, 'Response should return a Author header'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,24 @@
+from typing import Generator
+
+import pytest
+from flask.testing import FlaskClient
+from flask import Response
+from flask_api import status
+
+from .fake_db import dummy
+from KerbalStuff.app import app
+
+
+# FlaskClient requires a type parameter in mypy, but errors out with one at runtime
+@pytest.fixture
+def client() -> Generator['FlaskClient[Response]', None, None]:
+    with app.test_client() as client:
+        yield client
+
+
+def test_version(client: 'FlaskClient[Response]') -> None:
+    resp = client.get('/version')
+    assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert resp.data.startswith(b'commit'), 'Response should start with "commit"'
+    assert b'\nAuthor: ' in resp.data, 'Response should return a Author header'
+    assert b'\nDate: ' in resp.data, 'Response should return a Date header'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,21 +1,12 @@
-from typing import Generator
-
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
 from flask_api import status
 
-from .fake_db import dummy
-from KerbalStuff.app import app
+from .fixtures.client import client
 
 
-# FlaskClient requires a type parameter in mypy, but errors out with one at runtime
-@pytest.fixture
-def client() -> Generator['FlaskClient[Response]', None, None]:
-    with app.test_client() as client:
-        yield client
-
-
+@pytest.mark.usefixtures("client")
 def test_version(client: 'FlaskClient[Response]') -> None:
     resp = client.get('/version')
     assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'


### PR DESCRIPTION
## Motivation

Tests are a popular way to exercise code and ensure that certain things don't break. Currently SpaceDock has none.

## Changes

Now some `pytest` tests are added along with a GitHub workflow to run them. If any new code breaks these things in the future, GitHub will tell us about it.

This PR exercises all the `/api/` routes that do not require authentication. Authentication-based routes can be done in future pull requests.

- `test_version` - Retrieves the `/version` route and performs simple sanity checks on its response
- `test_api_browse` - Retrieves several routes for an empty db and confirms that they returns the expected JSON
  - `/api/browse`
  - `/api/browse/new`
  - `/api/browse/top`
  - `/api/browse/featured`
- `test_api_mod` - Creates a simple mod in the db, then requests several API calls and confirms that they return JSON with the correct properties
  - `/api/publishers`
  - `/api/games`
  - `/api/kspversions`
  - `/api/1/versions`
  - `/api/mod/1`
  - `/api/mod/1/latest`
  - `/api/user/TestModAuthor`
  - `/api/typeahead/mod?query=Test`
  - `/api/search/mod?query=Test&page=1`
  - `/api/search/user?query=Test&page=0`