### PR TITLE
Fix timeline CSS and default description check

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -233,18 +233,16 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
         mod.donation_link = donation_link
         mod.external_link = external_link
         mod.source_link = source_link
-        if isinstance(short_description, str):
-            mod.short_description = short_description.replace('\r\n', ' ').replace('\n', ' ')
-        else:
-            mod.short_description = ''
-        if isinstance(description, str):
-            mod.description = description.replace('\r\n', '\n')
-        else:
-            mod.description = ''
+        if not isinstance(short_description, str):
+            short_description = str(short_description)
+        mod.short_description = short_description.replace('\r\n', ' ').replace('\n', ' ')
+        if not isinstance(description, str):
+            description = str(description)
+        mod.description = description.replace('\r\n', '\n')
         mod.score = get_mod_score(mod)
-        if not license or license == '':
+        if not mod.license:
             return render_template("edit_mod.html", mod=mod, error="All mods must have a license.")
-        if description == default_description:
+        if mod.description == default_description:
             return render_template("edit_mod.html", mod=mod, stupid_user=True)
         if request.form.get('publish', None):
             mod.published = True

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -229,15 +229,23 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
         ckan = request.form.get('ckan')
         background = request.form.get('background')
         bgOffsetY = request.form.get('bg-offset-y', 0)
-        if not license or license == '':
-            return render_template("edit_mod.html", mod=mod, error="All mods must have a license.")
-        mod.short_description = short_description
         mod.license = license
         mod.donation_link = donation_link
         mod.external_link = external_link
         mod.source_link = source_link
-        mod.description = description
+        if isinstance(short_description, str):
+            mod.short_description = short_description.replace('\r\n', ' ').replace('\n', ' ')
+        else:
+            mod.short_description = ''
+        if isinstance(description, str):
+            mod.description = description.replace('\r\n', '\n')
+        else:
+            mod.description = ''
         mod.score = get_mod_score(mod)
+        if not license or license == '':
+            return render_template("edit_mod.html", mod=mod, error="All mods must have a license.")
+        if description == default_description:
+            return render_template("edit_mod.html", mod=mod, stupid_user=True)
         if request.form.get('publish', None):
             mod.published = True
         if ckan is None:

--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -859,26 +859,6 @@ div.header.upload-well a, .header.upload-well p.status {
     color: #333333;
 }
 
-.timeline-centered .timeline-entry .timeline-entry-inner div.timeline-icon {
-    background-color: #1184aa;
-    color: #1184aa;
-    border: none;
-    border: solid 1 mm #1184aa;
-    box-shadow: none;
-    border-radius: 0;
-
-}
-
-div.timeline-centered::before {
-    background-color: #1184aa;
-    border: none;
-    bottom: 30px;
-}
-
-div.timeline-end, .timeline-hide-end {
-    background-color: #F5F5F5;
-}
-
 div.header .vert-text {
     font: 4mm 'glacial_indifferenceregular';
     color: #333333;
@@ -896,10 +876,6 @@ div.header .vert-text {
     font: 6mm 'glacial_indifferenceregular';
     margin-top: 2.5mm;
     margin-bottom: 2.5mm;
-}
-
-div.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label h2, div.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label p, div.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label h2 a {
-    color: #333333;
 }
 
 div.tab-container {
@@ -1041,10 +1017,6 @@ div.header.upload-well {
 
 div.container p {
     margin: 2.5mm;
-}
-
-.timeline-centered .timeline-entry .timeline-entry-inner div.timeline-label {
-    background-color: #F5F5F5;
 }
 
 .logoimg {

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -82,10 +82,6 @@
     }
 }
 
-.tab-content {
-    padding-top: 50px;
-}
-
 #changelog {
     p {
         color: #000;

--- a/frontend/styles/timeline.scss
+++ b/frontend/styles/timeline.scss
@@ -17,9 +17,10 @@
     position: absolute;
     display: block;
     width: 4px;
-    background: #f5f5f6;
+    background-color: #1184aa;
+    border: none;
     top: 20px;
-    bottom: 20px;
+    bottom: 30px;
     margin-left: 28px;
 }
 
@@ -134,15 +135,15 @@
 }
 
 .timeline-centered .timeline-entry .timeline-entry-inner .timeline-icon {
-    background-color: rgba(29,60,142,1); /* #1D3C8E */
+    background-color: #1184aa;
     color: #fff;
     display: block;
     width: 40px;
     height: 40px;
     background-clip: padding-box;
-    border-radius: 20px;
+    border: none;
     text-align: center;
-    box-shadow: 0 0 0 5px #333;
+    box-shadow: none;
     float: left;
 
     .glyphicon, .fa {
@@ -173,11 +174,43 @@
 
 .timeline-centered .timeline-entry .timeline-entry-inner .timeline-label {
     position: relative;
-    background: transparent;
+    background: #F5F5F5;
     padding: 1em;
     margin-left: 45px;
     background-clip: padding-box;
     border-radius: 3px;
+
+    p {
+        font-family: "Noto Sans",sans-serif;
+        font-size: 12px;
+        margin: 0;
+    }
+
+    p + p {
+        margin-top: 15px;
+    }
+
+    h2 {
+        color: #333333;
+        font-family: "Noto Sans",sans-serif;
+        font-size: 16px;
+        margin-top: 0;
+        margin-bottom: 10px;
+        position: relative;
+        top: -5px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
+        a {
+            color: #333333;
+            text-decoration: underline;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
+    }
 }
 
 .timeline-centered .timeline-entry .timeline-entry-inner .timeline-label:after {
@@ -194,33 +227,6 @@
     margin-left: -9px;
 }
 
-.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label h2,.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label p {
-    color: #fff;
-    font-family: "Noto Sans",sans-serif;
-    font-size: 12px;
-    margin: 0;
-    line-height: 1.428571429;
-}
-
-.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label p + p {
-    margin-top: 15px;
-}
-
-.timeline-centered .timeline-entry .timeline-entry-inner .timeline-label h2 {
-    font-size: 16px;
-    margin-bottom: 10px;
-    position: relative;
-    top: -5px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    a {
-        color: #fff;
-        text-decoration: underline;
-
-        &:hover {
-            text-decoration: none;
-        }
-    }
+div.timeline-end, .timeline-hide-end {
+    background-color: #F5F5F5;
 }

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -43,6 +43,14 @@
         </div>
     </div>
     {% endif %}
+    {% if stupid_user %}
+    <div class="well danger well-sm">
+        <div class="container">
+            <h1>You haven't finished filling out your mod listing!</h1>
+            <p>Before you publish it, you should at least <a href="{{ url_for("mods.edit_mod", mod_id=mod.id, mod_name=mod.name) }}">edit your description</a>.</p>
+        </div>
+    </div>
+    {% endif %}
 
     <div class="container lead">
         <div class="row">

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -28,6 +28,14 @@
     <input type="hidden" name="background" id="background" value="{%if mod.background %}{{ mod.background }}{% endif %}">
     <input type="hidden" name="bg-offset-y" id="bg-offset-y" value="{% if mod.bgOffsetY %}{{ mod.bgOffsetY }}{% endif %}">
 
+    {% if new %}
+    <div class="well info well-sm">
+        <div class="container">
+            <h1>Your mod has been created!</h1>
+            <p>You aren't quite done, though. Read through your listing, edit the description, add some flair, and publish it!</p>
+        </div>
+    </div>
+    {% endif %}
     {% if error %}
     <div class="well well-sm danger">
         <div class="container">

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -13,14 +13,6 @@
 <div class="header" style="background-image: url(/static/background.jpg);"></div>
 {% endif %}
 
-{% if new %}
-<div class="well info well-sm">
-    <div class="container">
-        <h1>Your mod has been created!</h1>
-        <p>You aren't quite done, though. Read through your listing, add some flair, and publish it!</p>
-    </div>
-</div>
-{% endif %}
 {% if stupid_user %}
 <div class="well danger well-sm">
     <div class="container">


### PR DESCRIPTION
## Problem
#293 tried to fix some parts of utterly broken `bootstrap.css` on the run, which apparently broke the icons,
because the now uncommented lines overwrite the ones from `timeline.scss`, setting the icon color to the background color.
Thanks @V1TA5 for discovering the exact cause.

Since #293 you conveniently get redirected to the mod edit page after creating a mod. However, we lost the banner saying you should edit the description and stuff, which is only displayed on the mod page which is now skipped.

The `stupid_user` check...
https://github.com/KSP-SpaceDock/SpaceDock/blob/b3220388dd71e5333710bde557683c3fd306b993/KerbalStuff/blueprints/mods.py#L440-L441
...that checks whether a user has edited the default description before publishing, doesn't work anymore. Apparently it's caused by the text being transmitted with CR-LF (`\r\n`) instead of LF (`\n`) in the POST now. Not sure what changed to cause this now, but it also affects production.

## Changes
All `timeline` related CSS has been moved to /merged/with `timeline.scss`. There was quite a bit of trial and error involved since it wasn'tt always that obvious what overwrites what, but I think I got it sorted out correctly in the end.

There's quite a bit more broken CSS in `bootstrap-theme.css`, for example all the lines with a space between value and unit (like `10 px` instead of `10px`), which the browser will ignore.
Apparently we can't just "fix" them by removing the space in between, because this again breaks some stuff as I realized.
So I decided to leave that as is for now and maybe take another look in the future (or nuke it entirely).

The "new mod" banner is now moved to the mod edit page, and to make it work the `new` request argument is also kept during the redirection. I've also removed some unused variables passed to the templates.

On POST requests to `/mod/<id>/<name>/edit`, `\r\n` are now replaced with `\n` in the description. The `stupid_user` check is also active for both the "Save" and the "Save & Publish" buttons on the edit page to account for #293.