### PR TITLE
Purge ATS cache upon deletion

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -2,6 +2,7 @@ import os
 import random
 from datetime import datetime, timedelta
 from shutil import rmtree
+from socket import socket
 from typing import Any, Dict, Tuple, Optional, Union
 
 import dns.resolver
@@ -581,7 +582,7 @@ def delete_version(mod_id: int, version_id: str) -> werkzeug.wrappers.Response:
     return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name, ga=game))
 
 
-def create_connection_cdn_purge(address, *args, **kwargs):
+def create_connection_cdn_purge(address: Tuple[str, Union[str, int, None]], *args: str, **kwargs: int) -> socket:
     # Taken from https://stackoverflow.com/a/22614367
     host, port = address
 

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -5,6 +5,7 @@ from shutil import rmtree
 from urllib.parse import urlparse, quote_plus
 from typing import Union, Dict, Any
 import werkzeug.wrappers
+import requests
 
 from flask import Blueprint, render_template, send_file, make_response, url_for, abort, session, \
     redirect, request
@@ -557,6 +558,7 @@ def delete_version(mod_id: int, version_id: str) -> werkzeug.wrappers.Response:
         abort(404)
     if version[0].id == mod.default_version_id:
         abort(400)
+    requests.request('PURGE', f'https://127.0.0.1/{version[0].download_path}')
     db.delete(version[0])
     mod.versions = [v for v in mod.versions if v.id != int(version_id)]
     db.commit()

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -587,7 +587,8 @@ def create_connection_cdn_purge(address: Tuple[str, Union[str, int, None]], *arg
     host, port = address
 
     cdn_internal = _cfg('cdn-internal')
-    if cdn_internal:
+    cdn_domain = _cfg('cdn-domain')
+    if cdn_internal and cdn_domain and cdn_domain.startswith(host):
         result = dns.resolver.resolve(cdn_internal)
         host = result[0].to_text()
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -59,8 +59,11 @@ redis-connection=redis://redis:6379/0
 # Absolute path to the directory you want to store mods in
 storage=/opt/spacedock/storage
 
-# Redirect downloads to a CDN.
+# Redirect downloads to a CDN. Can also contain a partial path, without trailing slash.
 cdn-domain=
+# The internal hostname of the CDN / a reverse proxy in front of this server that caches mod files.
+# If set, the backend will send a PURGE request when a mod version gets deleted to clear it from the cache.
+cdn-internal=
 
 # Set hook_secret and your GitHub web hook's secret to the same value to authenticate hooks
 # to trigger automatic redeployment.

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -2,6 +2,7 @@ alembic
 bcrypt
 celery
 click
+dnspython
 flask
 flask-login
 flask-markdown
@@ -21,4 +22,5 @@ requests
 requests-oauthlib==0.8.0
 sqlalchemy
 sqlalchemy_utils
+urllib3
 werkzeug==0.16.1


### PR DESCRIPTION
## Problem

See #312, when a mod author deletes a release, it continues to be served at the same URL for some time.

## Cause

The Apache Traffic Server caches downloads, and it doesn't know when they've been deleted.

## Changes

Now we issue a `PURGE` request to the host set in the `cdn-internal` setting in `config.ini` when we delete a mod version, to tell ATS to remove that URL from its cache:

- https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/storage/index.en.html#removing-an-object-from-the-cache

This is not a standard HTTP verb, so we have to use the syntax for custom verbs:

- https://requests.readthedocs.io/en/master/user/advanced/#http-verbs

Fixes #312.