### PR TITLE
Auto-import KSP versions from CKAN

### DIFF
--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -1,10 +1,15 @@
 import threading
 import requests
+import re
 from flask import url_for
-from typing import Dict
+from typing import Dict, Iterable
 
 from .config import _cfg
-from .objects import Mod
+from .objects import Mod, Game, GameVersion
+from .database import db
+
+CKAN_BUILDS_URL = 'https://github.com/KSP-CKAN/CKAN-meta/raw/master/builds.json'
+MAJOR_MINOR_PATCH_PATTERN = re.compile('^([^.]+\.[^.]+\.[^.]+)')
 
 
 def send_to_ckan(mod: Mod) -> None:
@@ -41,3 +46,20 @@ def notify_ckan(mod: Mod, event_type: str) -> None:
 def _bg_post(url: str, data: Dict[str, str]) -> None:
     """Fire and forget some data to a POST URL in a background thread"""
     threading.Thread(target=requests.post, args=(url, data)).start()
+
+
+def import_ksp_versions_from_ckan(ksp_game_id: int) -> None:
+    current_versions = {gv.friendly_version
+                        for gv in Game.query.get(ksp_game_id).versions}
+    for version in ksp_versions_from_ckan():
+        if version not in current_versions:
+            db.add(GameVersion(friendly_version=version, game_id=ksp_game_id))
+            db.commit()
+
+
+def ksp_versions_from_ckan() -> Iterable[str]:
+    builds = requests.get(CKAN_BUILDS_URL).json()
+    for _, full_version in builds['builds'].items():
+        m = MAJOR_MINOR_PATCH_PATTERN.match(full_version)
+        if m:
+            yield m.groups()[0]

--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -53,6 +53,7 @@ def import_ksp_versions_from_ckan(ksp_game_id: int) -> None:
                         for gv in Game.query.get(ksp_game_id).versions}
     for version in ksp_versions_from_ckan():
         if version not in current_versions:
+            current_versions.add(version)
             db.add(GameVersion(friendly_version=version, game_id=ksp_game_id))
             db.commit()
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -25,6 +25,9 @@ domain=localhost:5080
 # Change this value to something random and secret
 secret-key=hello world
 
+# Set this to the id of a Game that should automatically sync up with CKAN's KSP builds.json
+ksp-game-id=
+
 # Enable offloading of downloads to the reverse proxy server. Make sure the reverse proxy is set up!
 # valid values are:
 # false - disable offloading

--- a/config.ini.example
+++ b/config.ini.example
@@ -25,7 +25,8 @@ domain=localhost:5080
 # Change this value to something random and secret
 secret-key=hello world
 
-# Set this to the id of a Game that should automatically sync up with CKAN's KSP builds.json
+# Set this to the id of the Game that represents KSP.
+# Its GameVersions will automatically sync up with CKAN's KSP builds.json.
 ksp-game-id=
 
 # Enable offloading of downloads to the reverse proxy server. Make sure the reverse proxy is set up!


### PR DESCRIPTION
## Background

The CKAN team maintains a JSON file with all the known versions of KSP:

- https://github.com/KSP-CKAN/CKAN-meta/raw/master/builds.json

This is generally updated rapidly after a new version of KSP comes out.

## Motivation

Currently SpaceDock needs to be updated separately. I previously suggested automatically syncing them up, and @V1TA5 sounded amenable.

## Changes

Now if you set the config parameter `ksp-game-id` to the ID of your KSP Game, you too can enjoy beautiful automatic version syncing:

![image](https://user-images.githubusercontent.com/1559108/85840715-92746100-b762-11ea-8a0d-04eb43c32b41.png)

A scheduled task runs once an hour that parses CKAN's builds.json file and adds new GameVersions as needed.


