### PR TITLE
Add gameshort to returned object in /api/games

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -126,7 +126,8 @@ def game_info(game: Game) -> Dict[str, str]:
         "background": game.background,
         "bg_offset_x": game.bgOffsetX,
         "bg_offset_y": game.bgOffsetY,
-        "link": game.link
+        "link": game.link,
+        "short": game.short
     }
 
 


### PR DESCRIPTION
While I was messing around with remaking OpenDock to use the newest version of Vue (and correctly use it), I noticed that `/api/games` didn't return the `gameshort` for the games.