### PR TITLE
Thumbnail image creation fixes

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -190,8 +190,8 @@ def _update_image(old_path: str, base_name: str, base_path: str) -> Optional[str
     storage = _cfg('storage')
     if not storage:
         return None
-    file_type = os.path.splitext(os.path.basename(f.filename))[1]
-    if file_type not in ('.png', '.jpg'):
+    file_type = os.path.splitext(os.path.basename(f.filename))[1].lower()
+    if file_type not in ('.png', '.jpg', '.jpeg'):
         abort(json_response({'error': True, 'reason': 'This file type is not acceptable.'}, 400))
     filename = base_name + file_type
     full_path = os.path.join(storage, base_path)

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -180,28 +180,7 @@ class Mod(Base):  # type: ignore
     ckan = Column(Boolean)
 
     def background_thumb(self) -> str:
-        thsz = _cfg('thumbnail_size')
-        storage = _cfg('storage')
-        if not thsz or not storage:
-            return self.background
-        thumbnail_sizes_str = thsz.split('x')
-        thumbnail_size = (int(thumbnail_sizes_str[0]), int(thumbnail_sizes_str[1]))
-        split = os.path.split(self.background)
-        thumb_path = os.path.join(split[0], 'thumb_' + split[1])
-        full_thumb_path = os.path.join(
-            os.path.join(storage, thumb_path.replace('/content/', '')))
-        full_image_path = os.path.join(storage, self.background.replace('/content/', ''))
-        if not os.path.isfile(full_thumb_path):
-            try:
-                thumbnail.create(full_image_path, full_thumb_path, thumbnail_size)
-            except Exception:
-                site_logger.exception('Unable to create thumbnail')
-                try:
-                    os.remove(full_image_path)
-                except:
-                    pass
-                return self.background
-        return thumb_path
+        return thumbnail.get_or_create(self.background)
 
     def __repr__(self) -> str:
         return '<Mod %r %r>' % (self.id, self.name)

--- a/KerbalStuff/thumbnail.py
+++ b/KerbalStuff/thumbnail.py
@@ -1,12 +1,73 @@
 import os.path
-from typing import Tuple
 
 from PIL import Image
 
+from KerbalStuff.config import _cfg, _cfgi, site_logger
 
-def create(imagePath: str, thumbnailPath: str, thumbnailSize: Tuple[int, int]) -> None:
-    if not os.path.isfile(imagePath):
+
+def create(background_path: str, thumbnail_path: str) -> None:
+    if not os.path.isfile(background_path):
         return
-    im = Image.open(imagePath)
-    im.thumbnail(thumbnailSize, Image.ANTIALIAS)
-    im.save(thumbnailPath, 'jpeg', quality=50, optimize=True)
+
+    size_str = _cfg('thumbnail_size')
+    if not size_str:
+        size_str = "320x195"
+    size_str_tuple = size_str.split('x')
+    size = (int(size_str_tuple[0]), int(size_str_tuple[1]))
+
+    quality = _cfgi('thumbnail_quality')
+    # Docs say the quality shouldn't be above 95:
+    # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg
+    if not quality or not (0 <= quality <= 95):
+        quality = 80
+
+    im = Image.open(background_path)
+
+    # We want to resize the image to the desired size in the least costly way,
+    # while not distorting it. This means we first check which side needs _less_ rescaling to reach
+    # the target size. After that we scale it down while keeping the original aspect ratio.
+    x_ratio = abs(im.width/size[0])
+    y_ratio = abs(im.height/size[1])
+
+    if x_ratio < y_ratio:
+        im = im.resize((size[0], round(im.height/x_ratio)), Image.LANCZOS)
+    else:
+        im = im.resize((round(im.width/y_ratio), size[1]), Image.LANCZOS)
+
+    # Now there's one pair of edges that already has the target length (height or width).
+    # Next step is cropping the thumbnail out of the center of the down-scaled base image,
+    # to also downsize the other edge pair without distorting the image.
+    # We basically define the upper left and the lower right corner of the area to crop out here,
+    # but we have to serve them separately (better: in one 4-tuple) to im.crop():
+    # https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.crop
+    box_left = round(0.5 * (im.width - size[0]))
+    box_upper = round(0.5 * (im.height - size[1]))
+    box_right = round(0.5 * (im.width + size[0]))
+    box_lower = round(0.5 * (im.height + size[1]))
+    im = im.crop((box_left, box_upper, box_right, box_lower))
+
+    if im.mode != "RGB":
+        im = im.convert("RGB")
+    im.save(thumbnail_path, 'jpeg', quality=quality, optimize=True)
+
+
+def get_or_create(background_url: str) -> str:
+    storage = _cfg('storage')
+    if not storage:
+        return background_url
+
+    (background_directory, background_file_name) = os.path.split(background_url)
+
+    thumb_file_name = os.path.splitext(background_file_name)[0] + '.jpg'
+    thumb_url = os.path.join(background_directory, 'thumb_' + thumb_file_name)
+
+    thumb_disk_path = os.path.join(storage, thumb_url.replace('/content/', ''))
+    background_disk_path = os.path.join(storage, background_url.replace('/content/', ''))
+
+    if not os.path.isfile(thumb_disk_path):
+        try:
+            create(background_disk_path, thumb_disk_path)
+        except Exception as e:
+            site_logger.exception(e)
+            return background_url
+    return thumb_url

--- a/config.ini.example
+++ b/config.ini.example
@@ -87,8 +87,12 @@ google_analytics_domain=
 # Blog comments
 disqus_id=
 
-# Thumbnail size in WxH format, leave blank to disable screenshots
-thumbnail_size=320x320
+# Thumbnail size in WxH format. Defaults to 320x195 if not set.
+# The better it matches the aspect ratio as it is displayed in the mod box, the better the quality.
+# It's somewhere between 16:9 and 16:10, but changes a bit based on client screen size.
+thumbnail_size=320x195
+# Thumbnail quality, between 0 and 100. Defaults to 80 if not set.
+thumbnail_quality=80
 
 # URL to notify of mod creation
 create-url=


### PR DESCRIPTION
# Problems
1) Thumbnail images are generated as JPEG but saved under whichever file extension the source background image has. So there are thumbnails with `.png` which are actually JPEGs.
2) Thumbnail creation for background images with alpha channel fails:
```
OSError: cannot write mode RGBA as JPEG 
```
3) When the thumbnail creation fails, we also delete the source background. This leads to strange behaviours combined with the caching traffic server, where images seem to magically remove themselves after a varying timespan.
4) VITAS wants the quality of thumbnails to be configurable.
5) Uploads of background images with the extension `.jpeg` are not allowed, only `.jpg` and `.png`.

# Changes
1) Thumbnails are now explicitly saved with `.jpg`
2) If the source image has a alpha channel we convert the thumbnail to RGB.
3) Background images are no longer deleted if thumbnail generation fails.
4) There's a new config option `thumbnail_quality`.
5) Background images with `.jpeg` are now allowed too.
6) PIL's `im.thumbnail()` is replaced by custom code. `thumbnail()` took the target size as upper limit, so images having a ratio suitable for the background had a very poor resolution (height ~80px) as thumbnail. The new logic ensures that the image always has the exact dimensions as set in the config.

Note that a lot of this code is likely to be removed/changed again when we split backgrounds and thumbnails into separate uploadable images in the future.
Since this was a rather quick fix and the the above feature may take some time until it will be implemented, I decided to do it nevertheless.


Fixes #308 
Fixes #309