### PR TITLE
Add Save & Publish button to edit mod page if not published

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -227,6 +227,8 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
         mod.source_link = source_link
         mod.description = description
         mod.score = get_mod_score(mod)
+        if request.form.get('publish', None):
+            mod.published = True
         if ckan is None:
             ckan = False
         else:

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -37,15 +37,16 @@
     {% endif %}
 
     <div class="container lead">
-        <div class="row vertical-centered">
+        <div class="row">
             <div class="col-md-8">
                 <h1 title="{{ mod.name }}">Edit {{ mod.name }}</h1>
                 <input type="text" class="form-control input-block-level" name="short-description" value="{{ mod.short_description }}" placeholder="Short description..." />
             </div>
-            <div class="col-md-2">
+            <div class="col-md-4">
                 <input type="submit" class="btn btn-primary btn-block" value="Save Changes" />
-            </div>
-            <div class="col-md-2">
+                {%- if not mod.published -%}
+                    <input type="submit" class="btn btn-success btn-block" name="publish" value="Save &amp; Publish" />
+                {%- endif -%}
                 <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}" class="btn btn-default btn-block">Cancel</a>
             </div>
         </div>


### PR DESCRIPTION
## Motivation

I think some users don't realize that mods on SpaceDock have to be "published" to be visible. For example, see KSP-CKAN/NetKAN#7995, which requests CKAN indexing for a mod that as of this writing is not published after 3 days.

## Changes

Now the mod editing page has a new "Save & Publish" button when editing a mod that isn't published, which saves the changes and sets the mod as published. Hopefully people will at least see this button and think about what publishing might mean, and they might even click it!