### PR TITLE
Exclude pending authors from API

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -410,7 +410,8 @@ def mod_info_api(mod_id: int) -> Union[Dict[str, Any], Tuple[Dict[str, Any], int
     info = mod_info(mod)
     info["versions"] = list()
     for author in mod.shared_authors:
-        info["shared_authors"].append(user_info(author.user))
+        if author.accepted:
+            info["shared_authors"].append(user_info(author.user))
     for v in mod.versions:
         info["versions"].append(version_info(mod, v))
     info["description"] = mod.description


### PR DESCRIPTION
## Problem

The API includes pending authors:

https://spacedock.info/mod/2062/KSC%20Extended

![image](https://user-images.githubusercontent.com/1559108/103370562-b9ee1280-4a92-11eb-97ae-7b84f32834e2.png)

https://spacedock.info/api/mod/2062

![image](https://user-images.githubusercontent.com/1559108/103370566-bc506c80-4a92-11eb-818f-fe64d2864e2a.png)

This effectively reports changes to author teams before they're confirmed by the participants.

Found after https://github.com/KSP-CKAN/CKAN-meta/commit/5b17390e48094a9a7b4330cb5e0b9cb3d26cad26

## Cause

The `Mod.shared_authors` objects have an `accepted` property that is set to `True` when a pending author is confirmed. The UI checks it, but the API doesn't.

## Changes

Now only confirmed authors are returned.