### PR TITLE
Don't join mod_search to ModVersions

### DIFF
--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -53,7 +53,7 @@ def versions_behind(mod: Mod) -> int:
 
 def search_mods(ga: Optional[Game], text: str, page: int, limit: int) -> Tuple[List[Mod], int]:
     terms = text.split(' ')
-    query = db.query(Mod).join(Mod.user).join(Mod.versions).join(Mod.game)
+    query = db.query(Mod).join(Mod.user).join(Mod.game)
     if ga:
         query = query.filter(Mod.game_id == ga.id)
     query = query.filter(Mod.published == True)


### PR DESCRIPTION
## Problem

`/kerbal-space-program/browse/top` only returns Scatterer in @V1TA5's test instance, and you can jump to subsequent pages to get 1, 2, or 3 other mods where there should be 30 per page.

## Cause

The query in `search_mods` is returning many many duplicates, because `.join(Mod.versions)` makes it return one entry per ModVersion. Scatterer has lots of releases, so it takes up a whole page, and so on for other mods with long histories.

## Changes

Now we don't join to Mod.versions anymore. Each entry will represent one mod. This will properly populate the search results.