### PR TITLE
Modpack fixes

### DIFF
--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -226,6 +226,17 @@ def manual_confirm(user_id: int) -> werkzeug.wrappers.Response:
     return redirect(url_for('profile.view_profile', username=user.username))
 
 
+@admin.route("/admin/grant-admin/<int:user_id>", methods=['POST'])
+@adminrequired
+@with_session
+def grant_admin(user_id: int) -> werkzeug.wrappers.Response:
+    user = User.query.get(user_id)
+    if not user:
+        abort(404)
+    user.admin = True
+    return redirect(url_for('profile.view_profile', username=user.username))
+
+
 # Note: Add .limit() to the returned object if need, per_page is only used to calculate the offset
 def search_users(query: str) -> Query:
     temp = User.query.filter(

--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -34,10 +34,11 @@ def game(gameshort: str) -> str:
     recent = Mod.query.filter(Mod.published, Mod.game_id == ga.id, ModVersion.query.filter(
         ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated)).limit(6)[:6]
     user_count = User.query.count()
-    mod_count = Mod.query.filter(Mod.game_id == ga.id).filter(Mod.published == True).count()
+    mod_count = Mod.query.filter(Mod.game_id == ga.id, Mod.published == True).count()
     yours = list()
     if current_user:
-        yours = sorted(current_user.following, key=lambda m: m.updated, reverse=True)[:6]
+        yours = sorted(filter(lambda m: m.game_id == ga.id, current_user.following),
+            key=lambda m: m.updated, reverse=True)[:6]
     return render_template("game.html",
                            ga=ga,
                            featured=featured,

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -272,8 +272,9 @@ def publishers_list() -> List[Dict[str, Any]]:
 @api.route("/api/typeahead/mod")
 @json_output
 def typeahead_mod() -> Iterable[Dict[str, Any]]:
-    query = request.args.get('query') or ''
-    return serialize_mod_list(typeahead_mods(query))
+    game_id = request.args.get('game_id', '')
+    query = request.args.get('query', '')
+    return serialize_mod_list(typeahead_mods(game_id, query))
 
 
 @api.route("/api/search/mod")
@@ -609,7 +610,7 @@ def create_list() -> Union[Dict[str, Any], Tuple[Dict[str, Any], int]]:
                        game_id=game)
     db.add(mod_list)
     db.commit()
-    return {'url': url_for("lists.view_list", list_id=mod_list.id, list_name=mod_list.name)}
+    return {'url': url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name)}
 
 
 @api.route('/api/mod/create', methods=['POST'])

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -14,8 +14,8 @@ lists = Blueprint('lists', __name__, template_folder='../../templates/lists')
 
 
 def _get_mod_list(list_id: str) -> Tuple[ModList, Game, bool]:
-    mod_list = ModList.query.filter(ModList.id == list_id).first()
-    ga = Game.query.filter(Game.id == mod_list.game_id).first()
+    mod_list = ModList.query.get(list_id)
+    ga = Game.query.get(mod_list.game_id)
     if not mod_list:
         abort(404)
     editable = False
@@ -49,7 +49,7 @@ def create_list() -> str:
 @loginrequired
 @with_session
 def delete(list_id: str) -> werkzeug.wrappers.Response:
-    mod_list = ModList.query.filter(ModList.id == list_id).first()
+    mod_list = ModList.query.get(list_id)
     if not mod_list:
         abort(404)
     editable = False
@@ -114,7 +114,7 @@ def edit_list(list_id: str, list_name: str) -> Union[str, werkzeug.wrappers.Resp
         # Add mods
         added_mods = [m for m in mods if not m in [mod.mod.id for mod in mod_list.mods]]
         for m in added_mods:
-            mod = Mod.query.filter(Mod.id == m).first()
+            mod = Mod.query.get(m)
             mli = ModListItem()
             mli.mod_id = mod.id
             mli.mod_list = mod_list

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -15,9 +15,9 @@ lists = Blueprint('lists', __name__, template_folder='../../templates/lists')
 
 def _get_mod_list(list_id: str) -> Tuple[ModList, Game, bool]:
     mod_list = ModList.query.get(list_id)
-    ga = Game.query.get(mod_list.game_id)
     if not mod_list:
         abort(404)
+    ga = Game.query.get(mod_list.game_id)
     editable = False
     if current_user:
         if current_user.admin:

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -85,7 +85,7 @@ def mod_rss(mod_id: int, mod_name: str) -> str:
 @mods.route("/mod/<int:mod_id>", defaults={'mod_name': None})
 @mods.route("/mod/<int:mod_id>/<path:mod_name>")
 @with_session
-def mod(mod_id: int, mod_name: str) -> str:
+def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
     protocol = _cfg("protocol")
     domain = _cfg("domain")
     if not protocol or not domain:
@@ -99,6 +99,8 @@ def mod(mod_id: int, mod_name: str) -> str:
             editable = True
     if not mod.published and not editable:
         abort(401)
+    if request.args.get('new') is not None:
+        return redirect(url_for("mods.edit_mod", mod_id=mod.id, mod_name=mod.name))
     latest = mod.default_version
     referral = request.referrer
     if referral:

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -210,7 +210,7 @@ class Mod(Base):  # type: ignore
 class ModList(Base):  # type: ignore
     __tablename__ = 'modlist'
     id = Column(Integer, primary_key=True)
-    created = Column(DateTime, default=datetime.now)
+    created = Column(DateTime, default=datetime.now, index=True)
     user_id = Column(Integer, ForeignKey('user.id'))
     user = relationship('User', backref=backref('packs', order_by=created))
     game_id = Column(Integer, ForeignKey('game.id'))

--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -119,12 +119,12 @@ def search_users(text: str, page: int) -> Iterable[User]:
     return results[page * 10:page * 10 + 10]
 
 
-def typeahead_mods(text: str) -> Iterable[Mod]:
+def typeahead_mods(game_id: str, text: str) -> Iterable[Mod]:
     query = db.query(Mod)
     filters = list()
     filters.append(Mod.name.ilike('%' + text + '%'))
     query = query.filter(or_(*filters))
-    query = query.filter(Mod.published == True)
+    query = query.filter(Mod.game_id == game_id, Mod.published == True)
     query = query.order_by(desc(Mod.score))
     results = query.all()
     return results

--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -46,10 +46,20 @@ def get_mod_score(mod: Mod) -> int:
 
 
 def versions_behind(mod: Mod) -> int:
-    all = (version.Version(v.friendly_version) for v in mod.game.versions)
-    compat = version.Version(mod.default_version.gameversion.friendly_version)
-    return sum(1 for v in all if v > compat)
+    try:
+        all = game_versions(mod.game)
+        compat = version.Version(mod.default_version.gameversion.friendly_version)
+        return sum(1 for v in all if v > compat)
+    except version.InvalidVersion:
+        return 0
 
+def game_versions(game: Game) -> Iterable[version.Version]:
+    for gv in game.versions:
+        try:
+            ver = version.Version(gv.friendly_version)
+            yield ver
+        except version.InvalidVersion:
+            pass
 
 def search_mods(ga: Optional[Game], text: str, page: int, limit: int) -> Tuple[List[Mod], int]:
     terms = text.split(' ')

--- a/alembic/versions/2020_06_26_01_24-1aa078e0fb7e.py
+++ b/alembic/versions/2020_06_26_01_24-1aa078e0fb7e.py
@@ -1,0 +1,22 @@
+"""Index ModList.created
+
+Revision ID: 1aa078e0fb7e
+Revises: 544564b4e738
+Create Date: 2020-06-26 01:24:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1aa078e0fb7e'
+down_revision = '544564b4e738'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.create_index(op.f('ix_modlist_created'), 'modlist', ['created'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_modlist_created'), table_name='modlist')

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -59,17 +59,20 @@ link.addEventListener('click', (e) ->
     e.preventDefault()
     xhr = new XMLHttpRequest()
     follow = false
+    mod_id = e.target.dataset.mod
     if e.target.classList.contains('follow-mod-button')
-        xhr.open('POST', "/mod/#{e.target.dataset.mod}/follow")
+        xhr.open('POST', "/mod/#{mod_id}/follow")
         e.target.classList.remove('follow-mod-button')
         e.target.classList.add('unfollow-mod-button')
         e.target.textContent = 'Unfollow'
         follow = true
+        $("#modbox-#{mod_id}-following").show()
     else
-        xhr.open('POST', "/mod/#{e.target.dataset.mod}/unfollow")
+        xhr.open('POST', "/mod/#{mod_id}/unfollow")
         e.target.classList.remove('unfollow-mod-button')
         e.target.classList.add('follow-mod-button')
         e.target.textContent = 'Follow'
+        $("#modbox-#{mod_id}-following").hide()
     xhr.onload = () ->
         try
             JSON.parse(this.responseText)

--- a/frontend/coffee/list.coffee
+++ b/frontend/coffee/list.coffee
@@ -6,8 +6,6 @@ error = (name) ->
     document.getElementById('error-alert').classList.remove('hidden')
     valid = false
 
-
-
 document.getElementById('submit').addEventListener('click', () ->
     a.classList.remove('has-error') for a in document.querySelectorAll('.has-error')
     document.getElementById('error-alert').classList.add('hidden')

--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -63,7 +63,7 @@ html body {
 .btn-info,
 .btn-warning,
 .btn-danger {
-    border-radius: 0px;
+    border-radius: 0;
 
 }
 
@@ -199,6 +199,7 @@ fieldset[disabled] .btn-primary:active,
 .btn-primary.disabled.active,
 .btn-primary[disabled].active,
 fieldset[disabled] .btn-primary.active {
+    color: #000d50;
     background-color: #FFFFFF;
     background-image: none;
 }
@@ -251,7 +252,7 @@ fieldset[disabled] .btn-success.active {
 .btn-info {
     background-color: #FFFFFF;
     color: #743af3;
-    border-color: #743af3
+    border-color: #743af3;
     background-repeat: repeat-x;
 }
 
@@ -403,7 +404,7 @@ fieldset[disabled] .btn-danger.active {
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
 .dropdown-menu > .active > a:focus {
-/ / background-color: #173072;
+    background-color: #173072;
     background-color: #555555;
 }
 
@@ -419,7 +420,7 @@ fieldset[disabled] .btn-danger.active {
 
 .navbar-brand,
 .navbar-nav > li > a {
-/ / text-shadow: 0 1 px 0 rgba(255, 255, 255, 0.25);
+    text-shadow: 0 1 px 0 rgba(255, 255, 255, 0.25);
     color: #FFFFFF;
 }
 
@@ -622,18 +623,18 @@ fieldset[disabled] .btn-danger.active {
 .well {
     background-color: #EFEFEF;
     border-radius: 0;
-/ / border-left: none;
-/ / border-right: none;
+    border-left: none;
+    border-right: none;
     padding: 0;
     vertical-align: middle;
     margin: 2.5mm;
-/ / margin-top: 2.5 mm;
-/ / margin-bottom: 2.5 mm;
+    margin-top: 2.5 mm;
+    margin-bottom: 2.5 mm;
 }
 
 .well .container h1 {
     font: 5mm 'moonlight';
-/ / padding-top: 2.5 mm;
+    padding-top: 2.5 mm;
     line-height: 2;
 
 }
@@ -661,7 +662,7 @@ div.modal-content {
 div.well div.main-cat.container {
     padding-top: 2.5mm;
     padding-bottom: 2.5mm;
-/ / min-height: 1.4 cm;
+    min-height: 1.4 cm;
 }
 
 div.well div.main-cat.container a.btn {
@@ -699,14 +700,14 @@ h3 {
     margin-right: 2.5mm;
     margin-left: 2.5mm;
     padding: 0;
-/ / width: 98.5 %;
+    width: 98.5%;
 }
 
 div.container {
     width: 100%;
     padding: 0;
-/ / padding-right: 2.5 mm;
-/ / padding-left: 2.5 mm;
+    padding-right: 2.5 mm;
+    padding-left: 2.5 mm;
 }
 
 nav div.container {
@@ -835,8 +836,6 @@ div.col-xs-1, div.col-sm-1, div.col-md-1, div.col-lg-1, div.col-xs-2, div.col-sm
     padding-bottom: 0;
     padding-left: 2.5mm;
     padding-right: 2.5mm;
-	//margin-left: 2.5mm;
-	//margin-right: 2.5mm;
 }
 
 .pull-right{
@@ -862,9 +861,9 @@ div.header.upload-well a, .header.upload-well p.status {
 
 .timeline-centered .timeline-entry .timeline-entry-inner div.timeline-icon {
     background-color: #1184aa;
-/ / color: #1184aa;
+    color: #1184aa;
     border: none;
-/ / border: solid 1 mm #1184aa;
+    border: solid 1 mm #1184aa;
     box-shadow: none;
     border-radius: 0;
 
@@ -930,7 +929,7 @@ div.well.info .container {
 }
 
 div.col-md-8 {
-/ / padding: 0;
+    padding: 0;
 
 }
 
@@ -944,7 +943,7 @@ div.col-md-8 .btn {
 }
 
 .row:after {
-/ / margin-bottom: 2.5 mm;
+    margin-bottom: 2.5 mm;
 }
 
 #add-shared-author {
@@ -959,13 +958,6 @@ div.thumbnail {
 
 div.thumbnail a {
     max-height: 5cm;
-}
-
-.item div.ksp-update {
-    right: auto;
-    top: auto;
-    font-size: 3mm;
-    padding: 1mm;
 }
 
 .item div.caption {
@@ -1022,7 +1014,7 @@ div.service-icon {
     text-align: center;
     padding: 5.5mm;
     border-radius: 0;
-/ / background-color: #FFFFFF;
+    background-color: #FFFFFF;
     margin: 2.5mm;
 }
 

--- a/frontend/styles/listing.scss
+++ b/frontend/styles/listing.scss
@@ -1,23 +1,41 @@
 .item .ksp-update {
-    position: absolute;
+    font-size: 3mm;
+    padding: 1mm;
     float: right;
-    right: 1px;
-    top: 21px;
+    clear: both;
     color: #fff;
     background: rgba(0,0,0,0.5);
     padding: 4px 10px;
-    font-size: 15px;
 }
 
 .item .following-mod {
-    position: absolute;
+    font-size: 3mm;
+    padding: 1mm;
     float: right;
-    left: 1px;
-    top: 21px;
+    clear: both;
     color: #fff;
-    background: rgba(119,162,64,0.5);
+    background: rgba(119,162,64,0.75);
     padding: 4px 10px;
-    font-size: 15px;
+}
+
+.item .not-following-mod {
+    font-size: 3mm;
+    padding: 1mm;
+    float: right;
+    clear: both;
+    color: #fff;
+    background: rgba(119,162,64,0.75);
+    padding: 4px 10px;
+}
+
+.item .download-link {
+    font-size: 3mm;
+    padding: 1mm;
+    float: right;
+    clear: both;
+    color: #fff;
+    background: rgba(0,0,0,0.75);
+    padding: 4px 10px;
 }
 
 .thumbnail .header-img {

--- a/frontend/styles/stylesheet.scss
+++ b/frontend/styles/stylesheet.scss
@@ -160,5 +160,9 @@ footer {
     color: #000;
 }
 
+.edit-list .CodeMirror {
+    height: 150px;
+}
+
 @import "typeahead";
 @import "navigation";

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -28,6 +28,7 @@
                     <th>Location</th>
                     <th>Description</th>
                     <th>Public</th>
+                    <th>Admin</th>
                 </tr>
                 </thead>
 
@@ -44,6 +45,7 @@
                     <td>{{ user.location }}</td>
                     <td>{{ user.description }}</td>
                     <td>{{ user.public }}</td>
+                    <td>{{ user.admin }}</td>
                 </tr>
                 {% endfor %}
                 </tbody>

--- a/templates/create_list.html
+++ b/templates/create_list.html
@@ -27,7 +27,7 @@
             <h2 class="control-label">What game is it for?</h2>
 
             <select id="pack-game" name="pack-game" class="chosen-select">
-                {% for g in game %}
+                {% for g in games %}
 
                 <option data-slug="{{ g.short }}" value="{{g.id}}" {% if g.id == ga.id %}selected{% endif %}>{{g.name}}</option>
                 {% endfor %}
@@ -61,11 +61,6 @@
                 var slug = $("#pack-game option:selected").attr("data-slug");
                 var gid = $("#pack-game option:selected").attr("value");
                 $(".gamename").html(gamename).attr("href", "/" + slug);
-                if (gid != "3102") { //if not ksp then hide ckan checkbox
-                    $(".ckan").hide();
-                } else {
-                    $(".ckan").show();
-                }
             }
 
             updategame();

--- a/templates/edit_list.html
+++ b/templates/edit_list.html
@@ -9,13 +9,13 @@
     <link rel="stylesheet" type="text/css" href="/static/editor.css"/>
 {% endblock %}
 {% block body %}
-<form action="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}" method="POST">
+<form class="edit-list" action="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}" method="POST">
     <div class="header upload-well scrollable" id="header-well" style="
-        {% if mod_list.background %}
-        background-image: url({{ mod_list.background }});
-        {% else %}
-        background-image: url(/static/background.jpg);
-        {% endif %}
+        {%- if mod_list.background -%}
+            background-image: url({{ mod_list.background }});
+        {%- else -%}
+            background-image: url(/static/background.jpg);
+        {%- endif -%}
         background-position: 0 {% if mod_list.bgOffsetY %}{{ mod_list.bgOffsetY }}px{% else %}0{% endif %};
         background-color: #ddd;"
         data-event="upload_bg"
@@ -41,10 +41,8 @@
             <div class="col-md-8">
                 <h1 title="{{ mod_list.name }}">Edit {{ mod_list.name }}</h1>
             </div>
-            <div class="col-md-2">
+            <div class="col-md-4">
                 <input type="submit" class="btn btn-primary btn-block" value="Save Changes" />
-            </div>
-            <div class="col-md-2">
                 <a href="{{ url_for("lists.view_list", list_id=mod_list.id, list_name=mod_list.name) }}" class="btn btn-default btn-block">Cancel</a>
             </div>
         </div>
@@ -56,7 +54,7 @@
     </div>
 
     <div class="container">
-        <h2>Add or Remove Mods</h2>
+        <h2>Add or Remove Mods for {{ mod_list.game.name }}</h2>
         <p class="text-muted">You can only add mods that are already hosted on {{ site_name }}.</p>
         <div class="row">
             <div class="col-md-10">
@@ -69,25 +67,24 @@
         <div id="mods-list-box" style="min-height: 300px">
             {% for list_item in mod_list.mods %}
             {% set mod = list_item.mod %}
-            <div class="pack-item" data-mod="{{ mod.id }}" style="background-image: 
-                {% if mod.background %}
-                url('{{ mod.background }}');
-                {% else %}
-                url('/static/background-s.jpg');
-                {% endif %}
+            <div class="pack-item" data-mod="{{ mod.id }}" style="
+                {%- if mod.background -%}
+                    background-image: url('{{ mod.background }}');
+                {%- else -%}
+                    background-image: url('/static/background-s.jpg');
+                {%- endif -%}
                 background-position: 0 {{ mod.bgOffsetY }}px;">
                 <div class="well well-sm">
                     <div class="pull-right">
-                        <button class="close down" data-mod="{{ mod.id }}" style="font-size: 10pt; line-height: 24px; padding-left: 4px"><span class="glyphicon glyphicon-chevron-down"></span></button>
-                        <button class="close remove" data-mod="{{ mod.id }}">&times;</button>
-                        <button class="close up" data-mod="{{ mod.id }}" style="font-size: 10pt; line-height: 22px; padding-right: 6px"><span class="glyphicon glyphicon-chevron-up"></span></button>
+                        <button class="close remove" data-mod="{{ mod.id }}"><span class="glyphicon glyphicon-trash"></span></button>
+                        <button class="close down" data-mod="{{ mod.id }}"><span class="glyphicon glyphicon-chevron-down"></span></button>
+                        <button class="close up" data-mod="{{ mod.id }}"><span class="glyphicon glyphicon-chevron-up"></span></button>
                     </div>
                     <h3>
                         <a href="{{ url_for("mods.mod", mod_name=mod.name, mod_id=mod.id) }}">{{ mod.name }}</a>
                         {{ mod.default_version.friendly_version }}
-                        <span class="badge">KSP {{ mod.default_version.ksp_version }}</span>
+                        <span class="badge">{{mod.game.name}} {{ mod.default_version.gameversion.friendly_version }}</span>
                     </h3>
-
                     <p>{{ mod.short_description }}</p>
                 </div>
             </div>
@@ -100,6 +97,7 @@
 {% block scripts %}
     <script>
         window.pack_list = {{ mod_ids | tojson }};
+        window.game_id = {{ mod_list.game.id }};
     </script>
     <script src="/static/typeahead.bundle.min.js"></script>
     <script src="/static/editor.js"></script>

--- a/templates/edit_list.html
+++ b/templates/edit_list.html
@@ -81,7 +81,13 @@
                         <button class="close up" data-mod="{{ mod.id }}"><span class="glyphicon glyphicon-chevron-up"></span></button>
                     </div>
                     <h3>
-                        <a href="{{ url_for("mods.mod", mod_name=mod.name, mod_id=mod.id) }}">{{ mod.name }}</a>
+                        {%- if mod.published -%}
+                            <a href="{{ url_for("mods.mod", mod_name=mod.name, mod_id=mod.id) }}">{{ mod.name }}</a>
+                        {%- elif mod.user_id == current_user.id or current_user.admin -%}
+                            (NOT PUBLISHED) <a href="{{ url_for("mods.mod", mod_name=mod.name, mod_id=mod.id) }}">{{ mod.name }}</a>
+                        {%- else -%}
+                            (NOT PUBLISHED) {{ mod.name }}
+                        {%- endif %}
                         {{ mod.default_version.friendly_version }}
                         <span class="badge">{{mod.game.name}} {{ mod.default_version.gameversion.friendly_version }}</span>
                     </h3>

--- a/templates/game.html
+++ b/templates/game.html
@@ -17,7 +17,7 @@
     </div>
 </div>
 -->
-{% if user and len(yours) >= 3 %}
+{% if user and len(yours) >= 1 %}
 <div class="well" style="margin-bottom: 0;">
     <div class="container">
         <a href="/profile/{{ user.username }}" class="btn btn-primary pull-right">
@@ -101,6 +101,16 @@
         {% endfor %}
     </div>
 </div>
+<div class="container">
+    <div class="row">
+        <div class="col-md-12">
+            <a class="btn btn-lg btn-block btn-default" href="/packs{% if ga %}/{{ ga.short }}{% endif %}">
+                Browse Mod Packs
+                <span class="glyphicon glyphicon-chevron-right"></span>
+            </a>
+        </div>
+    </div>
+</div>
 {% else %}
 <div class="well"  style="margin-bottom: 0;margin-top: 2.5mm;">
     <div class="container main-cat">
@@ -113,15 +123,21 @@
 </div>
 <div class="container">
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-4">
             <a class="btn btn-lg btn-block btn-default" href="{% if ga %}/{{ ga.short }}{% endif %}/browse/updated">
                 Browse Recently Updated Mods
                 <span class="glyphicon glyphicon-chevron-right"></span>
             </a>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-4">
             <a class="btn btn-lg btn-block btn-default" href="{% if ga %}/{{ ga.short }}{% endif %}/browse/top">
                 Browse Popular Mods
+                <span class="glyphicon glyphicon-chevron-right"></span>
+            </a>
+        </div>
+        <div class="col-md-4">
+            <a class="btn btn-lg btn-block btn-default" href="/packs{% if ga %}/{{ ga.short }}{% endif %}">
+                Browse Mod Packs
                 <span class="glyphicon glyphicon-chevron-right"></span>
             </a>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -130,24 +130,24 @@
                          <div class="form-group">
                             <label for="email" class="col-sm-2 control-label">Email</label>
                             <div class="col-sm-10">
-                               <input type="email" class="form-control" id="email" placeholder="Email" name="email" value="">
+                               <input type="email" class="form-control" id="newEmail" placeholder="Email" name="email" value="">
                             </div>
                          </div>
                          <div class="form-group">
                             <label for="username" class="col-sm-2 control-label">Username</label>
                             <div class="col-sm-10">
-                               <input type="text" class="form-control" id="username" placeholder="Username" name="username" value="">
+                               <input type="text" class="form-control" id="newUsername" placeholder="Username" name="username" value="">
                             </div>
                          </div>
                          <div class="form-group">
                             <label for="password" class="col-sm-2 control-label">Password</label>
                             <div class="col-sm-10">
-                               <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                               <input type="password" class="form-control" id="newPassword" name="password" placeholder="Password">
                             </div>
                          </div>
                          <div class="form-group">
                             <div class="col-sm-10 col-sm-offset-2">
-                               <input type="password" class="form-control" id="password" name="repeatPassword" placeholder="Repeat password">
+                               <input type="password" class="form-control" id="newRepeatPassword" name="repeatPassword" placeholder="Repeat password">
                             </div>
                          </div>
                          <div class="form-group">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -32,7 +32,7 @@
         <title>{{ site_name }}</title>
         {% endblock %}
         <link href="/static/bootstrap.min.css" rel="stylesheet">
-	 <link href="/static/bootstrap-theme.css" rel="stylesheet">
+        <link href="/static/bootstrap-theme.css" rel="stylesheet">
 
 
         {% block styles %}
@@ -40,18 +40,18 @@
         {% endblock %}
         <!-- Piwik -->
           {% if admin %}
-          	{% set VisitorType = 'Admin' %}
+              {% set VisitorType = 'Admin' %}
           {% else %}
-          	{% if not user %}
-				{% set VisitorType = 'Guest' %}
-            {% else %}
-				{% set VisitorType = 'Member' %}
-            {% endif %}
+              {% if not user %}
+                  {% set VisitorType = 'Guest' %}
+              {% else %}
+                  {% set VisitorType = 'Member' %}
+              {% endif %}
           {% endif %}
           {% if results is defined %}
-          	{% set SearchResultCount = results|length %}
+              {% set SearchResultCount = results|length %}
           {% else %}
-          	{% set SearchResultCount = 0 %}
+              {% set SearchResultCount = 0 %}
           {% endif %}
         <noscript><p><img src="//stats.52k.de/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
         <!-- End Piwik Code -->
@@ -201,7 +201,7 @@
                 </div>
             </div>
         </footer>
-<!-- Modal -->
+        <!-- Modal -->
         <div class="modal fade" id="loginModal" tabindex="-1" role="dialog" aria-labelledby="Login"
              aria-hidden="true">
             <div class="modal-dialog" role="document">
@@ -253,6 +253,7 @@
                 </div>
             </div>
         </div>
+        <!-- End Modal -->
     </body>
     <script src="/static/jquery.min.js"></script>
     <script src="/static/underscore.min.js"></script>
@@ -301,6 +302,10 @@
             $(".changer").mouseout(function (el, index) {
                 $(this).children(".front").show();
                 $(this).children(".back").hide();
+            });
+
+            $("#loginModal").on('shown.bs.modal', function () {
+                $("#username").focus();
             });
 
         });

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -1,41 +1,49 @@
 <div class="item col-md-2 modbox"  style="margin-bottom:5mm;">
-<div class="flip-container" ontouchstart="this.classList.toggle('hover');">
-	<div class="changer">
-    <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}" style="width: 100%;">
-        {% if mod.default_version %}
-        <div class="ksp-update">For {{ mod.default_version.gameversion.friendly_version }}</div>
-        {% endif %}
-        {% if following_mod(mod) %}
-        <div class="following-mod">Following</div>
-        {% endif %}
-        <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">
-            <div class="header-img" style="background-color: #000000;
-            {% if not mod.background %}
-            background-image: url(/static/background-s.jpg);
-            {% else %}
-            background-image: url({{ mod.background_thumb() }});
-            {% endif %}
-            "></div>
-        </a>
-        <div class="caption">
-            <h2 class="group inner list-group-item-heading">
-                {{ mod.name }}
-            </h2>
-        </div>
-    </div>
-    <div class="thumbnail back" id="modbox-{{ mod.id }}-desc" data-umodid="{{ mod.id }}"  style="width: 100%;">
-        <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}" style="text-decoration: none; color: #333333;">
-            <div class="header-img" style="overflow: hidden;text-overflow: ellipsis;background-color: #07acd2;color: #FFFFFF;">
-                <span style="padding:2.5mm">{{ mod.short_description }}</span>
+    <div class="flip-container" ontouchstart="this.classList.toggle('hover');">
+        <div class="changer">
+            <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}" style="width: 100%;">
+                {% if mod.default_version %}
+                    <div class="ksp-update">{{mod.default_version.friendly_version}} for {{ mod.default_version.gameversion.game.name }} {{ mod.default_version.gameversion.friendly_version }}</div>
+                {% endif %}
+                <div class="following-mod" id="modbox-{{ mod.id }}-following" style="display:{%- if following_mod(mod) -%}block{%- else -%}none{%- endif -%}">Following</div>
+                <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">
+                    <div class="header-img" style="background-color: #000000;
+                    {%- if not mod.background -%}
+                        background-image: url(/static/background-s.jpg);
+                    {%- else -%}
+                        background-image: url({{ mod.background_thumb() }});
+                    {%- endif -%}
+                    "></div>
+                </a>
+                <div class="caption">
+                    <h2 class="group inner list-group-item-heading">
+                        {{ mod.name }}
+                    </h2>
+                </div>
             </div>
-        </a>
-        <div class="caption">
-            <h2 class="group inner list-group-item-heading" style="background-color: #FFFFFF;">
-                {{ mod.name }}
-            </h2>
+            <div class="thumbnail back" id="modbox-{{ mod.id }}-desc" data-umodid="{{ mod.id }}"  style="width: 100%;">
+                {% if mod.default_version %}
+                    <div style="position:absolute;top:0px;right:10px;">
+                        <div class="ksp-update" style="visibility:hidden;">GameNameSpacer</div>
+                        {% if following_mod(mod) %}
+                            <a href="#" class="following-mod unfollow-mod-button" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
+                        {% elif user %}
+                            <a href="#" class="not-following-mod follow-mod-button" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
+                        {% endif %}
+                        <a href='{{url_for("mods.download", mod_id=mod.id, mod_name=mod.name)}}' class="download-link">Download</a>
+                    </div>
+                {% endif %}
+                <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}" style="text-decoration: none; color: #333333;">
+                    <div class="header-img" style="display:block;overflow: hidden;text-overflow: ellipsis;background-color: #07acd2;color: #FFFFFF;">
+                        <span style="padding:2.5mm">{{ mod.short_description }}</span>
+                    </div>
+                </a>
+                <div class="caption">
+                    <h2 class="group inner list-group-item-heading" style="background-color: #FFFFFF;">
+                        {{ mod.name }}
+                    </h2>
+                </div>
+            </div>
         </div>
     </div>
-    </div>
 </div>
-</div>
-

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -77,7 +77,7 @@
         <div class="row">
             <div class="col-md-6">
                 <div class="timeline-centered">
-                    
+
                     <div class="timeline-entry">
                         <div class="timeline-entry-inner">
                             <div class="timeline-icon">
@@ -127,7 +127,7 @@
                         </div>
                     </div>
                     {% endif %}
-                    
+
                     <div class="timeline-entry">
                         <div class="timeline-entry-inner">
                             <div class="timeline-icon">
@@ -143,13 +143,13 @@
                             </div>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
 
             <div class="col-md-6">
                 <div class="timeline-centered">
-                    
+
                     <div class="timeline-entry">
                         <div class="timeline-entry-inner">
                             <div class="timeline-icon">
@@ -214,7 +214,7 @@
                         </div>
                     </div>
                     {% endif %}
-                    
+
                     <div class="timeline-entry">
                         <div class="timeline-entry-inner">
                             <div class="timeline-icon">
@@ -230,7 +230,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
         </div>
@@ -416,7 +416,7 @@
         </div>
     </div>
 </div>
-<div class="modal fade" id="version-edit-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
+<div class="modal fade" id="version-edit-modal" tabindex="-1" role="dialog" aria-labelledby="version-edit-modal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <form action="/mod/{{ mod.id }}/edit_version" method="POST" enctype="multipart/form-data">
@@ -437,7 +437,7 @@
         </div>
     </div>
 </div>
-<div class="modal fade" id="confirm-update" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
+<div class="modal fade" id="confirm-update" tabindex="-1" role="dialog" aria-labelledby="confirm-update" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <form action="/mod/{{ mod.id }}/autoupdate" method="POST">
@@ -525,18 +525,18 @@
                     <div class="form-group">
                         <label for="username" class="col-sm-2 control-label">Username</label>
                         <div class="col-sm-10">
-                            <input type="text" class="form-control" id="username" placeholder="Username" name="username" value="">
+                            <input type="text" class="form-control" id="newUsername" placeholder="Username" name="username" value="">
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="password" class="col-sm-2 control-label">Password</label>
                         <div class="col-sm-10">
-                            <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                            <input type="password" class="form-control" id="newPassword" name="password" placeholder="Password">
                         </div>
                     </div>
                     <div class="form-group">
                         <div class="col-sm-10 col-sm-offset-2">
-                            <input type="password" class="form-control" id="password" name="repeatPassword" placeholder="Repeat password">
+                            <input type="password" class="form-control" id="newRepeatPassword" name="repeatPassword" placeholder="Repeat password">
                         </div>
                     </div>
                     <div class="form-group">

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -16,63 +16,62 @@
 <div class="container lead">
     <div class="row">
         <div class="col-md-8">
-            <h3 title="{{ mod_list.name }}">{{ mod_list.name }} <small>from {{ mod_list.user.username }}</small></h3>
+            <h3 title="{{ mod_list.name }}">
+                {{ mod_list.name }}
+                <br/>
+                <small>
+                    for {{ mod_list.game.name }},
+                    from <a href='{{url_for("profile.view_profile", username=mod_list.user.username)}}'>{{ mod_list.user.username }}</a>
+                </small>
+            </h3>
         </div>
         {% if editable %}
-        <div class="col-md-4">
-            <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}"
-                class="btn btn-default btn-block btn-lg" style="height: 40px; line-height: 20px;">Edit Pack</a>
-            <a href="{{ url_for("lists.delete", list_id=mod_list.id) }}"
-                class="btn btn-danger btn-block btn-lg" style="height: 40px; line-height: 20px;">Delete Pack</a>
-        </div>
+            <div class="col-md-4">
+                <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}"
+                    class="btn btn-primary btn-default btn-block btn-lg" style="height: 40px; line-height: 20px;">Edit Pack</a>
+                <a data-toggle="modal" href="#confirm-delete-pack"
+                    class="btn btn-danger btn-block btn-lg" style="height: 40px; line-height: 20px;">Delete Pack</a>
+            </div>
         {% endif %}
     </div>
 </div>
 
 <div class="well well-sm md-well">
     <div class="container">
-        {% if mod_list.description %}
-        {{ mod_list.description | markdown }}
-        {% else %}
-        <p>Your mod pack is empty right now! You should
-        <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}">edit it</a>
-        to add some mods. You can edit this text, too!</p>
-        {% endif %}
+        {%- if mod_list.description -%}
+            {{ mod_list.description | markdown }}
+        {%- else -%}
+            <p>Your mod pack is empty right now! You should
+            <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}">edit it</a>
+            to add some mods. You can edit this text, too!</p>
+        {%- endif -%}
     </div>
 </div>
 
 <div class="container">
     {% for list_item in mod_list.mods %}
     {% set mod = list_item.mod %}
-    <div class="pack-item" style="background-image: 
-        {% if mod.background %}
-        url('{{ mod.background }}');
-        {% else %}
-        url('/static/background-s.jpg');
-        {% endif %}
-        background-position: 0 {{ mod.bgOffsetY }}px;">
-        <div class="well well-sm">
-            <h3>
-                <a href="{{ url_for("mods.mod", mod_name=mod.name, mod_id=mod.id) }}">{{ mod.name }}</a>
-                {{ mod.default_version.friendly_version }}
-                for KSP {{ mod.default_version.gameversion.friendly_version }}
-                <small>from <a href="/profile/{{ mod.user.username }}">{{ mod.user.username }}</a></small>
-            </h3>
-            <p>{{ mod.short_description }}</p>
-        </div>
-        <div class="row">
-            <div class="col-md-4">
-                {% if following_mod(mod) %}
-                <a href="#" class="unfollow-mod-button btn btn-block btn-lg btn-success" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
-                {% else %}
-                <a href="#" class="follow-mod-button btn btn-block btn-lg btn-success" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
-                {% endif %}
+        {% include "mod-box.html" %}
+    {% endfor %}
+</div>
+
+<div class="modal fade" id="confirm-delete-pack" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="myModalLabel">Delete Pack?</h4>
             </div>
-            <div class="col-md-8">
-                <a href="{{ url_for("mods.download", mod_name=mod.name, mod_id=mod.id) }}" class="btn btn-block btn-lg btn-primary">Download</a>
+            <div class="modal-body">
+                <p>This will forever delete the {{ mod_list.name }} pack. There is no undoing this action.</p>
+                <p>Are you sure you wish to continue?</p>
+            </div>
+            <div class="modal-footer">
+                <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                <a href="{{ url_for("lists.delete", list_id=mod_list.id) }}"
+                    class="btn btn-danger">Confirm</a>
             </div>
         </div>
     </div>
-    {% endfor %}
 </div>
 {% endblock %}

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -50,8 +50,10 @@
 
 <div class="container">
     {% for list_item in mod_list.mods %}
-    {% set mod = list_item.mod %}
-        {% include "mod-box.html" %}
+        {% set mod = list_item.mod %}
+        {% if mod.published %}
+            {% include "mod-box.html" %}
+        {% endif %}
     {% endfor %}
 </div>
 

--- a/templates/pack-box.html
+++ b/templates/pack-box.html
@@ -1,20 +1,22 @@
-<div class="item col-md-4 modbox" >
+<div class="item col-md-4 packbox" >
     <div class="thumbnail">
         <a href="{{ url_for("lists.view_list", list_id=list.id, list_name=list.name) }}">
             <div class="header-img" style="
-            {% if not list.background %}
-            background-image: url(/static/background-s.jpg);
-            {% else %}
-            background-image: url({{ list.background }});
-            {% endif %}
+                {%- if not list.background -%}
+                    background-image: url(/static/background-s.jpg);
+                {%- else -%}
+                    background-image: url({{ list.background }});
+                {%- endif -%}
             "></div>
         </a>
         <div class="caption">
             <h2 class="group inner list-group-item-heading">
                 {{ list.name }}
             </h2>
-            <p style="height: 75px; overflow: hidden;">
-            {{ list.description }}
+            <p style="max-height: 75px; overflow: hidden;">
+                {% if list.description %}
+                    {{ list.description }}
+                {% endif %}
             </p>
         </div>
     </div>

--- a/templates/packs.html
+++ b/templates/packs.html
@@ -1,0 +1,40 @@
+{% extends "layout.html" %}
+{% block styles %}
+<link rel="stylesheet" type="text/css" href="/static/index.css" />
+<link rel="stylesheet" type="text/css" href="/static/mod.css" />
+{% endblock %}
+{% block title -%}
+    <title>Mod Packs {%- if game %} for {{game.name}} {%- endif -%}</title>
+{%- endblock %}
+{% block body %}
+    <div class="well">
+        <div class="container">
+            <h1>Mod Packs {%- if game %} for {{game.name}} {%- endif -%}</h1>
+        </div>
+    </div>
+    <div class="container">
+        <div class="row">
+            {% for list in packs  %}
+                {% include "pack-box.html" %}
+            {% endfor %}
+        </div>
+        <div style="margin-top: 5mm" class="row" style="margin-bottom:2.5mm;">
+            <div class="col-md-2">
+                {% if page != 1 %}
+                <a href="/packs{% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page - 1 }}"
+                    class="btn btn-lg btn-primary btn-block">
+                    <span class="glyphicon glyphicon-arrow-left"></span> Previous
+                </a>
+                {% endif %}
+            </div>
+            <div class="col-md-2 col-md-offset-8">
+                {% if page < total_pages %}
+                <a href="/packs{% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page + 1 }}"
+                    class="btn btn-lg btn-primary btn-block">
+                    Next <span class="glyphicon glyphicon-arrow-right"></span>
+                </a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -33,113 +33,153 @@
     </div>
 </div>
 {% endif %}
-<div class="info-list">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-6">
-                <div class="timeline-centered">
-                    {% if profile.forumUsername %}
-                    <div class="timeline-entry">
-                        <div class="timeline-entry-inner">
-                            <div class="timeline-icon">
-                                <span class="glyphicon glyphicon-link"></span>
-                            </div>
-                            <div class="timeline-label">
-                                <h2>
-                                    <span class="text-muted">
-                                        Forums:
-                                    </span>
-                                    <!-- Due to the Forum update, and the fact that IPS4 doesn't have an API like vBullentin, we are removing this until we can adress it. -->
-                                    <!--<a target="_blank" href="http://forum.kerbalspaceprogram.com/members/{{ profile.forumId}}-{{ profile.forumUsername }}">-->
-                                        {{ profile.forumUsername }}
-                                    <!--</a>-->
-                                </h2>
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-                    {% if profile.twitterUsername %}
-                    <div class="timeline-entry">
-                        <div class="timeline-entry-inner">
-                            <div class="timeline-icon">
-                                <span class="glyphicon glyphicon-link"></span>
-                            </div>
-                            <div class="timeline-label">
-                                <h2>
-                                    <span class="text-muted">
-                                        Twitter:
-                                    </span>
-                                    <a target="_blank" href="https://twitter.com/{{ profile.twitterUsername }}">
-                                        @{{ profile.twitterUsername }}
-                                    </a>
-                                </h2>
+
+{% if profile.forumUsername or profile.twitterUsername or profile.redditUsername or profile.ircNick or profile.description or user.admin %}
+    <div class="info-list">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="timeline-centered">
+                        {% if profile.forumUsername %}
+                        <div class="timeline-entry">
+                            <div class="timeline-entry-inner">
+                                <div class="timeline-icon">
+                                    <span class="glyphicon glyphicon-link"></span>
+                                </div>
+                                <div class="timeline-label">
+                                    <h2>
+                                        <span class="text-muted">
+                                            Forums:
+                                        </span>
+                                        <!-- Due to the Forum update, and the fact that IPS4 doesn't have an API like vBullentin, we are removing this until we can adress it. -->
+                                        <!--<a target="_blank" href="http://forum.kerbalspaceprogram.com/members/{{ profile.forumId}}-{{ profile.forumUsername }}">-->
+                                            {{ profile.forumUsername }}
+                                        <!--</a>-->
+                                    </h2>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    {% endif %}
-                    {% if profile.redditUsername %}
-                    <div class="timeline-entry">
-                        <div class="timeline-entry-inner">
-                            <div class="timeline-icon">
-                                <span class="glyphicon glyphicon-link"></span>
-                            </div>
-                            <div class="timeline-label">
-                                <h2>
-                                    <span class="text-muted">
-                                        Reddit:
-                                    </span>
-                                    <a target="_blank" href="https://www.reddit.com/user/{{ profile.redditUsername }}">
-                                        /u/{{ profile.redditUsername }}
-                                    </a>
-                                </h2>
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-                    {% if profile.ircNick %}
-                    <div class="timeline-entry">
-                        <div class="timeline-entry-inner">
-                            <div class="timeline-icon">
-                                <span class="glyphicon glyphicon-link"></span>
-                            </div>
-                            <div class="timeline-label">
-                                <h2>
-                                    <span class="text-muted">
-                                        IRC:
-                                    </span>
-                                    {{ profile.ircNick }}
-                                </h2>
+                        {% endif %}
+                        {% if profile.twitterUsername %}
+                        <div class="timeline-entry">
+                            <div class="timeline-entry-inner">
+                                <div class="timeline-icon">
+                                    <span class="glyphicon glyphicon-link"></span>
+                                </div>
+                                <div class="timeline-label">
+                                    <h2>
+                                        <span class="text-muted">
+                                            Twitter:
+                                        </span>
+                                        <a target="_blank" href="https://twitter.com/{{ profile.twitterUsername }}">
+                                            @{{ profile.twitterUsername }}
+                                        </a>
+                                    </h2>
+                                </div>
                             </div>
                         </div>
+                        {% endif %}
+                        {% if profile.redditUsername %}
+                        <div class="timeline-entry">
+                            <div class="timeline-entry-inner">
+                                <div class="timeline-icon">
+                                    <span class="glyphicon glyphicon-link"></span>
+                                </div>
+                                <div class="timeline-label">
+                                    <h2>
+                                        <span class="text-muted">
+                                            Reddit:
+                                        </span>
+                                        <a target="_blank" href="https://www.reddit.com/user/{{ profile.redditUsername }}">
+                                            /u/{{ profile.redditUsername }}
+                                        </a>
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                        {% endif %}
+                        {% if profile.ircNick %}
+                        <div class="timeline-entry">
+                            <div class="timeline-entry-inner">
+                                <div class="timeline-icon">
+                                    <span class="glyphicon glyphicon-link"></span>
+                                </div>
+                                <div class="timeline-label">
+                                    <h2>
+                                        <span class="text-muted">
+                                            IRC:
+                                        </span>
+                                        {{ profile.ircNick }}
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                        {% endif %}
                     </div>
+                </div>
+
+                <div class="col-md-6">
+                    {{ profile.description | markdown }}
+                    {% if user.admin %}
+                    <p>
+                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Email:</span> <a href="mailto:{{ profile.email }}">{{ profile.email }}</a>
+                    <br />
+                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Confirmed:</span> {% if profile.confirmation == None -%}
+                        Yes
+                    {%- else -%}
+                        No
+                        <a href="/admin/manual-confirmation/{{ profile.id }}">[Confirm Manually]</a>
+                    {%- endif -%}
+                    <br />
+                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Public:</span> {% if profile.public -%}
+                        Yes
+                    {%- else -%}
+                        No
+                    {%- endif -%}
+                    <br />
+                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Created:</span> {{ profile.created }}
+                    <br />
+                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Admin:</span> {% if profile.admin -%}
+                        Yes
+                    {%- else -%}
+                        No
+                        <a data-toggle="modal" href="#confirm-grant-admin">[Grant Admin]</a>
+                    {%- endif -%}
+                    </p>
+                    <a href="/admin/impersonate/{{profile.username}}" class="btn btn-primary" style="margin-bottom: 10px; margin-top: 5px;">
+                        <span class="glyphicon glyphicon-fire"></span>
+                        Impersonate user
+                    </a>
                     {% endif %}
                 </div>
             </div>
+        </div>
+    </div>
+{% endif %}
 
-            <div class="col-md-6">
-                {{ profile.description | markdown }}
-                {% if user.admin %}
-                <p>
-                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Email:</span> <a href="mailto:{{ profile.email }}">{{ profile.email }}</a><br />
-                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Confirmed:</span>
-                {% if profile.confirmation == None %}
-                    Yes
-                {%else%}
-                    No
-                    <a href="/admin/manual-confirmation/{{ profile.id }}">[Confirm Manually]</a>
-                {% endif %}<br />
-                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Public:</span> {% if profile.public %}Yes{% else %}No{% endif %}<br />
-                <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Created:</span> {{ profile.created }}
-                </p>
-                <a href="/admin/impersonate/{{profile.username}}" class="btn btn-primary" style="margin-bottom: 10px;">
-                    <span class="glyphicon glyphicon-fire"></span>
-                    Impersonate user
-                </a>
-                {% endif %}
-            </div>
+{%- if user.admin -%}
+<div class="modal fade" id="confirm-grant-admin" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form action="/admin/grant-admin/{{profile.id}}" method="POST">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Grant Administrator Privileges</h4>
+                </div>
+                <div class="modal-body">
+                    <p>This will give <b>{{ profile.username }}</b> administrator privileges, just like you. They will be able to edit or delete other users' mods, access the admin pages, and even grant admin to other users. If you need to undo this action, you will have to contact the site owner and request it to be reverted in the database.
+                    </p>
+                    <p>Are you sure you wish to continue?</p>
+                </div>
+                <div class="modal-footer">
+                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                    <input type="submit" class="btn btn-danger" value="Confirm">
+                </div>
+            </form>
         </div>
     </div>
 </div>
+{%- endif -%}
 
 {% if len(profile.packs) != 0 %}
 <div class="well">
@@ -150,7 +190,7 @@
 <div class="container">
     <div class="row">
         {% for list in profile.packs  %}
-        {% include "pack-box.html" %}
+            {% include "pack-box.html" %}
         {% endfor %}
     </div>
 </div>
@@ -165,7 +205,7 @@
 <div class="container">
     <div class="row">
         {% for mod in mods_created %}
-        {% include "mod-box.html" %}
+            {% include "mod-box.html" %}
         {% endfor %}
     </div>
 </div>
@@ -179,7 +219,7 @@
 <div class="container">
     <div class="row">
         {% for mod in mods_followed %}
-        {% include "mod-box.html" %}
+            {% include "mod-box.html" %}
         {% endfor %}
     </div>
 </div>

--- a/tests/test_api_mod.py
+++ b/tests/test_api_mod.py
@@ -59,7 +59,7 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     mod_resp = client.get('/api/mod/1')
     mod_version_resp = client.get('/api/mod/1/latest')
     user_resp = client.get('/api/user/TestModAuthor')
-    typeahead_resp = client.get('/api/typeahead/mod?query=Test')
+    typeahead_resp = client.get('/api/typeahead/mod?game_id=1&query=Test')
     search_mod_resp = client.get('/api/search/mod?query=Test&page=1')
     search_user_resp = client.get('/api/search/user?query=Test&page=0')
 


### PR DESCRIPTION
This pull request attempts to make mod packs somewhat usable, plus a few convenience/usability fixes.

Problems | Changes
:-- | :--
If you click Login to log in, you have to click the Username field to start typing. | Now the Username field has focus by default.
A mod box shows the game version, but not the game. | Now the default version, game, and game version are shown, which fixes #172.
If you have no forum name, twitter name, reddit name, irc name, or description, your user profile will have a blank box at the top. | Now the blank box is not shown.
The admin page doesn't say which users are admins | Now an Admin column shows who's an admin
The user profile doesn't say whether the user is an admin or allow an admin to make them an admin | Now admin-visible section of the user profile shows whether they're an admin, and a "Grant Admin" link allows admins to set non-admins to be admins
The list of mods for a given game shows all mods you follow regardless of game. But only if there are 3 or more. | Now only followed mods for the current game are shown. And we show them all, even if you only follow 1 or 2 mods.
If you create a mod, you're taken to the view-only page for that mod and have to click Edit Mod to fill in the details. | Now after you create a mod, you are taken directly to the mod editing page.
If you create a mod pack, you're taken to the view only page for that mod pack and have to click Edit Mod Pack to start adding mods. | Now after you create a mod pack, you are taken directly to the mod pack editing page.
Mod packs are shown only on user profiles. | Now a "Browse Mod Packs" link is available at the bottom of each game's mod list, which goes to a new `/packs/gameshort` route that shows a paginated listing of mod packs, 15 per page (half as many as for mods, since they're twice as wide). To make sure this is fast, `ModList.created` is now indexed.
Adding a mod to a mod pack is confusing; you can type a mod's name and click Add Mod and nothing happens. | Now the Add Mod button is disabled until you click a mod in the dropdown, which is what allows the page to get enough info to add the mod, and a tooltip in the disabled state tells the user directly to interact with the dropdown. This fixes #158.
It may not be clear why a mod shows up in the dropdown when trying to add a mod to a mod pack. |  Now while you type, the matching parts of each mod name are bolded.
The page to view a mod pack looks weird, each mod is shown with a long horizontal box that is not shown anywhere else on the site. | Now the standard mod box is used. To avoid losing functionality, the Follow/Unfollow and Download links are added to the standard mod box, which fixes #103 and fixes #160 and fixes #161. The long custom boxes are still used for editing because I did not want to try to make the up/down/remove buttons fit on the standard box, maybe later.
It is possible to add mods from any game to any mod pack. | Now you can only add mods that are for the game associated with the mod pack, which is displayed more prominently on the mod pack viewing and editing pages in case the user wonders why he or she can't find a particular mod.
You can add the same mod to a mod pack multiple times. | Now you can only add each mod once.
Mod pack mods loaded from the server have a different background than mods generated on the client. | Now they both use the blurry blue thing.
Mods shown in a mod pack always report the game name as "KSP" even if it's something else. | Now the actual game name is used.
Mod entries generated on the client show the game version as "undefined", and when editing, mods loaded from the server don't show a game version at all. | Now it uses the default version's game version.
The up and down arrows for moving mods in a mod pack don't work at all for client generated entries (you're taken to some other page), and are glitchy for server-loaded mods. | Now they work as intended, and the 'X' in the middle is replaced with a trash can on the far right.
The description text editor for a mod pack is gigantic, far beyond any reasonable length that might be needed. | Now it's one-third the previous height, which can still comfortably fit a fairly verbose paragraph.
The view only page for a mod pack shows the user name, but it's not clickable. | Now it's a link to their profile.
If you click "Delete Pack", the pack just _goes_. | Now a confirmation modal dialog appears to ask for confirmation.
The mod pack mod search field retains the name of a mod you just added after you add it, so you have to delete it to add more. | Now the field clears when a mod is added.
The mod pack creation page has a copy of the CKAN checkbox show/hide code with hard-coded game ID, but it doesn't have that checkbox. | Now this code is removed.
Listings of mod packs (on the profile) show each pack's description, but it overflows out the bottom of the box. | Now the description fits inside the box.

## Screenshots

Default focus of login:

![image](https://user-images.githubusercontent.com/1559108/86191319-5a777000-bb0c-11ea-9861-e07b5d87c184.png)

Mod pack deletion confirmation:

![image](https://user-images.githubusercontent.com/1559108/86191308-577c7f80-bb0c-11ea-8d6e-a0b3f5a50079.png)

Admin column in user list:

![image](https://user-images.githubusercontent.com/1559108/86191303-53e8f880-bb0c-11ea-9c95-cf95ffdc0cf5.png)

Admin indicator in profile:

![image](https://user-images.githubusercontent.com/1559108/86191295-50557180-bb0c-11ea-9802-2faaced08d8c.png)

Grant admin confirmation modal:

![image](https://user-images.githubusercontent.com/1559108/86191217-1dab7900-bb0c-11ea-9cdd-fc8ff1a8fe61.png)

Mod selection bold highlights:

![image](https://user-images.githubusercontent.com/1559108/86191290-4b90bd80-bb0c-11ea-93a6-632b93a0d249.png)

Add Mod button enabled after mod selection:

![image](https://user-images.githubusercontent.com/1559108/86191282-4764a000-bb0c-11ea-8c7d-94bbb850f61b.png)

Mod version and game name in thumbnail, download link on hover, mod pack link at bottom (not logged in):

![image](https://user-images.githubusercontent.com/1559108/86191276-429fec00-bb0c-11ea-9907-5d943e297682.png)

Same logged in:

![image](https://user-images.githubusercontent.com/1559108/86191234-29973b00-bb0c-11ea-8d22-2dd39bc43370.png)

Mod packs for a game:

![image](https://user-images.githubusercontent.com/1559108/86191256-387ded80-bb0c-11ea-9b58-205d44f0058e.png)

Contents of a mod pack (not logged in):

![image](https://user-images.githubusercontent.com/1559108/86191249-33b93980-bb0c-11ea-9161-de510681e482.png)

Contents of a mod pack, follow link in thumbnail hover (logged in):

![image](https://user-images.githubusercontent.com/1559108/86191242-2f8d1c00-bb0c-11ea-9237-c144908364ee.png)

Editing mod pack with reasonably sized description:

![image](https://user-images.githubusercontent.com/1559108/86191224-2308c380-bb0c-11ea-9102-99d77cd027c4.png)
