### PR TITLE
Chart downloads per mod version

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -104,6 +104,7 @@ def version_info(mod: Mod, version: ModVersion) -> Dict[str, Any]:
                                  mod_name=mod.name,
                                  version=version.friendly_version),
         "changelog": version.changelog,
+        "downloads": version.download_count,
     }
 
 

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -54,13 +54,16 @@ def _restore_game_info() -> Optional[Game]:
 @mods.route("/random")
 def random_mod() -> werkzeug.wrappers.Response:
     game_id = session.get('gameid')
-    mods = Mod.query.with_entities(Mod.id, Mod.name).filter(Mod.published == True)
+    query = Mod.query.with_entities(Mod.id, Mod.name)\
+        .filter(Mod.published == True)\
+        .order_by(Mod.created)
     if game_id:
-        mods = mods.filter(Mod.game_id == game_id)
-    mods = mods.all()
-    if not mods:
+        query = query.filter(Mod.game_id == game_id)
+    how_many = query.count()
+    if how_many < 1:
         abort(404)
-    mod_id, mod_name = random.choice(mods)
+    which = random.randint(0, how_many - 1)
+    mod_id, mod_name = query.offset(which).first()
     return redirect(url_for("mods.mod", mod_id=mod_id, mod_name=mod_name))
 
 
@@ -132,6 +135,9 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
         .filter(DownloadEvent.created > thirty_days_ago)\
             .order_by(DownloadEvent.created):
         download_stats.append(dumb_object(d))
+    downloads_per_version = [(ver.id, ver.friendly_version, ver.download_count)
+                             for ver
+                             in sorted(mod.versions, key=lambda ver: ver.id)]
     follower_stats = list()
     for f in FollowEvent.query\
         .filter(FollowEvent.mod_id == mod.id)\
@@ -183,6 +189,7 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
                                'owner': owner,
                                'pending_invite': pending_invite,
                                'download_stats': download_stats,
+                               'downloads_per_version': downloads_per_version,
                                'follower_stats': follower_stats,
                                'referrals': referrals,
                                'json_versions': json_versions,
@@ -497,7 +504,7 @@ def download(mod_id: int, mod_name: Optional[str], version: Optional[str]) -> Op
     if not mod_version:
         abort(404)
     download = DownloadEvent.query\
-        .filter(DownloadEvent.mod_id == mod.id and DownloadEvent.version_id == mod_version.id)\
+        .filter(DownloadEvent.mod_id == mod.id, DownloadEvent.version_id == mod_version.id)\
         .order_by(desc(DownloadEvent.created))\
         .first()
     storage = _cfg('storage')
@@ -518,6 +525,7 @@ def download(mod_id: int, mod_name: Optional[str], version: Optional[str]) -> Op
         else:
             download.downloads += 1
         mod.download_count += 1
+        mod_version.download_count += 1
         mod.score = get_mod_score(mod)
 
     cdn_domain = _cfg("cdn-domain")

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -310,15 +310,10 @@ class ModVersion(Base):  # type: ignore
     download_path = Column(String(512))
     changelog = Column(Unicode(10000))
     sort_index = Column(Integer, default=0)
+    download_count = Column(Integer, default=0)
 
     def __repr__(self) -> str:
         return '<Mod Version %r>' % self.id
-
-    def download_count(self) -> int:
-        return sum(evt.downloads for evt
-                   in DownloadEvent.query.filter(
-                       DownloadEvent.version_id == self.id
-                   ).all())
 
 
 class Media(Base):  # type: ignore

--- a/alembic/versions/2020_07_20_19_00_00-73c9d707134b.py
+++ b/alembic/versions/2020_07_20_19_00_00-73c9d707134b.py
@@ -1,0 +1,48 @@
+"""Add ModVersion.download_count
+
+Revision ID: 73c9d707134b
+Revises: 1aa078e0fb7e
+Create Date: 2020-07-20 19:00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '73c9d707134b'
+down_revision = '1aa078e0fb7e'
+
+from datetime import datetime
+from alembic import op
+import sqlalchemy as sa
+
+Base = sa.ext.declarative.declarative_base()
+
+
+class ModVersion(Base):  # type: ignore
+    __tablename__ = 'modversion'
+    id = sa.Column(sa.Integer, primary_key=True)
+    download_count = sa.Column(sa.Integer, default=0)
+
+
+class DownloadEvent(Base):  # type: ignore
+    __tablename__ = 'downloadevent'
+    id = sa.Column(sa.Integer, primary_key=True)
+    version_id = sa.Column(sa.Integer, sa.ForeignKey('modversion.id'))
+    version = sa.orm.relationship('ModVersion',
+                                  backref=sa.orm.backref('downloads', order_by="desc(DownloadEvent.created)"))
+    created = sa.Column(sa.DateTime, default=datetime.now, index=True)
+    downloads = sa.Column(sa.Integer, default=0)
+
+
+def upgrade() -> None:
+    op.add_column('modversion', sa.Column('download_count', sa.Integer()))
+
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+    for mod_version in session.query(ModVersion).all():
+        mod_version.download_count = sum(evt.downloads
+                                         for evt in mod_version.downloads)
+    session.commit()
+
+
+def downgrade() -> None:
+    op.drop_column('modversion', 'download_count')

--- a/frontend/coffee/stats.coffee
+++ b/frontend/coffee/stats.coffee
@@ -2,6 +2,7 @@ window.activateStats = () ->
     worker = new Worker("/static/statworker.js")
     worker.addEventListener('message', (e) ->
         switch e.data.action
+
             when "downloads_ready"
                 new Chart(document.getElementById('downloads-over-time').getContext("2d")).Line({
                     labels : e.data.data.labels,
@@ -22,6 +23,16 @@ window.activateStats = () ->
                     li.appendChild(keyColor)
                     li.appendChild(keyText)
                     keyUI.appendChild(li)
+
+            when "downloads_per_version_ready"
+                new Chart(document.getElementById('downloads-per-version').getContext('2d')).Bar({
+                    labels: e.data.data.labels,
+                    datasets: e.data.data.entries
+                },
+                {
+                    animation: false
+                })
+
             when "followers_ready"
                 new Chart(document.getElementById('followers-over-time').getContext("2d")).Line({
                     labels : e.data.data.labels,
@@ -30,8 +41,10 @@ window.activateStats = () ->
                 {
                     animation: false
                 })
+
     , false)
     worker.postMessage({ action: "set_versions", data: window.versions })
     worker.postMessage({ action: "set_timespan", data: window.thirty_days_ago })
     worker.postMessage({ action: "process_downloads", data: window.download_stats })
+    worker.postMessage({ action: "process_downloads_per_version", data: window.downloads_per_version })
     worker.postMessage({ action: "process_followers", data: window.follower_stats })

--- a/frontend/coffee/statworker.coffee
+++ b/frontend/coffee/statworker.coffee
@@ -17,6 +17,7 @@ self.addEventListener('message', (e) ->
         when "set_versions" then versions = e.data.data
         when "set_timespan" then thirty_days_ago = e.data.data
         when "process_downloads" then processDownloads(e.data.data)
+        when "process_downloads_per_version" then processDownloadsPerVersion(e.data.data)
         when "process_followers" then processFollowers(e.data.data)
 , false)
 
@@ -65,6 +66,19 @@ processDownloads = (download_stats) ->
             key: key,
             entries: entries,
             labels: labels
+        }
+    })
+
+processDownloadsPerVersion = (downloads_per_version) ->
+    postMessage({
+        action: "downloads_per_version_ready",
+        data: {
+            labels: downloads_per_version.map((v) -> v[1]),
+            entries: [ {
+                fillColor: colors[4][0],
+                strokeColor: colors[4][1],
+                data: downloads_per_version.map((v) -> v[2])
+            } ]
         }
     })
 

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -230,7 +230,6 @@
                             </div>
                         </div>
                     </div>
-
                 </div>
             </div>
         </div>
@@ -371,10 +370,12 @@
             <div class="row">
                 <div class="col-md-8">
                     <h3>Downloads over time</h3>
-                        <canvas id="downloads-over-time" class="canvas-chart" width=750 height=300></canvas>
+                        <canvas id="downloads-over-time" class="canvas-chart" width="750" height="300"></canvas>
                     <ul id="downloads-over-time-key" class="chart-key"></ul>
+                    <h3>Downloads per version</h3>
+                        <canvas id="downloads-per-version" class="canvas-chart" width="750" height="300"></canvas>
                     <h3>New followers per day</h3>
-                        <canvas id="followers-over-time" class="canvas-chart" width=750 height=300></canvas>
+                        <canvas id="followers-over-time" class="canvas-chart" width="750" height="300"></canvas>
                     </div>
                     <div class="col-md-4">
                     <h3>Top Referrers</h3>
@@ -568,6 +569,7 @@
             window.editable = false;
         {% endif %}
         window.download_stats = JSON.parse('{{ download_stats | tojson }}');
+        window.downloads_per_version = JSON.parse('{{ downloads_per_version | tojson }}');
         window.follower_stats = JSON.parse('{{ follower_stats | tojson }}');
         window.referrals = JSON.parse('{{ referrals | tojson }}');
         window.versions = JSON.parse('{{ json_versions | tojson }}');


### PR DESCRIPTION
## Motivation

The mod info page currently shows how many downloads each release had on each of the past 30 days, but there is no total count per version. It would be informative to see how a mod's releases have trended over time.

## Changes

Now the mod info page's stats tab shows a bar chart of how many downloads each version has had:

![image](https://user-images.githubusercontent.com/1559108/85902832-8c19cf80-b7ca-11ea-9682-8c0416dbf7de.png)

The counting is done via sqlalchemy magic to minimize data loaded from the db.

Fixes #185.

### Side fix

`/random` is slower than it needs to be because it loads all of the published mods to the client to pick one. Now we just get the count, choose a random index, and ask the db to hand us just that one mod. Should be faster.