### PR TITLE
Return ModVersion downloads in API

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -94,7 +94,7 @@ def mod_info(mod: Mod) -> Dict[str, Any]:
     }
 
 
-def version_info(mod: Mod, version: ModVersion) -> Dict[str, str]:
+def version_info(mod: Mod, version: ModVersion) -> Dict[str, Any]:
     return {
         "friendly_version": version.friendly_version,
         "game_version": version.gameversion.friendly_version,
@@ -103,7 +103,8 @@ def version_info(mod: Mod, version: ModVersion) -> Dict[str, str]:
         "download_path": url_for('mods.download', mod_id=mod.id,
                                  mod_name=mod.name,
                                  version=version.friendly_version),
-        "changelog": version.changelog
+        "changelog": version.changelog,
+        "downloads": version.download_count(),
     }
 
 

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -313,6 +313,12 @@ class ModVersion(Base):  # type: ignore
     def __repr__(self) -> str:
         return '<Mod Version %r>' % self.id
 
+    def download_count(self) -> int:
+        return sum(evt.downloads for evt
+                   in DownloadEvent.query.filter(
+                       DownloadEvent.version_id == self.id
+                   ).all())
+
 
 class Media(Base):  # type: ignore
     __tablename__ = 'media'

--- a/tests/test_api_mod.py
+++ b/tests/test_api_mod.py
@@ -128,6 +128,7 @@ def check_mod_version(mod_version_json: Dict[str, Any]) -> None:
     assert mod_version_json['friendly_version'] == '1.0.0.0', 'Version should match'
     assert mod_version_json['game_version'] == '1.2.3', 'Game version should match'
     assert mod_version_json['download_path'] == '/mod/1/Test%20Mod/download/1.0.0.0', 'Download should match'
+    assert mod_version_json['downloads'] == 0, 'Not downloaded yet'
 
 
 def check_user(user_json: Dict[str, Any]) -> None:


### PR DESCRIPTION
Some interest has been expressed in having download counts per mod version (see KSP-CKAN/NetKAN-Infra#109). The general idea is that some clients may wish to emphasize more recent downloads over older ones.

Now the API object returned for a ModVersion includes a `downloads` property that's the sum of the `DownloadEvent.downloads` rows associated with that version.