### PR TITLE
Zero score for mods without default versions

### DIFF
--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -20,6 +20,8 @@ def get_mod_score(mod: Mod) -> int:
     # Mods get points for being open source
     # New mods are given a hefty bonus to avoid drowning among established mods
     score = 0
+    if mod.default_version is None:
+        return score
     score += mod.follower_count * 10
     score += mod.download_count
     score += len(mod.versions) // 5

--- a/alembic/versions/2020_06_23_17_49_36-85be165bc5dc.py
+++ b/alembic/versions/2020_06_23_17_49_36-85be165bc5dc.py
@@ -81,6 +81,8 @@ def versions_behind(mod: Mod) -> int:
 
 def get_mod_score(mod: Mod) -> int:
     score = 0
+    if mod.default_version is None:
+        return score
     score += mod.follower_count * 10
     score += mod.download_count
     score += len(mod.versions) // 5


### PR DESCRIPTION
## Problem

```
(SpaceDock) root@sd1a:/var/www/virtual/spacedock.info/htdocs/SpaceDock# python3 spacedock database migrate
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 77f76102f99c -> 7993492be4eb, Add locked, lock_reason, locked_by and locked_by_id to mod
INFO  [alembic.runtime.migration] Running upgrade 7993492be4eb -> d6f41a805840, Index columns passed to .order_by()
INFO  [alembic.runtime.migration] Running upgrade d6f41a805840 -> 85be165bc5dc, Add Mod.score
Traceback (most recent call last):
  File "spacedock", line 216, in <module>
    cli()
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "spacedock", line 79, in migrate_database
    command.upgrade(cfg, 'head')
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/alembic/command.py", line 298, in upgrade
    script.run_env()
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/alembic/script/base.py", line 489, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 98, in load_python_file
    module = load_module_py(module_id, path)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/alembic/util/compat.py", line 184, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "alembic/env.py", line 71, in <module>
    run_migrations_online()
  File "alembic/env.py", line 63, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/alembic/runtime/environment.py", line 846, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/alembic/runtime/migration.py", line 520, in run_migrations
    step.migration_fn(**kw)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/alembic/versions/2020_06_23_17_49_36-85be165bc5dc.py", line 87, in upgrade
    mod.score = get_mod_score(mod)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/search.py", line 39, in get_mod_score
    num_incompat = versions_behind(mod)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/search.py", line 48, in versions_behind
    compat = version.Version(mod.default_version.gameversion.friendly_version)
AttributeError: 'NoneType' object has no attribute 'gameversion'
```

## Cause

Some mods in prod don't have default versions.

## Changes

Now if `mod.default_version` is None, we just return 0 for the score.