### PR TITLE
Don't require smtp-user and -password to be set in send_mail()

### DIFF
--- a/KerbalStuff/celery.py
+++ b/KerbalStuff/celery.py
@@ -24,19 +24,16 @@ def send_mail(sender: str, recipients: List[str], subject: str, message: str, im
     host = _cfg('smtp-host')
     if not host:
         return
-    user = _cfg('smtp-user')
-    if not user:
-        return
-    passwd = _cfg('smtp-password')
-    if not passwd:
-        return
     import smtplib
     from email.mime.text import MIMEText
     from email.utils import format_datetime
     smtp = smtplib.SMTP(host=host, port=_cfgi("smtp-port"))
     if _cfgb("smtp-tls"):
         smtp.starttls()
-    if _cfg("smtp-user") != "":
+    user = _cfg('smtp-user')
+    passwd = _cfg('smtp-password')
+    if user and passwd:
+        # If there's a user and no password, let the connection attempt fail hard so that it logs the message.
         smtp.login(user, passwd)
     msg = MIMEText(message)
     if important:


### PR DESCRIPTION
## !!! HAS TO BE MERGED TO BETA BEFORE PRODUCTION DEPLOYMENT !!!
## Problem
With #270 the behaviour of `celery.send_mail()` has been altered.
It requires `smtp-user` and `smtp-password` to be set in the `config.ini`, otherwise it returns without doing anything.
Before they were optional, and if present, used to log in into the mail server.

They shouldn't be necessary, sometimes mail server setup don't need explicit login to send a mail, this is also the case with SpaceDock alpha + beta + production. The mail server authenticates by whitelisted internal IP ranges.

## Changes
Make both config options optional again.
Only if both are set we try to log in, otherwise we let the function continue without logging in.
This means that if the user is set but password isn't, we let the connection attempt fail hard so that it hopefully appears in the logs.