### PR TITLE
Admin page fixes

### DIFF
--- a/templates/admin-game-versions.html
+++ b/templates/admin-game-versions.html
@@ -4,19 +4,29 @@
     <div class="container admin-container space-left-right">
         <div class="row">
             {% set base_url = 'admin.game_versions' %}
-            {% include 'admin-page-nav.html' %}
+            {% if game_version_count > 0 %}
+                {% include 'admin-page-nav.html' %}
+            {% else %}
+                <div class="col-sm-8"></div>
+            {% endif %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.game_versions", page=1) }}" method="GET">
                     <div class="form-group">
-                        <label for="game-version-search">Search games:</label>
+                        <label for="game-version-search">Search game versions:</label>
                         <input id="game-version-search" type="text" class="form-control search-box" name="query" {% if query %}value="{{ query }}"{% else %}placeholder="Search game versions..."{% endif %}>
                     </div>
                 </form>
             </div>
         </div>
         {% if game_version_count == 0 %}
-        <h3>Versions</h3>
-        <p>You have not added any Versions. Modders will not be able to create mods until you add at least one.</p>
+            <div class="row">
+                <h3>Versions</h3>
+                {%- if query -%}
+                    <p>No matches found.</p>
+                {%- else -%}
+                    <p>You have not added any versions. Modders will not be able to create mods until you add at least one.</p>
+                {%- endif -%}
+            </div>
         {% else %}
         <div class="row table-responsive bootstrap-table space-left-right">
             <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
@@ -39,11 +49,13 @@
         </div>
         {% endif %}
         <form role="form" action="{{ url_for("admin.create_version") }}" method="POST">
+            {%- if error -%}
+                <div class="row well danger"><h1>{{ error }}</h1></div>
+            {%- endif -%}
             <div class="row">
                 <div class="col-md-5">
                     <input type="text" id="friendly_version" name="friendly_version" class="form-control input-block-level" placeholder="Version name...">
                 </div>
-
                 <div class="col-md-5">
                     <select id="ganame" name="ganame" class="chosen-select">
                         {% for g in games %}

--- a/templates/admin-games.html
+++ b/templates/admin-games.html
@@ -4,7 +4,11 @@
     <div class="container admin-container space-left-right">
         <div class="row">
             {% set base_url = 'admin.games' %}
-            {% include 'admin-page-nav.html' %}
+            {% if game_count > 0 %}
+                {% include 'admin-page-nav.html' %}
+            {% else %}
+                <div class="col-sm-8"></div>
+            {% endif %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.games", page=1) }}" method="GET">
                     <div class="form-group">
@@ -15,8 +19,14 @@
             </div>
         </div>
         {% if game_count == 0 %}
-        <h3>Games</h3>
-        <p>You have not added any Games. Modders will not be able to create mods until you add at least one.</p>
+            <div class="row">
+                <h3>Games</h3>
+                {% if query %}
+                    <p>No matches found.</p>
+                {% else %}
+                    <p>You have not added any games. Modders will not be able to create mods until you add at least one.</p>
+                {% endif %}
+            </div>
         {% else %}
         <div class="row table-responsive bootstrap-table space-left-right">
             <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
@@ -43,7 +53,11 @@
                     <td>{{ g.created }}</td>
                     <td>{{ g.short_description }}</td>
                     <td>{{ g.description }}</td>
-                    <td><a href="{{ g.link }}" target="_BLANK">{{ g.link }}</a></td>
+                    {% if g.link %}
+                        <td><a href="{{ g.link }}" target="_BLANK">{{ g.link }}</a></td>
+                    {% else %}
+                        <td>{{ g.link }}</td>
+                    {% endif %}
                     <td>{{ g.releasedate }}</td>
                     <td>{{ g.fileformats }}</td>
                     <td>{{ g.rating }}</td>
@@ -55,6 +69,9 @@
         </div>
         {% endif %}
         <form role="form" action="{{ url_for("admin.create_game") }}" method="POST">
+            {%- if error -%}
+                <div class="row well danger"><h1>{{ error }}</h1></div>
+            {%- endif -%}
             <div class="row">
                 <div class="col-md-4">
                     <input type="text" id="gname" name="gname" class="form-control input-block-level" placeholder="Game name...">
@@ -63,14 +80,12 @@
                     <input type="text" id="sname" name="sname" class="form-control input-block-level" placeholder="Short name (for URL)...">
                 </div>
                 <div class="col-md-3">
-                    {# TODO not working, something with this jQuery sh* I think #}
                     <select id="pname" name="pname" class="chosen-select">
                         {% for p in publishers %}
                         <option value="{{p.id}}" {% if loop.first %}selected{% endif %}>{{p.name}}</option>
                         {% endfor %}
                     </select>
                 </div>
-
                 <div class="col-md-2">
                     <input type="submit" class="btn btn-primary btn-block" value="Add Game">
                 </div>

--- a/templates/admin-publishers.html
+++ b/templates/admin-publishers.html
@@ -4,7 +4,11 @@
     <div class="container admin-container space-left-right">
         <div class="row">
             {% set base_url = 'admin.publishers' %}
-            {% include 'admin-page-nav.html' %}
+            {% if publisher_count > 0 %}
+                {% include 'admin-page-nav.html' %}
+            {% else %}
+                <div class="col-sm-8"></div>
+            {% endif %}
             <div class="col-sm-4">
                 <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.publishers", page=1) }}" method="GET">
                     <div class="form-group">
@@ -15,8 +19,14 @@
             </div>
         </div>
         {% if publisher_count == 0 %}
-        <h3>Publishers</h3>
-        <p>You have not added any publishers. Modders will not be able to create mods until you add at least one.</p>
+            <div class="row">
+                <h3>Publishers</h3>
+                {%- if query -%}
+                    <p>No matches found.</p>
+                {%- else -%}
+                    <p>You have not added any publishers. Modders will not be able to create mods until you add at least one.</p>
+                {%- endif -%}
+            </div>
         {% else %}
         <div class="row table-responsive bootstrap-table space-left-right">
             <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
@@ -37,7 +47,11 @@
                     <td>{{ p.created }}</td>
                     <td>{{ p.short_description }}</td>
                     <td>{{ p.description }}</td>
-                    <td><a href="{{ p.link }}" target="_BLANK">{{ p.link }}</a></td>
+                    {% if p.link %}
+                        <td><a href="{{ p.link }}" target="_BLANK">{{ p.link }}</a></td>
+                    {% else %}
+                        <td>{{ p.link }}</td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
                 </tbody>
@@ -45,6 +59,9 @@
         </div>
         {% endif %}
         <form role="form" action="{{ url_for("admin.create_publisher") }}" method="POST">
+            {%- if error -%}
+                <div class="row well danger"><h1>{{ error }}</h1></div>
+            {%- endif -%}
             <div class="row">
                 <div class="col-md-4">
                     <input type="text" id="publisher_name" name="pname" class="form-control input-block-level" placeholder="Publisher name...">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -15,10 +15,10 @@
     <div class="centered admin-nav box panel panel-default" style="margin: 2.5mm">
         <ul class="nav nav-pills nav-justified panel-content">
             <li id="adm-link-users"><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
-            <li id="adm-link-blog"><a href="{{ url_for("admin.blog") }}">Blog</a></li>
             <li id="adm-link-publishers"><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
             <li id="adm-link-games"><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
             <li id="adm-link-game-versions"><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
+            <li id="adm-link-blog"><a href="{{ url_for("admin.blog") }}">Blog</a></li>
             <li id="adm-link-email"><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
             <li id="adm-link-links"><a href="{{ url_for("admin.links") }}">Links</a></li>
         </ul>
@@ -35,7 +35,6 @@
     <!-- Latest compiled and minified Locales -->
     <script src="/static/locale/bootstrap-table-en-US.min.js"></script>
     <script src="/static/chosen.jquery.min.js"></script>
-    <script src="/static/create.js"></script>
     <script src="/static/editor.js"></script>
     <script src="/static/marked.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
This pull request attempts to make the admin pages somewhat usable.

Problems | Changes
:-- | :--
The admin page's tabstrip contains Users, Blog, Publishers, Games, Game Versions, E-Mail, Links. The positioning of Blog is weird because it's in the middle of a bunch of record-editing tools, and far away from its fellow communication tool E-Mail. | Now the record editors are at the left and the communications tools are afterwards: Users, Publishers, Games, Game Versions, Blog, E-Mail, Links
If you search for a Publisher, Game, or Game Version and no matches are returned... ![image](https://user-images.githubusercontent.com/1559108/85492172-627a6180-b59a-11ea-8bf5-aafa265fa386.png) ... a pagination button is shown even though there's nothing to paginate, the section heading overlaps the pagination button, and the error message implies that no records exist and modders can't create mods. | Now the pagination buttons only show up when the record list is non-empty, the section heading has sufficient space, and the message simply says there were no matches. ![image](https://user-images.githubusercontent.com/1559108/85493595-d0278d00-b59c-11ea-9b7d-66792d019c28.png)
If you click the button to create a Publisher, Game, or Game Version without filling in all the fields, it redirects to `/asdf`. If you try to create a duplicate, it redirects to `/fdsa`. | Now an explanatory error message is shown without redirecting somewhere else, so you can try again. ![image](https://user-images.githubusercontent.com/1559108/85493137-f4cf3500-b59b-11ea-8e63-33f1d3447ac2.png)
You can't create the same game version for two different games. E.g., if KSP has "1.0", the admin page will consider that a duplicate if you try to create "1.0" for Balsa. | Now the duplicate check is per-game.
The search label for Game Versions says "Search games" | Now it says "Search game versions"
The Publisher and Game tables each contain a Link column which mostly contains invalid links to 'None' | Now these aren't rendered as links if they're None
The admin page's template loads the script file for mod creation. This is not needed and possibly dangerous since it could run unintended code. | Now this is removed.
If you create a Game, it will not be marked as active. Someone will have to go into the SQL for you and do it with code. | Now newly created Games are set to `active=True`.