### PR TITLE
Return JSON after errors in /api routes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,4 +18,4 @@ jobs:
         pip install -r requirements-tests.txt
     - name: pytest
       run: |
-        pytest -v
+        pytest -v tests/

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -16,7 +16,7 @@ from typing import Tuple, Optional
 from .api import default_description
 from ..ckan import send_to_ckan, notify_ckan
 from ..common import get_game_info, set_game_info, with_session, dumb_object, loginrequired, \
-    json_output, adminrequired, check_mod_editable, get_version_size
+    json_output, adminrequired, check_mod_editable, get_version_size, TRUE_STR
 from ..config import _cfg
 from ..database import db
 from ..email import send_autoupdate_notification, send_mod_locked
@@ -228,7 +228,7 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
         if ckan is None:
             ckan = False
         else:
-            ckan = (ckan.lower() in ['true', 'yes', 'on'])
+            ckan = (ckan.lower() in TRUE_STR)
         if ckan:
             if not mod.ckan:
                 mod.ckan = ckan

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
 from .test_version import *
 from .test_api_browse import *
 from .test_api_mod import *
+from .test_api_errors import *
+from .test_errors import *

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -3,7 +3,7 @@ import pytest
 from flask.testing import FlaskClient
 from flask import Response
 
-from tests.fake_db import dummy
+from .fake_config import dummy
 from KerbalStuff.database import create_database, create_tables, drop_database, drop_tables
 from KerbalStuff.app import app
 

--- a/tests/fixtures/fake_config.py
+++ b/tests/fixtures/fake_config.py
@@ -7,5 +7,7 @@ from KerbalStuff.config import config, env
 if not config.has_section(env):
     config.add_section(env)
 config[env]['connection-string'] = 'sqlite:///:memory:'
+config[env]['protocol'] = 'https'
+config[env]['domain'] = 'tests.spacedock.info'
 
 dummy = ''

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,33 @@
+import pytest
+from flask.testing import FlaskClient
+from flask import Response
+from flask_api import status
+
+from .fixtures.client import client
+
+
+@pytest.mark.usefixtures("client")
+def test_api_bad_url(client: 'FlaskClient[Response]') -> None:
+    # Arrange is handled by the fixture
+
+    # Act
+    bad_url_resp = client.get('/api/something_that_matches_no_routes/69/420')
+
+    # Assert
+    assert bad_url_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert bad_url_resp.json['code'] == status.HTTP_404_NOT_FOUND, 'Code should match'
+    assert bad_url_resp.json['error'] == True, 'Should contain "error" property'
+    assert 'not found' in bad_url_resp.json['reason'], 'Reason should be typical 404 lingo'
+
+
+@pytest.mark.usefixtures("client")
+def test_api_mod_not_found(client: 'FlaskClient[Response]') -> None:
+    # Arrange is handled by the fixture
+
+    # Act
+    missing_mod_resp = client.get('/api/mod/20000')
+
+    # Assert
+    assert missing_mod_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert missing_mod_resp.json['error'] == True, 'Should contain "error" property'
+    assert missing_mod_resp.json['reason'] == 'Mod not found.', 'Reason should match'

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,36 @@
+import pytest
+from flask.testing import FlaskClient
+from flask import Response
+from flask_api import status
+
+from .fixtures.client import client
+
+
+@pytest.mark.usefixtures("client")
+def test_bad_url(client: 'FlaskClient[Response]') -> None:
+    # Arrange is handled by the fixture
+
+    # Act
+    bad_url_resp = client.get('/something_that_matches_no_routes/69/420')
+
+    # Assert
+    assert bad_url_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert bad_url_resp.json is None, 'Should not be JSON'
+    assert bad_url_resp.mimetype == 'text/html', 'Should be HTML'
+    assert b'Not Found' in bad_url_resp.data, 'Should be a nice web page'
+    assert b'Looks like this was deleted, or maybe was never here. Who knows.' in bad_url_resp.data, 'Tells us it\'s gone'
+
+
+@pytest.mark.usefixtures("client")
+def test_mod_not_found(client: 'FlaskClient[Response]') -> None:
+    # Arrange is handled by the fixture
+
+    # Act
+    missing_mod_resp = client.get('/mod/20000')
+
+    # Assert
+    assert missing_mod_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert missing_mod_resp.json is None, 'Should not be JSON'
+    assert missing_mod_resp.mimetype == 'text/html', 'Should be HTML'
+    assert b'Not Found' in missing_mod_resp.data, 'Should be a nice web page'
+    assert b'Looks like this was deleted, or maybe was never here. Who knows.' in missing_mod_resp.data, 'Tells us it\'s gone'


### PR DESCRIPTION
## Problem
The API currently returns the HTML error pages whenever we hit an 500 or 404.
This is not a good API design and already tripped us over with the mod upload previously, since we didn't account for non-JSON responses. We solved it by adding an extra check for the returned status code, but it would be nice if we always had a JSON where we could just check the `error` bool.

## Changes
My first attempt was to create special error handlers only for the API routes, but Flask says no:
> However, the blueprint cannot handle 404 routing errors because the 404 occurs at the routing level before the blueprint can be determined.
https://flask.palletsprojects.com/en/1.1.x/errorhandling/#handling

(IMHO this restriction makes per-blueprint error handling practically useless, because 99.9% of errors you want to catch _are_ 404s and 500s)

So, I generalized the already existing app-wide error handlers, and implemented a check if the URL starts with `/api/`. If yes, the exception gets sent to a new `handle_api_exception()`.
The 500-handler had to be changed to handle _all_ exceptions (that aren't covered by a more specific error handler), because otherwise it would have only triggered when we specifically return a 500 status somewhere. Flask converts exceptions to 500s only _after_ it doesn't find any error handler matching the status code or exception.
https://flask.palletsprojects.com/en/1.1.x/errorhandling/#unhandled-exceptions


If the raised exception is already a or a subclass of `HTTPException` (this is the case for 404s, 403s, 405s...), we take the included `Response` object, swap out the data part with a JSON string formatted the same way we format all the other API failure responses (plus an additional `code` field), and send it to the user.
If the excpetion is of a different type, it means that our code itself has a bug and raised an exception somewhere (or something similar went wrong). We create a new `Response` object, again with a JSON formatted like above and including the exception message.
We return it as a `500 Internal Server Error`, the same way Flask would do it if there weren't an exception handler for it.

---

Example responses:
* `/api/doesntexist`:
```json
{
  "error": true,
  "reason": "404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.",
  "code": 404
}
```
* `/api/user/user/update-pg` with GET instead of POST
```json
{
  "error": true,
  "reason": "405 Method Not Allowed: The method is not allowed for the requested URL.",
  "code": 405
}
```
* `/api/mod/1/update` without being logged in:
```json
{
"error": true,
"reason": "You are not logged in."
}
```
