### PR TITLE
Open mod tabs from URL

### DIFF
--- a/frontend/coffee/mods.coffee
+++ b/frontend/coffee/mods.coffee
@@ -63,3 +63,19 @@ if reject
             window.location = window.location
         xhr.send()
     , false)
+
+switchTab = () ->
+    switch location.hash
+        when '#info', ''
+            $(".tab-pane.active").removeClass('active')
+            $("#info").addClass('active')
+        when '#changelog'
+            $(".tab-pane.active").removeClass('active')
+            $("#changelog").addClass('active')
+        when "#stats"
+            $(".tab-pane.active").removeClass('active')
+            $("#stats").addClass('active')
+
+$("a[href^='#'").click((e) -> window.location.hash = $(e.target).attr('href'))
+window.addEventListener('hashchange', (e) ->switchTab())
+switchTab()


### PR DESCRIPTION
## Motivation

It's often useful to refer to a mod's change log (list of historical versions) when investigating some issue, but sometimes users don't know where it is.

## Changes

Now these links will open the corresponding tabs:

- https://alpha.spacedock.info/mod/1#info
- https://alpha.spacedock.info/mod/1#changelog
- https://alpha.spacedock.info/mod/1#stats

Is there a better access point for toggling these other than removing and adding the `active` CSS class? I could not find out much about how the tab control is supposed to work.

Fixes #315.