### PR TITLE
Several CKAN integration fixes

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -39,13 +39,16 @@ app = Flask(__name__, template_folder='../templates')
 # https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options
 # Set 'Secure', 'HttpOnly' and 'SameSite' attributes for session and remember-me cookiesHTTPS
 app.config.update(
-    SESSION_COOKIE_SECURE=True,
     SESSION_COOKIE_HTTPONLY=True,
     SESSION_COOKIE_SAMESITE='Lax',
-    REMEMBER_COOKIE_SECURE=True,
     REMEMBER_COOKIE_HTTPONLY=True,
     REMEMBER_COOKIE_SAMESITE='Lax'
 )
+if not app.debug:
+    app.config.update(
+        SESSION_COOKIE_SECURE=True,
+        REMEMBER_COOKIE_SECURE=True
+    )
 app.jinja_env.filters['first_paragraphs'] = first_paragraphs
 app.jinja_env.filters['bleach'] = sanitize_text
 app.secret_key = _cfg("secret-key")

--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -34,9 +34,9 @@ def send_to_ckan(mod: Mod) -> None:
         })
 
 
-def notify_ckan(mod: Mod, event_type: str) -> None:
+def notify_ckan(mod: Mod, event_type: str, force: bool = False) -> None:
     url = _cfg("notify-url")
-    if mod.ckan and mod.published and url:
+    if mod.ckan and url and (mod.published or force):
         _bg_post(url, {
             'mod_id': mod.id,
             'event_type': event_type,

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   db:
-    image: postgres:11.4
+    image: postgres:11
     restart: always
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
@@ -57,8 +57,9 @@ services:
     environment:
       - CONNECTION_STRING=${CONNECTION_STRING}
     command: >
-      celery worker
-      --app KerbalStuff.celery:app
+      celery
+      -A KerbalStuff.celery:app
+      worker
       --loglevel=INFO
       -B
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   db:
-    image: postgres:11.4
+    image: postgres:11
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -60,8 +60,9 @@ services:
     environment:
       - CONNECTION_STRING=${CONNECTION_STRING}
     command: >
-      celery worker
-      --app KerbalStuff.celery:app
+      celery
+      -A KerbalStuff.celery:app
+      worker
       --loglevel=DEBUG
       --concurrency=1
       -B

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -173,17 +173,34 @@
     </div>
     {% endif %}
 
-    <div class="container" style="margin-top: 2.5mm;">
-        <p>
-            <span class="col-md-10 form-group"><a target="_blank" href="/markdown">Markdown</a> is supported here.</span>
-            {% if not mod.ckan %}
-            <label>
-                <input id="ckan" name="ckan" style="margin-top: 8px;" type="checkbox"> Add mod to <a target="_blank" href="https://github.com/KSP-CKAN/CKAN">CKAN</a>
-                <span data-original-title="This makes it so that users can automate the installation of your mod. Your mod won't be added to CKAN until you publish it." class="glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="left" title=""></span>
-            </label>
-            {% endif %}
-        </p>
-        <textarea class="form-control input-block-level" name="description" id="description" rows=25>{{ mod.description }}</textarea>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-4"><a target="_blank" href="/markdown">Markdown</a> is supported here.</div>
+            <div class="col-md-8 form-group text-right">
+                <input id="ckan" name="ckan" type="checkbox"
+                    {% if mod.ckan %}
+                       checked="checked"
+                       {% if mod.published and not user.admin %}
+                           disabled="disabled"
+                       {% endif %}
+                    {% endif %}
+                />
+                <label for="ckan">Request addition to <a target="_blank" href="https://github.com/KSP-CKAN/CKAN">CKAN</a></label>
+                <button type="button" class="btn btn-mini" onclick="$('#ckan-help').toggle()">
+                    <span class="glyphicon glyphicon-question-sign"></span>
+                </button>
+                <div id="ckan-help" hidden="hidden" class="text-muted">
+                    <small>
+                    This requests addition to CKAN by triggering a <a href="https://github.com/KSP-CKAN/NetKAN/pulls?q=is%3Apr+author%3Anetkan-bot+sort%3Aupdated-desc">pull request in the NetKAN repository</a> to index your mod in the CKAN after you publish it.<br>
+                    The CKAN team will adjust the metadata to make sure the mod gets installed correctly and add potential dependencies and other relationships.<br>
+                    Thereupon the mod will be available for users to download and install via the CKAN client.
+                    </small>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <textarea class="form-control input-block-level" name="description" id="description" rows=25>{{ mod.description }}</textarea>
+        </div>
     </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Problems
* CKAN doesn't get pull requests for around half of new mods with the CKAN badge enabled.
  The following steps lead to no notification sent:
  1) Create mod
  2) Edit mod, check CKAN badge, "Save Changes"
  3) Edit mod, "Edit & Publish"
* The "Add to CKAN" checkbox is hidden after it has been enabled once. Authors thus can't verify whether they checked it and might get confused; they also can't disable it again for unpublished mods, even though it wouldn't create any problems there.
* Once the checkbox is activated, it's set in stone. However sometimes it happens that CKAN doesn't index a mod it gets a PR for for whatever reason. It would be nice if admins could deactivate the checkbox again.
* For some reason the tooltip for the CKAN checkbox doesn't work anymore.
* The "(un)locked" and "edit" notifications don't get sent.

## Causes
* The second time you edit a mod the checkbox isn't included in the HTML, thus `request.form.get("ckan")` is `None` in the POST. So `ckan` is `False`, and we never get to the `send_to_ckan()` part. Even if it weren't, `mod.ckan` would be already true the second time and prevent it as well.
* When we reach `notify_ckan()` for "locked" and "unlocked", `mod.published` is `False`. Thus the notification isn't sent.

## Changes
* The CKAN logic in `/mod/<int:mod_id>/<path:mod_name>/edit` is reworked.
  * If the badge has just been activated, send the mod to CKAN (`send_to_ckan()` will take care of cancelling if the mod isn't published yet)
  * If the badge has already been activated before, but the mod has been published just now, send it to ckan.
  * If the badge has been activated before (and the mod has already been published previsouly), notify CKAN about an edit.
* The checkbox can be disabled again, as long as the mod isn't published yet or you're an admin. Yes, authors can also disable the checkbox if the mod is unpublished due to it being locked, but I think this is fine, there's a decent change CKAN froze the mod already anyways (if they got the notification).
* The HTML around the CKAN checkbox has been polished. The checkbox is shown all the time on the edit page, pre-checked if it has already been activated. However it's locked for users if the mod is published. The toolltip is replaced by a hidden, more detailed help text shown on button press.
  ![image](https://user-images.githubusercontent.com/28812678/109215878-154b3100-77b4-11eb-9c01-7f310c100fdc.png)
* There's a new `force` parameter in `notify_ckan()`, defaulting to `False`. It overrides `(mod.published)`. We set it to `True` when calling in `lock()` and `unlock()`, and also `delete()` even though it isn't necessary there but let's guard against future changes.


* The command for celery in the docker-compose files is fixed. Since version 5.0 the `--app`/`-A` option needs to be _before_ the `worker` argument. I've had this in my working directory for some time apparently and forgot about it. The systemd files are fine, they already have it in that order.
* Postgres is no longer locked to the minor version, only to the major. It doesn't match current production anyway (11.3, bad, I know), and it makes sense to stay up to date locally so we can detect problems early.
* The `Secure` cookie settings for Flask are only enabled if `app.debug` is `False`, to allow local testing with Chrome. Need to think of a solution for the cookies set dynamically via JS.