### PR TITLE
Score penalties for incompatible mods

### DIFF
--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -6,10 +6,12 @@ flask
 flask-login
 flask-markdown
 flask-oauthlib
+gunicorn
 future
 jinja2
 markdown
 oauthlib==2.0.6
+packaging
 pillow
 psycopg2-binary
 PyGithub
@@ -20,4 +22,3 @@ requests-oauthlib==0.8.0
 sqlalchemy
 sqlalchemy_utils
 werkzeug==0.16.1
-gunicorn


### PR DESCRIPTION
## Problem

@DasSkelett is perturbed that a mod for KSP 1.1 is on the second page of the mod list by virtue of its high download count:

- https://spacedock.info/mod/79/BDArmory

This potentially could invite some users to download it, when it probably won't work if they try to use it with the current game, and they probably want something newer. The same problem applies across the board, once a mod accumulates a large number of downloads, nothing can knock it off the pedestal, whether it is maintained or abandoned.

## Changes

Now the mod scoring system includes a new penalty for being horribly out of date. For a given mod, we look at the game version with which its default version is compatible, and for each newer known release of that game, we apply a 5% penalty. To avoid accumulating a big group of zero-score mods, we cap the new penalty at 90%, which as of this writing would apply to all mods that haven't been updated since KSP 1.3.1 or earlier (90/5 = 18 versions).

- https://spacedock.info/api/3102/versions

In the case of BDArmory, it is currently 26 versions behind, so it would receive the maximum penalty and go from ~154255 to ~15425, which would land it somewhere around page 15.