### PR TITLE
Get scheme from 'protocol' config for mod download redirection to CDN

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -533,9 +533,10 @@ def download(mod_id: int, mod_name: Optional[str], version: Optional[str]) -> Op
         mod_version.download_count += 1
         mod.score = get_mod_score(mod)
 
+    protocol = _cfg("protocol")
     cdn_domain = _cfg("cdn-domain")
-    if cdn_domain:
-        return redirect("http://" + cdn_domain + '/' + mod_version.download_path, code=302)
+    if protocol and cdn_domain:
+        return redirect(protocol + '://' + cdn_domain + '/' + mod_version.download_path, code=302)
 
     response = None
     if _cfg("use-x-accel") == 'nginx':

--- a/config.ini.example
+++ b/config.ini.example
@@ -60,6 +60,7 @@ redis-connection=redis://redis:6379/0
 storage=/opt/spacedock/storage
 
 # Redirect downloads to a CDN. Can also contain a partial path, without trailing slash.
+# The 'protocol' setting from above will also be used for the CDN.
 cdn-domain=
 # The internal hostname of the CDN / a reverse proxy in front of this server that caches mod files.
 # If set, the backend will send a PURGE request when a mod version gets deleted to clear it from the cache.


### PR DESCRIPTION
## Problem
Chrome shows an "unsecure download" warning since the latest version for mod downloads from SpaceDock, and you have to explicitly allow each download:
![image](https://user-images.githubusercontent.com/28812678/95026550-53737700-0692-11eb-9f40-5a6e6e641fa9.png)

This is because we redirect via HTTP for downloads on setups where `cdn-domain` is set:
![image](https://user-images.githubusercontent.com/28812678/95026454-c7f9e600-0691-11eb-9f14-2545d5d6edee.png)

With the next update released in 2 days, Chrome will entirely **block** our mod downloads:
https://blog.chromium.org/2020/02/protecting-users-from-insecure.html
![image](https://user-images.githubusercontent.com/28812678/95026699-7a7e7880-0693-11eb-964a-b53c60900518.png)


## Changes
Now we use the `protocol` setting from the `config.ini` to decide which scheme to use if a "CDN" is used.
This implicitly forces deployments of this code to also use HTTPS for their CDN if they use HTTPS on the main domain. This isn't really a drawback IMHO, it only makes sense, and otherwise they'd be hit by the exact same problem anyways.

This probably can't be tested locally, but we should be able to test this on both alpha+beta, which both also make use of `cdn-domain`.

**This fix is very urgent given that Chrome will start blocking our downloads with the next release in two days!**