### PR TITLE
Fix service icons on logged out index

### DIFF
--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -985,15 +985,6 @@ div.navbar-brand {
     width: auto;
 }
 
-div.service-icon {
-    font: 2cm 'Glyphicons Halflings';
-    text-align: center;
-    padding: 5.5mm;
-    border-radius: 0;
-    background-color: #FFFFFF;
-    margin: 2.5mm;
-}
-
 .modal-body input[type="text"], .modal-body input[type="password"], .modal-body input[type="email"] {
     border: solid .5mm #DDDDDD;
     background-color: #EEEEEE;

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -104,19 +104,20 @@
 }
 
 .service-icon {
-    border:3px solid #fff;
-    border-radius:50%;
-    display:inline-block;
-    font-size:56px;
-    width:140px;
-    height:140px;
-    line-height:136px;
-    vertical-align:middle;
-    text-align:center;
-    transition-duration:.3s;
-    transition-property:transform;
-    transform:translateZ(0);
-    box-shadow:0 0 1px rgba(0,0,0,0)
+    font: 2cm 'Glyphicons Halflings';
+    text-align: center;
+    border-radius: 0;
+    margin: 2.5mm;
+    border: 3px solid #fff;
+    display: inline-block;
+    width: 140px;
+    height: 140px;
+    line-height: 136px;
+    vertical-align: middle;
+    transition-duration: .3s;
+    transition-property: transform;
+    transform: translateZ(0);
+    box-shadow: 0 0 1px rgba(0,0,0,0)
 }
 
 h2 small {


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/95122173-b9eda900-0715-11eb-8b5f-c5a1aaac48e0.png)

## Cause

Another legacy KerbalStuff hack of bootstrap exposed by #293 trying to remove syntax errors.

## Changes

Now `div.service-icon` is removed from bootstrap and reconciled with the existing properties of `.service-icon` in index.scss.

![image](https://user-images.githubusercontent.com/1559108/95122327-f3beaf80-0715-11eb-9d6f-35c9b9349937.png)
