### PR TITLE
URL for current latest download

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -480,7 +480,7 @@ def _allow_download(mod: Mod) -> bool:
 
 
 @mods.route('/mod/<int:mod_id>/download/<version>', defaults={'mod_name': None})
-@mods.route('/mod/<int:mod_id>//download', defaults={'mod_name': None, 'version': None})
+@mods.route('/mod/<int:mod_id>/download', defaults={'mod_name': None, 'version': None})
 @mods.route('/mod/<int:mod_id>/<path:mod_name>/download', defaults={'version': None})
 @mods.route('/mod/<int:mod_id>/<path:mod_name>/download/<version>')
 @with_session

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -57,7 +57,7 @@
         </div>
         <div class="{% if user %}col-md-2{% else %}col-md-4{% endif %}">
             <a  class="btn btn-block btn-lg btn-primary piwik_download" id="download-link-primary"
-                href="{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name, version=latest.friendly_version) }}">
+                href="{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name) }}">
                 Download {% if latest.id in size_versions and size_versions[latest.id] is not none %} ({{ size_versions[latest.id] }}) {% endif %}</a>
         </div>
         {% if user %}

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -69,7 +69,7 @@
                 {% endif %}
             </div>
             <div class="col-md-8">
-                <a href="{{ url_for("mods.download", mod_name=mod.name, mod_id=mod.id, version=mod.default_version.friendly_version) }}" class="btn btn-block btn-lg btn-primary">Download</a>
+                <a href="{{ url_for("mods.download", mod_name=mod.name, mod_id=mod.id) }}" class="btn btn-block btn-lg btn-primary">Download</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Motivation

Currently SpaceDock supports these formats to download a mod:

1. https://spacedock.info/mod/id/modname/download/version
2. https://spacedock.info/mod/id/download/version

Both require you to know the version you want; it would be nice to generate a permalink that always returns the default version without having to know what it is.

## Changes

Now a new URL format returns the default download for a given mod, based on format 1 above with the version omitted (these are not currently valid links and are provided just as examples):

- http://spacedock.info/mod/id/modname/download

The mod name can also be omitted:

- https://spacedock.info/mod/id/download

If you name your mod `download`, it will be impossible to view the mod info page via the `/mod/id/name` route. But it will already be impossible to do all sorts of other things like update or edit, so too bad for you.

The Download button at the top of the mod info page and the Download buttons on the mod pack listing are updated to use the new URL format.

Fixes #251.