### PR TITLE
[WIP] Add cascade delete constraints, allow users to delete their accounts

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -52,10 +52,11 @@ def _restore_game_info() -> Optional[Game]:
     game_id = session.get('gameid')
 
     if game_id:
-        game = Game.query.filter(Game.active == True, Game.id == game_id).one()
+        game = Game.query.filter(Game.active == True, Game.id == game_id).one_or_none()
         # Make sure it's fully set in the session cookie.
-        set_game_info(game)
-        return game
+        if game:
+            set_game_info(game)
+            return game
 
     return None
 
@@ -393,7 +394,7 @@ def export_referrals(mod_id: int, mod_name: str) -> werkzeug.wrappers.Response:
 @loginrequired
 @with_session
 def delete(mod_id: int) -> werkzeug.wrappers.Response:
-    mod, game = _get_mod_game_info(mod_id)
+    mod, _ = _get_mod_game_info(mod_id)
     editable = False
     if current_user:
         if current_user.admin:

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -405,8 +405,7 @@ def delete(mod_id: int) -> werkzeug.wrappers.Response:
     storage = _cfg('storage')
     if storage:
         full_path = os.path.join(storage, mod.base_path())
-        rmtree(full_path)
-
+        rmtree(full_path, ignore_errors=True)
     db.delete(mod)
     db.commit()
     notify_ckan(mod, 'delete', True)
@@ -637,6 +636,11 @@ def delete_version(mod_id: int, version_id: str) -> werkzeug.wrappers.Response:
         abort(400)
 
     purge_download(version[0].download_path)
+
+    storage = _cfg('storage')
+    if storage:
+        full_path = os.path.join(storage, version.download_path)
+        os.remove(full_path)
 
     db.delete(version)
     db.commit()

--- a/alembic/versions/2023_03_20_12_00_00-7eec82634342.py
+++ b/alembic/versions/2023_03_20_12_00_00-7eec82634342.py
@@ -1,0 +1,99 @@
+"""Add ondelete='CASCADE' to foreign keys that need it
+
+Revision ID: 7eec82634342
+Revises: b9e4c97b74c1
+Create Date: 2023-03-20 12:00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7eec82634342'
+down_revision = 'b9e4c97b74c1'
+
+from alembic import op
+
+
+def upgrade() -> None:
+    op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
+    op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('downloadevent_mod_id_fkey', 'downloadevent', type_='foreignkey')
+    op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('featured_mod_id_fkey', 'featured', type_='foreignkey')
+    op.create_foreign_key('featured_mod_id_fkey', 'featured', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('followevent_mod_id_fkey', 'followevent', type_='foreignkey')
+    op.create_foreign_key('followevent_mod_id_fkey', 'followevent', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('game_publisher_id_fkey', 'game', type_='foreignkey')
+    op.create_foreign_key('game_publisher_id_fkey', 'game', 'publisher', ['publisher_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('gameversion_game_id_fkey', 'gameversion', type_='foreignkey')
+    op.create_foreign_key('gameversion_game_id_fkey', 'gameversion', 'game', ['game_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('media_mod_id_fkey', 'media', type_='foreignkey')
+    op.create_foreign_key('media_mod_id_fkey', 'media', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('mod_game_id_fkey', 'mod', type_='foreignkey')
+    op.create_foreign_key('mod_game_id_fkey', 'mod', 'game', ['game_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('mod_user_id_fkey', 'mod', type_='foreignkey')
+    op.create_foreign_key('mod_user_id_fkey', 'mod', 'user', ['user_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('modlist_user_id_fkey', 'modlist', type_='foreignkey')
+    op.create_foreign_key('modlist_user_id_fkey', 'modlist', 'user', ['user_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('modlist_game_id_fkey', 'modlist', type_='foreignkey')
+    op.create_foreign_key('modlist_game_id_fkey', 'modlist', 'game', ['game_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('modlistitem_mod_id_fkey', 'modlistitem', type_='foreignkey')
+    op.create_foreign_key('modlistitem_mod_id_fkey', 'modlistitem', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('modlistitem_mod_list_id_fkey', 'modlistitem', type_='foreignkey')
+    op.create_foreign_key('modlistitem_mod_list_id_fkey', 'modlistitem', 'modlist', ['mod_list_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('modversion_gameversion_id_fkey', 'modversion', type_='foreignkey')
+    op.create_foreign_key('modversion_gameversion_id_fkey', 'modversion', 'gameversion', ['gameversion_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('modversion_mod_id_fkey', 'modversion', type_='foreignkey')
+    op.create_foreign_key('modversion_mod_id_fkey', 'modversion', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('referralevent_mod_id_fkey', 'referralevent', type_='foreignkey')
+    op.create_foreign_key('referralevent_mod_id_fkey', 'referralevent', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('sharedauthor_mod_id_fkey', 'sharedauthor', type_='foreignkey')
+    op.create_foreign_key('sharedauthor_mod_id_fkey', 'sharedauthor', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('sharedauthor_user_id_fkey', 'sharedauthor', type_='foreignkey')
+    op.create_foreign_key('sharedauthor_user_id_fkey', 'sharedauthor', 'user', ['user_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('mod_followers_user_id_fkey', 'mod_followers', type_='foreignkey')
+    op.create_foreign_key('mod_followers_user_id_fkey', 'mod_followers', 'user', ['user_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('mod_followers_mod_id_fkey', 'mod_followers', type_='foreignkey')
+    op.create_foreign_key('mod_followers_mod_id_fkey', 'mod_followers', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+
+
+def downgrade() -> None:
+    op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
+    op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'])
+    op.drop_constraint('downloadevent_mod_id_fkey', 'downloadevent', type_='foreignkey')
+    op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('featured_mod_id_fkey', 'featured', type_='foreignkey')
+    op.create_foreign_key('featured_mod_id_fkey', 'featured', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('followevent_mod_id_fkey', 'followevent', type_='foreignkey')
+    op.create_foreign_key('followevent_mod_id_fkey', 'followevent', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('game_publisher_id_fkey', 'game', type_='foreignkey')
+    op.create_foreign_key('game_publisher_id_fkey', 'game', 'publisher', ['publisher_id'], ['id'])
+    op.drop_constraint('gameversion_game_id_fkey', 'gameversion', type_='foreignkey')
+    op.create_foreign_key('gameversion_game_id_fkey', 'gameversion', 'game', ['game_id'], ['id'])
+    op.drop_constraint('media_mod_id_fkey', 'media', type_='foreignkey')
+    op.create_foreign_key('media_mod_id_fkey', 'media', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('mod_game_id_fkey', 'mod', type_='foreignkey')
+    op.create_foreign_key('mod_game_id_fkey', 'mod', 'game', ['game_id'], ['id'])
+    op.drop_constraint('mod_user_id_fkey', 'mod', type_='foreignkey')
+    op.create_foreign_key('mod_user_id_fkey', 'mod', 'user', ['user_id'], ['id'])
+    op.drop_constraint('modlist_user_id_fkey', 'modlist', type_='foreignkey')
+    op.create_foreign_key('modlist_user_id_fkey', 'modlist', 'user', ['user_id'], ['id'])
+    op.drop_constraint('modlist_game_id_fkey', 'modlist', type_='foreignkey')
+    op.create_foreign_key('modlist_game_id_fkey', 'modlist', 'game', ['game_id'], ['id'])
+    op.drop_constraint('modlistitem_mod_id_fkey', 'modlistitem', type_='foreignkey')
+    op.create_foreign_key('modlistitem_mod_id_fkey', 'modlistitem', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('modlistitem_mod_list_id_fkey', 'modlistitem', type_='foreignkey')
+    op.create_foreign_key('modlistitem_mod_list_id_fkey', 'modlistitem', 'modlist', ['mod_list_id'], ['id'])
+    op.drop_constraint('modversion_gameversion_id_fkey', 'modversion', type_='foreignkey')
+    op.create_foreign_key('modversion_gameversion_id_fkey', 'modversion', 'gameversion', ['gameversion_id'], ['id'])
+    op.drop_constraint('modversion_mod_id_fkey', 'modversion', type_='foreignkey')
+    op.create_foreign_key('modversion_mod_id_fkey', 'modversion', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('referralevent_mod_id_fkey', 'referralevent', type_='foreignkey')
+    op.create_foreign_key('referralevent_mod_id_fkey', 'referralevent', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('sharedauthor_mod_id_fkey', 'sharedauthor', type_='foreignkey')
+    op.create_foreign_key('sharedauthor_mod_id_fkey', 'sharedauthor', 'mod', ['mod_id'], ['id'])
+    op.drop_constraint('sharedauthor_user_id_fkey', 'sharedauthor', type_='foreignkey')
+    op.create_foreign_key('sharedauthor_user_id_fkey', 'sharedauthor', 'user', ['user_id'], ['id'])
+    op.drop_constraint('mod_followers_user_id_fkey', 'mod_followers', type_='foreignkey')
+    op.create_foreign_key('mod_followers_user_id_fkey', 'mod_followers', 'user', ['user_id'], ['id'])
+    op.drop_constraint('mod_followers_mod_id_fkey', 'mod_followers', type_='foreignkey')
+    op.create_foreign_key('mod_followers_mod_id_fkey', 'mod_followers', 'mod', ['mod_id'], ['id'])

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -8,10 +8,9 @@
     - https://github.com/miguelgrinberg/Flask-Migrate/issues/155
 """
 
-from typing import List, Optional, Union
-
-import sqlalchemy.sql.type_api
 import sqlalchemy as sa
+import sqlalchemy.sql.type_api
+from typing import List, Optional, Union
 
 
 class op:

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -211,11 +211,21 @@
             <a class="btn btn-default" href="#" data-toggle="modal" data-target="#change-password" role="button">Click to change password</a>
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-12">
+            <h2>Delete User Account</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <a class="btn btn-default" href="#" data-toggle="modal" data-target="#confirm-delete-account" role="button">Click to delete your account</a>
+        </div>
+    </div>
 </div>
 
 <div class="container lead">
     <div class="row">
-        <div class="col-md-8">
+        <div class="col-md-12">
             <h2>Connected Accounts</h2>
         </div>
 
@@ -280,7 +290,7 @@
         <div class="modal-content">
             <div class="modal-header">
               <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-              <h4 class="modal-title" id="myModalLabel">Disconnect Account: {{provider_full_name}}</h4>
+              <h4 class="modal-title">Disconnect Account: {{provider_full_name}}</h4>
             </div>
             <div class="modal-body">
               <p>This action will disconnect your {{provider_full_name}} account from your {{ site_name }} account.</p>
@@ -303,7 +313,7 @@
         <div class="modal-content">
             <div class="modal-header">
               <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-              <h4 class="modal-title" id="myModalLabel">Change Password</h4>
+              <h4 class="modal-title">Change Password</h4>
             </div>
             <form action="#" id="password-form">
                 <div class="modal-body">
@@ -329,6 +339,32 @@
                     <p id="error-message" class="hidden"></p>
                     <a href="#" class="btn btn-default btn-pw-change" data-dismiss="modal">Cancel</a>
                     <input type="submit" id="change-password-submit" class="btn btn-primary btn-pw-change" value="Change password">
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<div class="modal fade" id="confirm-delete-account" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+              <h4 class="modal-title">Delete User Account</h4>
+            </div>
+            <form action="#" id="delete-account-form">
+                <div class="modal-body">
+                    <p>Are you really, really, really sure you want to delete your account? You can't undo this. It'll be gone.
+                    This will delete any data associated with your account, including uploaded mods.</p>
+                    <div class="form-group">
+                        <label for="username">Your username</label>
+                        <input type="text" id="username" placeholder="Enter your username to confirm" class="form-control"
+                               name="username">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <p id="delete-account-error-message" class="hidden"></p>
+                    <a href="#" class="btn btn-default btn-account-del" data-dismiss="modal">Cancel</a>
+                    <input type="submit" id="delete-user-submit" class="btn btn-danger btn-account-del" value="Delete account">
                 </div>
             </form>
         </div>

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -205,6 +205,10 @@
                             <span class="glyphicon glyphicon-fire"></span>
                             Impersonate user
                         </a>
+                        <a href="#" class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete-account" role="button" style="margin-bottom: 10px; margin-top: 5px;">
+                            <span class="glyphicon glyphicon-fire"></span>
+                            Delete user
+                        </a>
                     {% endif %}
                 </div>
             </div>
@@ -229,6 +233,32 @@
                 <div class="modal-footer">
                     <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
                     <input type="submit" class="btn btn-danger" value="Confirm">
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<div class="modal fade" id="confirm-delete-account" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+              <h4 class="modal-title">Delete User Account</h4>
+            </div>
+            <form action="#" id="delete-account-form">
+                <div class="modal-body">
+                    <p>Are you really, really, really sure you want to delete that account? It can't be undone. It'll be gone.
+                    This will delete any data associated with this account, including uploaded mods.</p>
+                    <div class="form-group">
+                        <label for="username">Username</label>
+                        <input type="text" id="username" placeholder="Enter the user's username to confirm" class="form-control"
+                               name="username">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <p id="delete-account-error-message" class="hidden"></p>
+                    <a href="#" class="btn btn-default btn-account-del" data-dismiss="modal">Cancel</a>
+                    <input type="submit" id="delete-user-submit" class="btn btn-danger btn-account-del" value="Delete account">
                 </div>
             </form>
         </div>
@@ -303,4 +333,10 @@
     </div>
 </div>
 {% endif %}
+{% endblock %}
+{% block scripts %}
+    <script>
+        window.username = "{{profile.username}}";
+    </script>
+    <script src="/static/profile.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Motivation
Every now and then users want to delete their accounts (we should ask for the reason the next time, out of interest).
Every website with the option to create accounts should (and also must) have another option to delete these accounts again.

## How and what
There's still the discussion on what we actually want to delete if a user deletes their account.

For know, to get us started, I decided to stay consistent with what we already do and delete everything linked to that user, both in the database and on disk. This means mods of these users are deleted too.

Please continue this discussion in #215 or on the Discord and leave the comments on this PR to actual code review.
I'll update this PR depending on how we decide on that.

## Changes
* If the user's session cookie has an invalid game id (e.g. if the game has been deleted after it has been set in the cookie) `_restore_game_info()` threw an exception. Now it returns `None`.
* Some database magic: Added cascade delete constraints to all the relationships / foreign key constraints where it makes sense. This simplifies the deletion of mods (and also deletes some stuff we forgot until now, like download events and follow events), and enables the deletion of user accounts. It'll likely help us in the future too.
This needs a database migration.
* Based on this, I added an option for users to delete their accounts in the profile edit page. There's not much to it, I've mostly copied the code from the password change option where possible. To prevent some unfortunate mouse clicks having a devastating effect, you have to enter your username to confirm the deletion.
* Admins can also delete users, on the user profile page (where all the other per-user admin infos and options are)

Closes #215 