### PR TITLE
Remove download count from mod version api again

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -104,7 +104,6 @@ def version_info(mod: Mod, version: ModVersion) -> Dict[str, Any]:
                                  mod_name=mod.name,
                                  version=version.friendly_version),
         "changelog": version.changelog,
-        "downloads": version.download_count(),
     }
 
 

--- a/tests/test_api_mod.py
+++ b/tests/test_api_mod.py
@@ -118,7 +118,6 @@ def check_mod(mod_json: Dict[str, Any]) -> None:
     assert mod_json['short_description'] == 'A mod for testing', 'Short description should match'
     assert mod_json['author'] == 'TestModAuthor', 'Author should match'
     assert mod_json['license'] == 'MIT', 'License should match'
-    assert mod_json['downloads'] == 0, 'Should have no downloads'
     assert mod_json['followers'] == 0, 'Should have no followers'
     assert mod_json['versions'][0]['friendly_version'] == '1.0.0.0', 'Version should match'
     assert mod_json['versions'][0]['game_version'] == '1.2.3', 'Game version should match'
@@ -128,7 +127,6 @@ def check_mod_version(mod_version_json: Dict[str, Any]) -> None:
     assert mod_version_json['friendly_version'] == '1.0.0.0', 'Version should match'
     assert mod_version_json['game_version'] == '1.2.3', 'Game version should match'
     assert mod_version_json['download_path'] == '/mod/1/Test%20Mod/download/1.0.0.0', 'Download should match'
-    assert mod_version_json['downloads'] == 0, 'Not downloaded yet'
 
 
 def check_user(user_json: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Problem
After the production upgrade the API has gotten really slow wherever it returns mod info.
Additionally we experience the whole site slowing down over time. VITAS reported the db being the cause of the slowdown.
I suspect it is a result of #286.

## Change
Remove the `"downloads": version.download_count()` line again, hoping it mitigates the problem for now and gives us time to re-implement it less db-hungry.