### PR TITLE
Minor UI tweaks

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -5,7 +5,6 @@ import locale
 import os
 import subprocess
 import sys
-import re
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from time import strftime
@@ -210,14 +209,6 @@ def find_dnt() -> None:
     g.do_not_track = do_not_track
 
 
-# Match beginnings of words and capital letters (for StudlyCapsNames)
-abbrev_pattern = re.compile('\\b\\w|[A-Z]')
-
-
-def abbrev(gamename: str) -> str:
-    return gamename if len(gamename) < 7 else ''.join(abbrev_pattern.findall(gamename))
-
-
 @app.context_processor
 def inject() -> Dict[str, Any]:
     protocol = _cfg('protocol')
@@ -237,7 +228,6 @@ def inject() -> Dict[str, Any]:
         'ua_platform': getattr(request.user_agent, 'platform', None),
         'analytics_id': _cfg("google_analytics_id"),
         'analytics_domain': _cfg("google_analytics_domain"),
-        'abbrev': abbrev,
         'disqus_id': _cfg("disqus_id"),
         'dnt': True,
         'ads': False,

--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -5,6 +5,7 @@ import locale
 import os
 import subprocess
 import sys
+import re
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from time import strftime
@@ -209,6 +210,14 @@ def find_dnt() -> None:
     g.do_not_track = do_not_track
 
 
+# Match beginnings of words and capital letters (for StudlyCapsNames)
+abbrev_pattern = re.compile('\\b\\w|[A-Z]')
+
+
+def abbrev(gamename: str) -> str:
+    return gamename if len(gamename) < 7 else ''.join(abbrev_pattern.findall(gamename))
+
+
 @app.context_processor
 def inject() -> Dict[str, Any]:
     protocol = _cfg('protocol')
@@ -228,6 +237,7 @@ def inject() -> Dict[str, Any]:
         'ua_platform': getattr(request.user_agent, 'platform', None),
         'analytics_id': _cfg("google_analytics_id"),
         'analytics_domain': _cfg("google_analytics_domain"),
+        'abbrev': abbrev,
         'disqus_id': _cfg("disqus_id"),
         'dnt': True,
         'ads': False,

--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -31,8 +31,7 @@ def game(gameshort: str) -> str:
         desc(Mod.download_count)).limit(6)[:6]
     new = Mod.query.filter(Mod.published, Mod.game_id == ga.id).order_by(
         desc(Mod.created)).limit(6)[:6]
-    recent = Mod.query.filter(Mod.published, Mod.game_id == ga.id, ModVersion.query.filter(
-        ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated)).limit(6)[:6]
+    recent = Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated)).limit(6)[:6]
     user_count = User.query.count()
     mod_count = Mod.query.filter(Mod.game_id == ga.id, Mod.published == True).count()
     yours = list()
@@ -88,8 +87,7 @@ def browse_new_rss() -> Response:
 
 @anonymous.route("/browse/updated")
 def browse_updated() -> str:
-    mods = Mod.query.filter(Mod.published, ModVersion.query.filter(
-        ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated))
+    mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated))
     mods, page, total_pages = paginate_mods(mods)
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
                            url="/browse/updated", name="Recently Updated Mods", rss="/browse/updated.rss", site_name=_cfg('site-name'), support_mail=_cfg('support-mail'))
@@ -97,8 +95,7 @@ def browse_updated() -> str:
 
 @anonymous.route("/browse/updated.rss")
 def browse_updated_rss() -> Response:
-    mods = Mod.query.filter(Mod.published, ModVersion.query.filter(
-        ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated))
+    mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated))
     mods = mods.limit(30)
     site_name = _cfg('site-name')
     if not site_name:
@@ -185,8 +182,7 @@ def singlegame_browse_new_rss(gameshort: str) -> Response:
 @anonymous.route("/<gameshort>/browse/updated")
 def singlegame_browse_updated(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, ModVersion.query.filter(
-        ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated))
+    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated))
     mods, page, total_pages = paginate_mods(mods)
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
                            url="/browse/updated", name="Recently Updated Mods", rss="/browse/updated.rss", site_name=_cfg('site-name'), support_mail=_cfg('support-mail'))
@@ -198,8 +194,7 @@ def singlegame_browse_updated_rss(gameshort: str) -> Response:
     if not site_name:
         abort(404)
     ga = get_game_info(short=gameshort)
-    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, ModVersion.query.filter(
-        ModVersion.mod_id == Mod.id).count() > 1).order_by(desc(Mod.updated))
+    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated))
     mods = mods.limit(30)
     return Response(render_template("rss.xml", mods=mods, title="Recently updated on " + site_name, ga=ga,
                                     description="Mods on " +

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -3,7 +3,7 @@ from typing import Tuple, List, Union, Optional
 
 from flask import Blueprint, render_template, url_for, abort, redirect, request
 from flask_login import current_user
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 import werkzeug.wrappers
 
 from ..common import loginrequired, with_session, get_game_info, paginate_mods
@@ -31,7 +31,9 @@ def _get_mod_list(list_id: str) -> Tuple[ModList, Game, bool]:
 @lists.route("/packs/<gameshort>")
 def packs(gameshort: Optional[str]) -> str:
     game = None if not gameshort else get_game_info(short=gameshort)
-    query = ModList.query.order_by(desc(ModList.created))
+    query = ModList.query \
+        .filter(or_(ModList.mods.any(), ModList.description != '')) \
+        .order_by(desc(ModList.created))
     if game:
         query = query.filter(ModList.game_id == game.id)
     packs, page, total_pages = paginate_mods(query, 15)

--- a/templates/game.html
+++ b/templates/game.html
@@ -3,38 +3,25 @@
 <link rel="stylesheet" type="text/css" href="/static/index.css" />
 {% endblock %}
 {% block body %}
-<!--
-<div class="header">
-    <div class="vert-text">
-        {% if not user %}
-        <h3>Welcome to {{ site_name }}!</h3>
-        <p>Hosting {{ mod_count }} mods for {{ "{:,}".format(user_count) }} users!</p>
-        <a data-scroll class="btn btn-circle" href="#about"><span class="glyphicon glyphicon-chevron-down"></span></a>
-        {% else %}
-        <h3>Welcome back, {{ user.username }}!</h3>
-        <p>We have {{ mod_count }} mods for you and {{ "{:,}".format(user_count - 1) }} other users!</p>
-        {% endif %}
-    </div>
-</div>
--->
 {% if user and len(yours) >= 1 %}
-<div class="well" style="margin-bottom: 0;">
+    <div class="well" style="margin-bottom: 0;">
+        <div class="container">
+            <a href="/profile/{{ user.username }}" class="btn btn-primary pull-right">
+                Your Profile
+                <span class="glyphicon glyphicon-chevron-right"></span>
+            </a>
+            <h1>Your Mods <small>Recently updated mods you follow</small></h1>
+        </div>
+    </div>
     <div class="container">
-        <a href="/profile/{{ user.username }}" class="btn btn-primary pull-right">
-            Your Profile
-            <span class="glyphicon glyphicon-chevron-right"></span>
-        </a>
-        <h1>Your Mods <small>Recently updated mods you follow</small></h1>
+        <div class="row">
+            {% for mod in yours %}
+            {% include "mod-box.html" %}
+            {% endfor %}
+        </div>
     </div>
-</div>
-<div class="container">
-    <div class="row">
-        {% for mod in yours %}
-        {% include "mod-box.html" %}
-        {% endfor %}
-    </div>
-</div>
 {% endif %}
+
 <div class="well"  style="margin-bottom: 0;">
     <div class="container main-cat">
         <a href="{% if ga %}/{{ ga.short }}{% endif %}/browse/featured" class="btn btn-primary pull-right">
@@ -68,7 +55,6 @@
         {% endfor %}
     </div>
 </div>
-{% if not user %}
 <div class="well"  style="margin-bottom: 0;margin-top: 2.5mm;">
     <div class="container main-cat">
         <a href="{% if ga %}/{{ ga.short }}{% endif %}/browse/updated" class="btn btn-primary pull-right">
@@ -111,37 +97,4 @@
         </div>
     </div>
 </div>
-{% else %}
-<div class="well"  style="margin-bottom: 0;margin-top: 2.5mm;">
-    <div class="container main-cat">
-        <a href="{% if ga %}/{{ ga.short }}{% endif %}/browse/all" class="btn btn-primary pull-right">
-            Browse All Mods
-            <span class="glyphicon glyphicon-chevron-right"></span>
-        </a>
-        <h3>Browse all {{ mod_count }} Mods</h3>
-    </div>
-</div>
-<div class="container">
-    <div class="row">
-        <div class="col-md-4">
-            <a class="btn btn-lg btn-block btn-default" href="{% if ga %}/{{ ga.short }}{% endif %}/browse/updated">
-                Browse Recently Updated Mods
-                <span class="glyphicon glyphicon-chevron-right"></span>
-            </a>
-        </div>
-        <div class="col-md-4">
-            <a class="btn btn-lg btn-block btn-default" href="{% if ga %}/{{ ga.short }}{% endif %}/browse/top">
-                Browse Popular Mods
-                <span class="glyphicon glyphicon-chevron-right"></span>
-            </a>
-        </div>
-        <div class="col-md-4">
-            <a class="btn btn-lg btn-block btn-default" href="/packs{% if ga %}/{{ ga.short }}{% endif %}">
-                Browse Mod Packs
-                <span class="glyphicon glyphicon-chevron-right"></span>
-            </a>
-        </div>
-    </div>
-</div>
-{% endif %}
 {% endblock %}

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -3,7 +3,7 @@
         <div class="changer">
             <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}" style="width: 100%;">
                 {% if mod.default_version %}
-                    <div class="ksp-update">{{mod.default_version.friendly_version}} for {{ abbrev(mod.default_version.gameversion.game.name) }} {{ mod.default_version.gameversion.friendly_version }}</div>
+                    <div class="ksp-update">{{mod.default_version.friendly_version}} for {{ mod.default_version.gameversion.game.abbrev }} {{ mod.default_version.gameversion.friendly_version }}</div>
                 {% endif %}
                 <div class="following-mod" id="modbox-{{ mod.id }}-following" style="display:{%- if following_mod(mod) -%}block{%- else -%}none{%- endif -%}">Following</div>
                 <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -3,7 +3,7 @@
         <div class="changer">
             <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}" style="width: 100%;">
                 {% if mod.default_version %}
-                    <div class="ksp-update">{{mod.default_version.friendly_version}} for {{ mod.default_version.gameversion.game.name }} {{ mod.default_version.gameversion.friendly_version }}</div>
+                    <div class="ksp-update">{{mod.default_version.friendly_version}} for {{ abbrev(mod.default_version.gameversion.game.name) }} {{ mod.default_version.gameversion.friendly_version }}</div>
                 {% endif %}
                 <div class="following-mod" id="modbox-{{ mod.id }}-following" style="display:{%- if following_mod(mod) -%}block{%- else -%}none{%- endif -%}">Following</div>
                 <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -157,10 +157,8 @@
                                         {% endif %}
                                     </span>
                                     <a href="/profile/{{ mod.user.username }}">{{ mod.user.username }}</a>{%if total_authors != 1%},{%endif %}
-                                    {% for author in mod.shared_authors %}
-                                    {% if author.accepted %}
-                                    <a href="/profile/{{ author.user.username }}">{{ author.user.username }}</a>{%if not loop.last%},{%endif%}
-                                    {% endif %}
+                                    {% for author in mod.shared_authors if author.accepted %}
+                                        <a href="/profile/{{ author.user.username }}">{{ author.user.username }}</a>{%if not loop.last%},{%endif%}
                                     {% endfor %}
                                 </h2>
                             </div>

--- a/templates/pack-box.html
+++ b/templates/pack-box.html
@@ -10,14 +10,15 @@
             "></div>
         </a>
         <div class="caption">
-            <h2 class="group inner list-group-item-heading">
+            <h3 class="group inner list-group-item-heading">
                 {{ list.name }}
-            </h2>
-            <p style="max-height: 75px; overflow: hidden;">
+                <small>({{len(list.mods)}} mods)</small>
+            </h3>
+            <div style="max-height: 75px; overflow: hidden;">
                 {% if list.description %}
                     {{ list.description | markdown }}
                 {% endif %}
-            </p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Problems

- There are a lot of empty modpacks cluttering [the list on prod](https://spacedock.info/packs)
- Long modpack descriptions are displayed in full, stretching the box crazily
- Long game names are displayed in full in mod listings, which takes up a lot of space:
  ![image](https://user-images.githubusercontent.com/1559108/95382596-79c22e00-08af-11eb-95ab-847af7146cbc.png)
- If you invite a co-author to a mod that already has some, the authors list shows an extra comma in the time before the new author accepts:
  ![image](https://user-images.githubusercontent.com/1559108/95927489-7386f280-0d84-11eb-81c1-3d3f1f50298c.png)
- The per-game mod listings were needlessly different depending on whether you were logged in or logged out
- Mods with only one release are intended to be excluded from Recently Updated, but they're included

## Causes

- It was previously more difficult to figure out how to add a mod to a pack, so there's just an accumulation of bad data
- We have a max-height and overflow set up, but on a `p` element, which seems to clash with the `markdown` renderer, which puts its contents after that `p` instead of inside of it
- The `shared_authors` loop was checking `author.accepted` inside the loop, so the final non-accepted loop iteration would be empty, but the one before would still include a comma
- The `ModVersion.query.filter(ModVersion.mod_id == Mod.id).count() > 1` query doesn't work somehow.

## Changes

- Now empty modpacks are filtered out of the site-wide lists (but are still shown on the creator's profile). To accommodate "modpacks" consisting only of mods not hosted on SpaceDock which are listed in the description, a modpack with a description is not considered empty.
- Now the `p` is a `div`, making the max-height and overflow work as intended
- The number of mods in a pack is now included in the pack box, so you have some idea how complex it is before you click
  ![image](https://user-images.githubusercontent.com/1559108/95252727-fcc98280-07e2-11eb-969f-21bb942d3976.png)
- Now long game names are abbreviated in mod listings (short names are unchanged):
  ![image](https://user-images.githubusercontent.com/1559108/95382662-9b231a00-08af-11eb-829d-c6c829c5ab19.png)
  The exact logic is:
  1. If shorter than 7 characters, use as-is
  2. Get the characters from the starts of words and capital letters (in case of StudlyCapsNames) and concatenate them
- Now the extra comma is removed by checking `author.accepted` as part of the loop, so there is no loop body iteration for non-accepted authors
- Now the only difference between being logged in and logged out for the per-game mod listings is whether the Featured list appears. Fixes #216.
- Now single-release mods are excluded from Recently Updated, as intended. Fixes #170.