### PR TITLE
Set 'Secure', 'HttpOnly' and 'SameSite' attributes on cookies; escape untrusted HTML from user input

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -10,10 +10,10 @@ from time import strftime
 from typing import Tuple, List, Dict, Any, Optional, Union
 
 import requests
+import werkzeug.wrappers
 from flask import Flask, render_template, g, url_for, Response, request
 from flask_login import LoginManager, current_user
 from flaskext.markdown import Markdown
-import werkzeug.wrappers
 from werkzeug.exceptions import HTTPException, InternalServerError
 
 from .blueprints.accounts import accounts
@@ -26,7 +26,8 @@ from .blueprints.login_oauth import list_defined_oauths, login_oauth
 from .blueprints.mods import mods
 from .blueprints.profile import profiles
 from .celery import update_from_github
-from .common import first_paragraphs, many_paragraphs, json_output, jsonify_exception, wrap_mod, dumb_object
+from .common import first_paragraphs, many_paragraphs, json_output, jsonify_exception, wrap_mod, dumb_object, \
+    sanitize_text
 from .config import _cfg, _cfgb, _cfgd, _cfgi, site_logger
 from .custom_json import CustomJSONEncoder
 from .database import db
@@ -46,12 +47,12 @@ app.config.update(
     REMEMBER_COOKIE_SAMESITE='Lax'
 )
 app.jinja_env.filters['first_paragraphs'] = first_paragraphs
+app.jinja_env.filters['bleach'] = sanitize_text
 app.secret_key = _cfg("secret-key")
 app.jinja_env.cache = None
 app.json_encoder = CustomJSONEncoder
-markdown = Markdown(app, extensions=[KerbDown()])
-login_manager = LoginManager()
-login_manager.init_app(app)
+Markdown(app, extensions=[KerbDown(), 'fenced_code'])
+login_manager = LoginManager(app)
 
 
 @login_manager.user_loader

--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -35,11 +35,21 @@ from .kerbdown import KerbDown
 from .objects import User, BlogPost
 
 app = Flask(__name__, template_folder='../templates')
+# https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options
+# Set 'Secure', 'HttpOnly' and 'SameSite' attributes for session and remember-me cookiesHTTPS
+app.config.update(
+    SESSION_COOKIE_SECURE=True,
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE='Lax',
+    REMEMBER_COOKIE_SECURE=True,
+    REMEMBER_COOKIE_HTTPONLY=True,
+    REMEMBER_COOKIE_SAMESITE='Lax'
+)
 app.jinja_env.filters['first_paragraphs'] = first_paragraphs
 app.secret_key = _cfg("secret-key")
 app.jinja_env.cache = None
 app.json_encoder = CustomJSONEncoder
-markdown = Markdown(app, safe_mode='remove', extensions=[KerbDown()])
+markdown = Markdown(app, extensions=[KerbDown()])
 login_manager = LoginManager()
 login_manager.init_app(app)
 

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -6,8 +6,11 @@ import re
 from functools import wraps
 from typing import Union, List, Dict, Any, Optional, Callable, Tuple, Iterable
 
+import bleach
+from bleach_allowlist import bleach_allowlist
 from flask import jsonify, redirect, request, Response, abort, session
 from flask_login import current_user
+from markupsafe import Markup
 from werkzeug.exceptions import HTTPException
 from werkzeug.utils import secure_filename
 import werkzeug.wrappers
@@ -21,13 +24,21 @@ from .search import search_mods
 TRUE_STR = ('true', 'yes', 'on')
 PARAGRAPH_PATTERN = re.compile('\n\n|\r\n\r\n')
 
+cleaner = bleach.Cleaner(tags=bleach_allowlist.markdown_tags,
+                         attributes=bleach_allowlist.markdown_attrs,
+                         filters=[bleach.linkifier.LinkifyFilter])
+
 
 def first_paragraphs(text: str) -> str:
     return '\n\n'.join(PARAGRAPH_PATTERN.split(text)[0:3])
 
 
-def many_paragraphs(text:str) -> bool:
+def many_paragraphs(text: str) -> bool:
     return len(PARAGRAPH_PATTERN.split(text)) > 3
+
+
+def sanitize_text(text: str) -> Markup:
+    return Markup(cleaner.clean(text))
 
 
 def dumb_object(model):  # type: ignore

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -120,7 +120,7 @@ createCookie = (name, value, days) ->
         expires = "; expires=" + date.toGMTString()
     else
         expires = "; expires=session"
-    document.cookie = name + "=" + value + expires + "; path=/"
+    document.cookie = name + "=" + value + expires + "; path=/; SameSite=Lax; Secure=True"
 window.createCookie = createCookie
 
 createCookie('first_visit', 'false', 365 * 10)

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -1,5 +1,7 @@
 alembic
 bcrypt
+bleach
+bleach-allowlist
 celery
 click
 dnspython
@@ -11,6 +13,7 @@ gunicorn
 future
 jinja2
 markdown
+markupsafe
 oauthlib==2.0.6
 packaging
 pillow

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -309,7 +309,7 @@
 <div class="container">
     <div class="tab-content">
         <div class="tab-pane active space-left-right" id="info">
-            {{ mod.description | markdown }}
+            {{ mod.description | markdown | bleach }}
         </div>
         <div class="tab-pane  space-left-right" id="changelog">
             <div class="timeline-centered">
@@ -326,7 +326,7 @@
                             {% if not v.changelog %}
                             <p><em>No changelog provided</em></p>
                             {% else %}
-                            {{ v.changelog | markdown }}
+                            {{ v.changelog | markdown | bleach }}
                             {% endif %}
                             <p data-version="{{ v.id }}">
                                 <a class="btn btn-primary piwik_download" href="{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name, version=v.friendly_version) }}">

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -39,7 +39,7 @@
 <div class="well well-sm md-well">
     <div class="container">
         {%- if mod_list.description -%}
-            {{ mod_list.description | markdown }}
+            {{ mod_list.description | markdown | bleach }}
         {%- else -%}
             <p>Your mod pack is empty right now! You should
             <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}">edit it</a>

--- a/templates/pack-box.html
+++ b/templates/pack-box.html
@@ -16,7 +16,7 @@
             </h3>
             <div style="max-height: 75px; overflow: hidden;">
                 {% if list.description %}
-                    {{ list.description | markdown }}
+                    {{ list.description | markdown | bleach }}
                 {% endif %}
             </div>
         </div>

--- a/templates/rss-mod.xml
+++ b/templates/rss-mod.xml
@@ -9,7 +9,7 @@
         <item>
             <title>{{ mod.name }} {{ v.friendly_version }} for {{ mod.game.name }} {{ v.ksp_version }} Released</title>
             {% if v.changelog %}
-            <description><![CDATA[{{ v.changelog | markdown }}]]></description>
+            <description><![CDATA[{{ v.changelog | markdown | bleach }}]]></description>
             {% endif %}
             <pubDate>{{ v.created.strftime("%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
             <link>{{ root }}{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name, version=v.friendly_version) }}</link>

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -122,7 +122,7 @@
                 </div>
 
                 <div class="col-md-6">
-                    {{ profile.description | markdown }}
+                    {{ profile.description | markdown | bleach }}
                     {% if user.admin %}
                         <p>
                         <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Email: </span><a href="mailto:{{ profile.email }}">{{ profile.email }}</a>


### PR DESCRIPTION
## Problems
Recently I spotted some warning messages in the browser console regarding our cookie usage:
![image](https://user-images.githubusercontent.com/28812678/107081113-7eadd480-67f2-11eb-80da-9f28167c09d0.png)
Especially alerting was the message that the session cookie would be rejected in the future, which would likely break our login functionality.
See https://github.com/KSP-SpaceDock/SpaceDock/pull/335#pullrequestreview-574871740

Users can fill in arbitrary HTML code into mod / mod pack / profile descriptions, which won't be escaped but embedded and executed as is when someones views the page.

You can't mark code blocks using triple backticks like on GitHub.

## Causes
Browsers are moving to reject cookies that have neither `SameSite` nor `Secure` set, because those are vulnerable to XSS and CSRF attacks.
For details, see
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Secure
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
* https://blog.miguelgrinberg.com/post/cookie-security-for-flask-applications
* https://web.dev/samesite-cookies-explained/

I suspect we relied on Markdown's `safe_mode=remove` to strip any unsafe HTML code, which has been deprecated and removed a long time ago though:
https://python-markdown.github.io/change_log/release-2.6/#safe_mode-deprecated

## Changes
We set `Secure=True`, `SameSite=Lax` and `HttpOnly=True` for Flask's `session` and Flask-Login's `remember_token` cookies. This enforces the cookies to only be sent via HTTPS connections (except localhost), only if SpaceDock is accessed directly (not via iframes or image embeds), and that they can't be accessed by JavaScript.
For our own cookies set via JavaScript, we set `Secure=True` and `SameSite=Lax`. We don't set `HttpOnly=True` since we need to access them in the JS code.
There are still a bunch of warnings for cookies added by `piwik.js`, but I don't have influence on that file since it gets loaded from `stats.52k.de`. Also it's not vital to SpaceDock.

Now we are using `bleach` as recommended in the deprecation notice for `safe_mode` to filter any potentially bad HTML tags and attributes. It is implemented as another Jinja filter that should be applied after rendering the Markdown to HTML. Filtered tags will be escaped.
We use `bleach-allowlist` to get the list of safe tags and attributes we can keep, which is more permissive that the default list, while still guarding against XSS and other shenanigans.
* https://bleach.readthedocs.io/en/latest/
* https://github.com/yourcelf/bleach-allowlist

We are not filtering blog posts or mod locking messages, because I'd consider them trusted input given that it can only be entered by admins, and they might benefit from additional HTML features. I'm open to escaping this as well if you think we should, though.

It would be preferable if we escaped user input before writing it to the database, however this leads to double-escaped HTML if we keep the escaping in the templates, which we should because there could already be bad data in the database.
Some information on HTML escaping in Jinja2: https://jinja.palletsprojects.com/en/2.11.x/templates/#html-escaping

I've removed the `safe_mode='remove'` argument passed to `flaskext.Markdown`.
Also we don't need the returned object from `Markdown`, it registers itself to `app` as Jinja2 filter.

The Markdown extension [fenced_code](https://python-markdown.github.io/extensions/fenced_code_blocks/) is now activated to allow code blocks delimited by triple backticks or triple tildes.