### PR TITLE
Run db.commit() before calculating mod.score in update_mod()

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -28,7 +28,7 @@ from .blueprints.mods import mods
 from .blueprints.profile import profiles
 from .celery import update_from_github
 from .common import firstparagraph, remainingparagraphs, json_output, json_response, wrap_mod, dumb_object
-from .config import _cfg, _cfgb, _cfgd, _cfgi
+from .config import _cfg, _cfgb, _cfgd, _cfgi, site_logger
 from .custom_json import CustomJSONEncoder
 from .database import db
 from .helpers import is_admin, following_mod, following_user
@@ -77,6 +77,7 @@ if not app.debug:
     # https://flask.palletsprojects.com/en/1.1.x/errorhandling/#unhandled-exceptions
     @app.errorhandler(Exception)
     def handle_generic_exception(e: Exception) -> Union[Tuple[str, int], werkzeug.wrappers.Response]:
+        site_logger.exception(e)
         # shit
         try:
             db.rollback()

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -735,6 +735,7 @@ def update_mod(mod_id: int) -> Union[Dict[str, Any], Tuple[Dict[str, Any], int]]
     version.mod = mod
     mod.default_version = version
     mod.updated = datetime.now()
+    db.commit()
     mod.score = get_mod_score(mod)
     db.commit()
     if notify in TRUE_STR:

--- a/spacedock
+++ b/spacedock
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import sys
 


### PR DESCRIPTION
## !!! HAS TO BE MERGED TO BETA BEFORE PRODUCTION DEPLOYMENT !!!
## Problem
```
Traceback (most recent call last):
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/common.py", line 81, in go
    ret = f(*args, **kwargs)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/common.py", line 124, in wrapper
    result = f(*args, **kwargs)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/blueprints/api.py", line 152, in wrapper
    return func(*args, **kwargs)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/blueprints/api.py", line 738, in update_mod
    mod.score = get_mod_score(mod)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/search.py", line 39, in get_mod_score
    num_incompat = versions_behind(mod)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/search.py", line 48, in versions_behind
    compat = version.Version(mod.default_version.gameversion.friendly_version)
AttributeError: 'NoneType' object has no attribute 'friendly_version'
```
Relationships get populated after committing to the db.
With #287 we try to access a relationship of newly created mod versions, `ModVersion.gameversion`, before calling `db.commit()` in `api.update_mod()`.

## Solution
Insert a `db.commit()` before calculation `mod.score` in `api.update_mod()`.
Also since #284 exceptions aren't logged to syslog anymore since they are catched explicitly. I restored it by adding `site_logger.exception(e)` in the exception handler.
Also as discussed on Discord, the shebang of `spacedock` is changed to `#!/usr/bin/env python3`. This will execute the correct Python executable when running the script with `./spacedock` as long as the venv is activated. (`source bin/activate` is still needed!).