### PR TITLE
Render markdown-formatted modpack descriptions; other fixes and updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7 as backend-dev
+FROM python:3.8 as backend-dev
 ENV PYTHONUNBUFFERED=1
 RUN useradd -m -d /opt/spacedock -s /bin/bash spacedock
 RUN pip3 install --upgrade pip setuptools wheel pip-licenses

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -19,7 +19,7 @@ from .accounts import check_password_criteria
 from ..ckan import send_to_ckan, notify_ckan
 from ..common import json_output, paginate_mods, with_session, get_mods, json_response, \
     check_mod_editable, set_game_info, TRUE_STR, get_page
-from ..config import _cfg
+from ..config import _cfg, site_logger
 from ..database import db
 from ..email import send_update_notification, send_grant_notice, send_password_changed
 from ..objects import GameVersion, Game, Publisher, Mod, Featured, User, ModVersion, SharedAuthor, \
@@ -725,7 +725,8 @@ def update_mod(mod_id: int) -> Union[Dict[str, Any], Tuple[Dict[str, Any], int]]
     # Save zipball
     try:
         (full_path, relative_path) = _save_mod_zipball(mod.name, friendly_version, zipball)
-    except IOError:
+    except IOError as e:
+        site_logger.exception(e)
         return {'error': True, 'reason': 'Failed to save zip file.'}, 500
     if not zipfile.is_zipfile(full_path):
         return {'error': True, 'reason': 'This is not a valid zip file.'}, 400

--- a/README.md
+++ b/README.md
@@ -8,26 +8,24 @@ https://spacedock.info
 
 Quick overview:
 
-1. Install Python3 and Python3-dev, node.js, virtualenv, PostgreSQL
-2. Set up aforementioned things
-3. Clone SpaceDock repository
-4. Activate the virtualenv
-5. Install pip requirements
-6. Install coffeescript
-7. Configure SpaceDock
-8. SQL
-9. Site configuration
+1. Install and set up the dependencies
+2. Clone SpaceDock repository
+3. Activate the virtualenv
+4. Install pip requirements
+5. Install coffeescript
+6. Configure SpaceDock
+7. SQL
+8. Site configuration
 
 **Install the dependencies**
 
 You'll need these things:
+(Names taken from Ubuntu's package repository)
 
-* Python3
-* Python3-dev, for uwsgi
-* Node.js
-* virtualenv
-* PostgreSQL
-* Redis
+* python3, python3-dev for uwsgi, python3-pip, python3-virtualenv
+* nodejs, npm
+* postgresql (or postgresql-client if the database is on another server)
+* redis-tools
 
 Use the packages your OS provides, or build them from source.
 
@@ -75,7 +73,7 @@ Find a place you want the code to live.
 
 **Activate virtualenv**
 
-    $ virtualenv -p python3 --no-site-packages .
+    $ virtualenv -p python3 .
     $ source bin/activate
 
 If you're like me and are on a system where `python3` is not the name of your

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ ADD build.js ./
 RUN npm run build
 
 # Stage 2 - the environment
-FROM nginx:1.17
+FROM nginx:stable
 WORKDIR /var/www/static
 ADD static/css/ ./
 ADD static/js/ ./

--- a/templates/pack-box.html
+++ b/templates/pack-box.html
@@ -15,7 +15,7 @@
             </h2>
             <p style="max-height: 75px; overflow: hidden;">
                 {% if list.description %}
-                    {{ list.description }}
+                    {{ list.description | markdown }}
                 {% endif %}
             </p>
         </div>


### PR DESCRIPTION
## Changes
Some smaller fixes and updates:

* Render markdown-formatted modpack descriptions (spotted by @HebaruSan)
* Log exceptions to syslog when mod zips can't be saved
* Update README.md for the server setup steps according to what I had to do for re-setup alpha + beta
* Update backend Docker image to Python3.8 which we are also using in prod + alpha + beta
* Update frontend Docker image to nginx:latest since 1.17 is a bit old by now, and I think it does no harm to automatically stay up-to-date in development setups.