### PR TITLE
Announcements and blog fixes

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -27,17 +27,16 @@ from .blueprints.login_oauth import list_defined_oauths, login_oauth
 from .blueprints.mods import mods
 from .blueprints.profile import profiles
 from .celery import update_from_github
-from .common import firstparagraph, remainingparagraphs, json_output, json_response, wrap_mod, dumb_object
+from .common import first_paragraphs, many_paragraphs, json_output, json_response, wrap_mod, dumb_object
 from .config import _cfg, _cfgb, _cfgd, _cfgi, site_logger
 from .custom_json import CustomJSONEncoder
 from .database import db
 from .helpers import is_admin, following_mod, following_user
 from .kerbdown import KerbDown
-from .objects import User
+from .objects import User, BlogPost
 
 app = Flask(__name__, template_folder='../templates')
-app.jinja_env.filters['firstparagraph'] = firstparagraph
-app.jinja_env.filters['remainingparagraphs'] = remainingparagraphs
+app.jinja_env.filters['first_paragraphs'] = first_paragraphs
 app.secret_key = _cfg("secret-key")
 app.jinja_env.cache = None
 app.json_encoder = CustomJSONEncoder
@@ -223,6 +222,8 @@ def inject() -> Dict[str, Any]:
     if request.cookies.get('dismissed_donation') is not None:
         dismissed_donation = True
     return {
+        'announcements': BlogPost.query.filter(BlogPost.announcement == True).order_by(BlogPost.created.desc()).all(),
+        'many_paragraphs': many_paragraphs,
         'mobile': False,
         'ua_platform': getattr(request.user_agent, 'platform', None),
         'analytics_id': _cfg("google_analytics_id"),

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -2,6 +2,7 @@ import json
 import math
 import urllib.parse
 import os
+import re
 from functools import wraps
 from typing import Union, List, Dict, Any, Optional, Callable, Tuple, Iterable
 
@@ -17,30 +18,15 @@ from .objects import Game, Mod
 from .search import search_mods
 
 TRUE_STR = ('true', 'yes', 'on')
+PARAGRAPH_PATTERN = re.compile('\n\n|\r\n\r\n')
 
 
-def firstparagraph(text: str) -> str:
-    try:
-        para = text.index("\n\n")
-        return text[:para + 2]
-    except:
-        try:
-            para = text.index("\r\n\r\n")
-            return text[:para + 4]
-        except:
-            return text
+def first_paragraphs(text: str) -> str:
+    return '\n\n'.join(PARAGRAPH_PATTERN.split(text)[0:3])
 
 
-def remainingparagraphs(text: str) -> str:
-    try:
-        para = text.index("\n\n")
-        return text[para + 2:]
-    except:
-        try:
-            para = text.index("\r\n\r\n")
-            return text[para + 4:]
-        except:
-            return ""
+def many_paragraphs(text:str) -> bool:
+    return len(PARAGRAPH_PATTERN.split(text)) > 3
 
 
 def dumb_object(model):  # type: ignore

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -32,6 +32,7 @@ class BlogPost(Base):  # type: ignore
     id = Column(Integer, primary_key=True)
     title = Column(Unicode(1024))
     text = Column(Unicode(65535))
+    announcement = Column(Boolean(), index=True, nullable=True, default=False)
     created = Column(DateTime, default=datetime.now, index=True)
 
     def __repr__(self) -> str:

--- a/alembic/versions/2020_06_29_11_37_00-544564b4e738.py
+++ b/alembic/versions/2020_06_29_11_37_00-544564b4e738.py
@@ -1,0 +1,24 @@
+"""Add announcement to blog
+
+Revision ID: 544564b4e738
+Revises: 85be165bc5dc
+Create Date: 2020-06-29 11:37:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '544564b4e738'
+down_revision = '85be165bc5dc'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.add_column('blog', sa.Column('announcement', sa.Boolean(), nullable=True, default=False))
+    op.create_index(op.f('ix_blog_announcement'), 'blog', ['announcement'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_blog_announcement'), table_name='blog')
+    op.drop_column('blog', 'announcement')

--- a/frontend/styles/stylesheet.scss
+++ b/frontend/styles/stylesheet.scss
@@ -155,5 +155,10 @@ footer {
     }
 }
 
+.CodeMirror {
+    background-color: #fff;
+    color: #000;
+}
+
 @import "typeahead";
 @import "navigation";

--- a/templates/admin-blog.html
+++ b/templates/admin-blog.html
@@ -12,6 +12,12 @@
                 <label for="post-body">Body <small class="text-muted"><a target="_blank" href="/markdown">Markdown</a> supported</small></label>
                 <textarea name="post-body" id="post-body" class="form-control input-block-level" rows=10></textarea>
             </div>
+            <div class="checkbox">
+                <label>
+                    <input id="announcement" name="announcement" type="checkbox">
+                    Global announcement at top of all pages
+                </label>
+            </div>
             <input type="submit" class="btn btn-primary btn-block" value="Publish">
         </form>
     </div>

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -6,12 +6,23 @@
 <link rel="stylesheet" type="text/css" href="/static/stylesheet.css" />
 {% endblock %}
 {% block body %}
+<div class="row">
+    <a href="/blog">
+        <span class="glyphicon glyphicon-chevron-left"></span>
+        Back to {{site_name}} Blog
+    </a>
+</div>
 <div class="container">
-    <h1>{{ post.title }}{% if admin %}
+    <h1>{{ post.title }} <small>{{ post.created.strftime("%Y-%m-%d") }}</small> {% if admin %}
         <a href="/blog/{{ post.id }}/edit" class="btn btn-default btn-wide">Edit</a>
-        <button class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete">Delete</button>{% endif %}</h1>
-    {{ post.text | markdown }}
-    {% include 'disqus.html' %}
+        <button class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete">Delete</button>{% endif %}
+    </h1>
+    <div class="well">
+        {{ post.text | markdown }}
+    </div>
+    {%- if disqus_id %}
+        {% include 'disqus.html' %}
+    {%- endif %}
     {% if admin %}
     <div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
         <div class="modal-dialog">
@@ -33,5 +44,11 @@
         </div>
     </div>
     {% endif %}
+</div>
+<div class="row">
+    <a href="/blog">
+        <span class="glyphicon glyphicon-chevron-left"></span>
+        Back to {{site_name}} Blog
+    </a>
 </div>
 {% endblock %}

--- a/templates/blog_index.html
+++ b/templates/blog_index.html
@@ -6,16 +6,65 @@
 <link rel="stylesheet" type="text/css" href="/static/stylesheet.css" />
 {% endblock %}
 {% block body %}
-<div class="well">
-    <div class="container">
-        <h1>{{ site_name }} Blog</h1>
+<div class="container lead">
+    <div class="row vertical-centered">
+        <div class="col-md-8">
+            <h1>{{ site_name }} Blog</h1>
+        </div>
+        {% if admin %}
+            <div class="col-md-4">
+                <a class="btn btn-primary btn-block " href="{{ url_for("admin.blog") }}">New Blog Post</a>
+            </div>
+        {% endif %}
     </div>
 </div>
 <div class="container">
-{% for post in posts %}
-    <h3>{{ post.title }} <small>{{ post.created.strftime("%Y-%m-%d") }}</small></h3>
-    {{ post.text | firstparagraph | markdown }}
-    <p><a href="/blog/{{ post.id }}">Read more, leave a comment, etc <span class="glyphicon glyphicon-chevron-right"></span></a></p>
-{% endfor %}
+    {%- for post in posts -%}
+        <div class="well">
+            <div class="row vertical-centered">
+                <div class="col-md-10">
+                    <h2>{{ post.title }} <small>{{ post.created.strftime("%Y-%m-%d") }}</small></h2>
+                </div>
+                {% if admin %}
+                    <div class="col-md-2">
+                        <a href="/blog/{{ post.id }}/edit" class="btn btn-default btn-block">Edit</a>
+                    </div>
+                    <div class="col-md-2">
+                        <button class="btn btn-danger btn-block" data-toggle="modal" data-target="#confirm-delete-{{post.id}}">Delete</button>
+                    </div>
+                {% endif %}
+            </div>
+            <div class="container">
+                {{ post.text | first_paragraphs | markdown }}
+            </div>
+            {% if many_paragraphs(post.text) %}
+                <div class="container">
+                    <div class="badge">⋯</div>
+                </div>
+            {% endif %}
+            <p><a href="/blog/{{ post.id }}">Read more{% if disqus_id %}, leave a comment, etc.{% endif %}<span class="glyphicon glyphicon-chevron-right"></span></a></p>
+        </div>
+        {% if admin %}
+        <div class="modal fade" id="confirm-delete-{{post.id}}" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title">Confirm Deletion</h4>
+                    </div>
+                    <div class="modal-body">
+                        This action cannot be undone. Are you sure?
+                    </div>
+                    <div class="modal-footer">
+                        <form action="/blog/{{ post.id }}/delete" method="POST">
+                            <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                            <input type="submit" class="btn btn-danger" value="Delete">
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    {%- endfor -%}
 </div>
 {% endblock %}

--- a/templates/edit_blog.html
+++ b/templates/edit_blog.html
@@ -1,13 +1,18 @@
 {% extends "layout.html" %}
 {% block editorjs %}
 {% endblock %}
+{% block title %}
+<title>Edit Blog Post on {{ site_name }}</title>
+{% endblock %}
 {% block styles %}
     <link rel="stylesheet" type="text/css" href="/static/stylesheet.css"/>
     <link rel="stylesheet" type="text/css" href="/static/editor.css"/>
 {% endblock %}
 {% block body %}
-<div class="container">
-    <h3>Edit Post</h3>
+<div class="container lead">
+    <h1>Edit Blog Post</h1>
+</div>
+<div class="well">
     <form role="form" action="/blog/{{ post.id }}/edit" method="POST">
         <div class="form-group">
             <label for="post-title">Title</label>
@@ -18,11 +23,29 @@
         <link rel="stylesheet" href="/static/editor.css">
             <textarea name="post-body" id="post-body" class="form-control input-block-level" rows=10>{{ post.text }}</textarea>
         </div>
-        <input type="submit" class="btn btn-primary btn-block" value="Save">
+        <div class="checkbox">
+            <label>
+                <input id="announcement" name="announcement" type="checkbox"
+                    {%- if post.announcement %} checked{% endif -%} >
+                Global announcement at top of all pages
+            </label>
+        </div>
+        <div class="row">
+            <div class="col-md-6">
+                <input type="submit" class="btn btn-primary btn-block" value="Save">
+            </div>
+            <div class="col-md-6">
+                <a class="btn btn-default btn-block" href="/blog/{{ post.id }}">Cancel</a>
+            </div>
+        </div>
     </form>
 </div>
 {% endblock %}
 {% block scripts %}
     <script src="/static/editor.js"></script>
     <script src="/static/marked.js"></script>
+    <script type="text/javascript">
+        editor = new Editor();
+        editor.render();
+    </script>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -157,6 +157,16 @@
             </div>
         </nav>
         {% endblock %}
+        {%- if announcements %}
+            <div class="container">
+                {%- for announcement in announcements %}
+                    <div class="well alert alert-danger" style="padding:0.5em 1em;">
+                        <h1>{{ announcement.title }} <small>{{ announcement.created.strftime("%Y-%m-%d %H:%M") }}</small></h1>
+                        <div class="">{{ announcement.text | markdown }}</div>
+                    </div>
+                {%- endfor %}
+            </div>
+        {%- endif %}
         <div class="alert alert-info alert-dismissable alert-fixed hidden" id="alert-follow">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             <strong>Done!</strong> You'll get emailed updates for this mod.


### PR DESCRIPTION
## Motivation

When SpaceDock has a planned downtime, it's a struggle to notify users ahead of time. The only place that all SpaceDock users go is SpaceDock itself (unless you count CKAN users who don't even do that), but currently it has no ability to display such notifications.

## Changes

Now a new "Global announcement at top of all pages" checkbox appears when creating or editing a blog post. If checked, a new `BlogPost.announcement` column is set to true. All blog posts with that column set to true are pulled in to (Markdown-enabled) banners across the top of every page. To make sure this is fast, the new column is indexed.

![image](https://user-images.githubusercontent.com/1559108/86045168-cecce900-ba10-11ea-8a57-4f3e0a667c84.png)

To remove an announcement, the admin can edit the blog post and uncheck the checkbox.

This pull request also attempts to make the blog somewhat usable.

Problems | Changes
:-- | :--
The blog listing only shows the first paragraph of each post, which is extremely short and not enough information to decide whether to read the rest | Now the first three paragraphs are shown
When the blog listing truncates a post, there is no indication whether there is more text | Now an ellipsis badge appears if the post has been truncated
The blog listing is pretty minimal and not too easy on the eyes | Now the top heading and post titles are more prominent, and each post is put inside its own gray box
The individual blog post view is also not very pretty | Now the post text goes in a nice gray box, and there's a new "Back to SpaceDock.info Blog" link at the bottom
The blog backend uses `BlogPost.query.filter(BlogPost.id == id).first()` to load a record | Now it uses `BlogPost.query.get(id)` instead
If you delete a blog post, you get booted out to the main index page | Now you go to the blog listing
A blog post's creation timestamp is shown in the listing but not in the individual post view | Now it's shown in both
If you set `disqus_id` in config.ini, Disqus functionality is enabled. If you _don't_ set it, the links are still there but they don't work. | Now if the `disqus_id` setting isn't set, the Disqus functionality is not shown (including the "leave a comment, etc" blurb). This fixes #241.
To create, edit, or delete a blog post, the admin has to navigate to the admin pages or open an individual blog post | Now the blog listing gives admins new buttons for New Blog Post, Edit, and Delete
The blog post editing page has no HTML title set | Now it's "Edit Blog Post on Spacedock.info", and the in-page header is changed from Edit Post to Edit Blog Post
The blog post editing page has a Save button but no Cancel button. If you make some changes and decide you don't want to save them, you have to use your browser's back button or otherwise navigate away. | Now there's a Cancel button