### PR TITLE
Fix celery loglevel argument

### DIFF
--- a/systemd/spacedock-celery.service
+++ b/systemd/spacedock-celery.service
@@ -10,7 +10,7 @@ User=www-data
 Group=www-data
 WorkingDirectory=/var/www/virtual/spacedock.info/htdocs/SpaceDock
 Environment="PATH=/var/www/virtual/spacedock.info/htdocs/SpaceDock/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
-ExecStart=/var/www/virtual/spacedock.info/htdocs/SpaceDock/bin/celery -A KerbalStuff.celery:app worker -B --loglevel=info
+ExecStart=/var/www/virtual/spacedock.info/htdocs/SpaceDock/bin/celery -A KerbalStuff.celery:app worker -B --loglevel=INFO
 KillMode=process
 Restart=always
 RestartSec=60


### PR DESCRIPTION
## Problem
After the server restart last Friday, celery got auto-upgraded to version 5.0.0, since which the value of the `--loglevel` commandline argument has to be uppercase:
```
Oct  3 00:00:51 sd-alpha celery[4482]: Usage: celery worker [OPTIONS]
Oct  3 00:00:51 sd-alpha celery[4482]: Try 'celery worker --help' for help.
Oct  3 00:00:51 sd-alpha celery[4482]: Error: Invalid value for '-l' / '--loglevel': invalid choice: info. (choose from DEBUG, INFO, WARNING, ERROR, CRITICAL, FATAL)
```

This resulted in all SpaceDock services that are part of `spacedock.target` being restarted by systemd every minute or so.

## Changes
Changed `--loglevel=info` to `--loglevel=INFO` in `systemd/spacedock-celery.py`.
This is already changed on production to get it working again, and alpha+beta which I used to test if it actually solves the restart problem we had. I've reverted it on alpha+beta right now so this PR can autodeploy.