### PR TITLE
Switch emails to Jinja2 templates

### DIFF
--- a/emails/mod-autoupdated
+++ b/emails/mod-autoupdated
@@ -1,4 +1,4 @@
-Hi there! Thought you would like to know that {{ mod.user.username }} told us that version {{ latest.friendly_version }} of {{ mod.name }} works great with Kerbal Space Program {{ latest.gameversion.friendly_version }}.
+Hi there! Thought you would like to know that {{ mod.user.username }} told us that version {{ latest.friendly_version }} of {{ mod.name }} works great with {{ mod.game.name }} {{ latest.gameversion.friendly_version }}.
 
 If you are already up-to-date, you don't need to do anything. Otherwise, you can grab the latest version here:
 

--- a/emails/mod-locked
+++ b/emails/mod-locked
@@ -6,10 +6,8 @@ Unfortunately, your mod {{mod.name}} ({{url}}) has been locked and unpublished b
 
 
 Please contact us by replying to this e-mail, or via one of the following channels:
-
-{{#support_channels}}
-  * {{name}}: {{channel_url}}
-{{/support_channels}}
+{% for name, channel_url in support_channels.items() %}
+  * {{name}}: {{channel_url}}{% endfor %}
 
 
 Greetings

--- a/emails/mod-updated
+++ b/emails/mod-updated
@@ -1,9 +1,11 @@
-Hi there! {{ user.username }} has just published version {{ latest.friendly_version }} of {{ mod.name }} on {{ site_name }}! {{#changelog}}Here are the changes:
+Hi there! {{ user.username }} has just published version {{ latest.friendly_version }} of {{ mod.name }} on {{ site_name }}!
+
+Here are the changes:
 
 {{ changelog }}
 
-{{/changelog}}You can grab the new version here: http://{{ domain }}{{ url }}
+You can grab the new version here: https://{{ domain }}{{ url }}
 
-This version is compatible with Kerbal Space Program {{ latest.gameversion.friendly_version }}.
+This version is compatible with {{ mod.game.name }} {{ latest.gameversion.friendly_version }}.
 
 If you'd prefer us not to email you about this mod, you can hit "Unfollow" on this mod's page and you won't get them any more.

--- a/emails/password-changed
+++ b/emails/password-changed
@@ -4,10 +4,8 @@ Your password on {{ site_name }} has been changed.
 
 
 If this wasn't you, please contact us by replying to this e-mail, or via one of the following channels:
-
-{{#support_channels}}
-  * {{name}}: {{channel_url}}
-{{/support_channels}}
+{% for name, channel_url in support_channels.items() %}
+  * {{name}}: {{channel_url}}{% endfor %}
 
 
 Greetings

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -1,7 +1,6 @@
 alembic
 bcrypt
 celery
-chevron
 click
 flask
 flask-login

--- a/templates/rss-mod.xml
+++ b/templates/rss-mod.xml
@@ -7,7 +7,7 @@
         <atom:link href="{{ url_for("mods.mod_rss", mod_name=mod.name, mod_id=mod.id) }}" rel="self" type="application/rss+xml" />
         {% for v in mod.versions %}
         <item>
-            <title>{{ mod.name }} {{ v.friendly_version }} for Kerbal Space Program {{ v.ksp_version }} Released</title>
+            <title>{{ mod.name }} {{ v.friendly_version }} for {{ mod.game.name }} {{ v.ksp_version }} Released</title>
             {% if v.changelog %}
             <description><![CDATA[{{ v.changelog | markdown }}]]></description>
             {% endif %}


### PR DESCRIPTION
## Motivation
We currently render our email templates using Chevron, a Mustache implementation for Python (and based on Pystache which we used until it broke recently).
This requires some hacks to get us what we want, like that nasty `support_channels_to_map()` helper function.
So I thought, why not switch over to the other big template rendering utility which we are using a lot everywhere else, which is already in the list of dependencies, and which we are rather familiar with by now, called Jinja2?

## Changes
`chevron.render(f.read(), {args})` is replaced with `Template(f.read()`).render({args})` everywhere.
I decided to keep passing the arguments in one dict instead of separate arguments to reduce the chance for errors to creep in. I'm also happy to change it though, if you think we should do it the same way we do it with all the other templates.

The support channel dict can now be passed as-is, without converting it to a map/list thingy first.
The email templates are adjusted accordingly.

I also replaced some hardcoded game names to be rendered dynamically based on `mod.game.name`.