### PR TITLE
Abbreviate link for mod source code repository

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -1,5 +1,6 @@
 import os
 import random
+import re
 from datetime import datetime, timedelta
 from shutil import rmtree
 from socket import socket
@@ -30,6 +31,10 @@ from ..objects import Mod, ModVersion, DownloadEvent, FollowEvent, ReferralEvent
 from ..search import get_mod_score
 
 mods = Blueprint('mods', __name__, template_folder='../../templates/mods')
+
+SOURCE_REPOSITORY_URL_PATTERN = re.compile(
+    r'^https://git(hub|lab).com/(?P<repo_short>[^/]+/[^/]+)/?'
+)
 
 
 def _get_mod_game_info(mod_id: int) -> Tuple[Mod, Game]:
@@ -132,13 +137,14 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
     thirty_days_ago = datetime.now() - timedelta(days=30)
     referrals = list()
     for r in ReferralEvent.query\
-        .filter(ReferralEvent.mod_id == mod.id)\
-            .order_by(desc(ReferralEvent.events)):
+            .filter(ReferralEvent.mod_id == mod.id)\
+            .order_by(desc(ReferralEvent.events))\
+            .limit(10):
         referrals.append({'host': r.host, 'count': r.events})
     download_stats = list()
     for d in DownloadEvent.query\
-        .filter(DownloadEvent.mod_id == mod.id)\
-        .filter(DownloadEvent.created > thirty_days_ago)\
+            .filter(DownloadEvent.mod_id == mod.id)\
+            .filter(DownloadEvent.created > thirty_days_ago)\
             .order_by(DownloadEvent.created):
         download_stats.append(dumb_object(d))
     downloads_per_version = [(ver.id, ver.friendly_version, ver.download_count)
@@ -146,8 +152,8 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
                              in sorted(mod.versions, key=lambda ver: ver.id)]
     follower_stats = list()
     for f in FollowEvent.query\
-        .filter(FollowEvent.mod_id == mod.id)\
-        .filter(FollowEvent.created > thirty_days_ago)\
+            .filter(FollowEvent.mod_id == mod.id)\
+            .filter(FollowEvent.created > thirty_days_ago)\
             .order_by(FollowEvent.created):
         follower_stats.append(dumb_object(f))
     json_versions = list()
@@ -159,15 +165,19 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
             size_versions[v.id] = get_version_size(os.path.join(storage, v.download_path))
     if request.args.get('noedit') is not None:
         editable = False
-    forumThread = False
+    forum_thread = False
     if mod.external_link is not None:
         try:
             u = urlparse(mod.external_link)
             if u.netloc == 'forum.kerbalspaceprogram.com':
-                forumThread = True
+                forum_thread = True
         except Exception as e:
             print(e)
             pass
+    repo_short = None
+    if mod.source_link is not None:
+        match = SOURCE_REPOSITORY_URL_PATTERN.match(mod.source_link)
+        repo_short = match.group('repo_short') if match else None
     total_authors = 1
     pending_invite = False
     owner = editable
@@ -179,16 +189,16 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
                 pending_invite = True
             if current_user.id == a.user_id and a.accepted:
                 editable = True
-    game_versions = GameVersion.query.filter(
-        GameVersion.game_id == mod.game_id).order_by(desc(GameVersion.id)).all()
+    latest_game_version = GameVersion.query.filter(
+        GameVersion.game_id == mod.game_id).order_by(desc(GameVersion.id)).first()
     outdated = False
     if latest:
-        outdated = latest.gameversion.id != game_versions[0].id and latest.gameversion.friendly_version != '1.0.5'
+        outdated = latest.gameversion.id != latest_game_version.id
     return render_template("mod.html",
                            **{
                                'mod': mod,
                                'latest': latest,
-                               'featured': any(Featured.query.filter(Featured.mod_id == mod.id)),
+                               'featured': Featured.query.filter(Featured.mod_id == mod.id).count() > 0,
                                'editable': editable,
                                'owner': owner,
                                'pending_invite': pending_invite,
@@ -198,9 +208,10 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
                                'referrals': referrals,
                                'json_versions': json_versions,
                                'thirty_days_ago': thirty_days_ago,
-                               'game_versions': game_versions,
+                               'latest_game_version': latest_game_version,
                                'outdated': outdated,
-                               'forum_thread': forumThread,
+                               'forum_thread': forum_thread,
+                               'repo_short': repo_short,
                                'stupid_user': request.args.get('stupid_user') is not None and current_user == mod.user,
                                'total_authors': total_authors,
                                "site_name": _cfg('site-name'),
@@ -536,7 +547,7 @@ def download(mod_id: int, mod_name: Optional[str], version: Optional[str]) -> Op
     if not storage or not os.path.isfile(os.path.join(storage, mod_version.download_path)):
         abort(404)
 
-    if not 'Range' in request.headers:
+    if 'Range' not in request.headers:
         # Events are aggregated hourly
         if not download or ((datetime.now() - download.created).seconds / 60 / 60) >= 1:
             download = DownloadEvent()

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -113,7 +113,7 @@
                                     <span class="text-muted">
                                         Source code:
                                     </span>
-                                    <a href="{{ mod.source_link }}">{{ mod.source_link }}</a>
+                                    <a href="{{ mod.source_link }}">{{ repo_short if repo_short else mod.source_link }}</a>
                                 </h2>
                             </div>
                         </div>
@@ -176,11 +176,7 @@
                                     <span class="text-muted">
                                         Mod Website:
                                     </span>
-                                    {% if forum_thread %}
-                                    <a href="{{ mod.external_link }}">Forum Thread</a>
-                                    {% else %}
-                                    <a href="{{ mod.external_link }}">{{ mod.external_link }}</a>
-                                    {% endif %}
+                                    <a href="{{ mod.external_link }}">{{ "Forum Thread" if forum_thread else mod.external_link }}</a>
                                 </h2>
                             </div>
                         </div>
@@ -287,10 +283,10 @@
     </div>
 
 </div>
-        {% if editable and latest.gameversion.friendly_version != game_versions[0].friendly_version %}
+        {% if editable and outdated %}
         <div class="alert alert-info space-left-right" style="margin-bottom: 0; margin-top: 2.5mm;border-radius: 0;box-shadow: none;">
             <p>
-                This mod seems to be outdated. Is the latest version compatible with {{ ga.name }} {{ game_versions[0].friendly_version }}?
+                This mod seems to be outdated. Is the latest version compatible with {{ ga.name }} {{ latest_game_version.friendly_version }}?
                 <button style="margin-left: 10px;" class="btn btn-primary autoupdate" data-toggle="modal" data-target="#confirm-update">Yes, update automatically</button>
                 <a href="{{ url_for("mods.update", mod_id=mod.id, mod_name=mod.name) }}" class="btn btn-default">No, update manually</a>
             </p>
@@ -369,8 +365,8 @@
                     <div class="col-md-4">
                     <h3>Top Referrers</h3>
                     <ol>
-                    {% for a in referrals[:10] %}
-                    <li><a href="http://{{ a.host }}">{{ a.host }}</a></li>
+                    {% for ref in referrals %}
+                    <li><a href="http://{{ ref.host }}">{{ ref.host }}</a></li>
                     {% endfor %}
                     </ol>
                     <h3>Export Raw Stats</h3>
@@ -437,7 +433,7 @@
                 </div>
                 <div class="modal-body">
                     <p>You are about to modify version {{ latest.friendly_version }} of {{ mod.name }} to
-                    support {{ ga.name }} {{ game_versions[0].friendly_version }}. An email will be sent to
+                    support {{ ga.name }} {{ latest_game_version.friendly_version }}. An email will be sent to
                     {{ mod.follower_count }} followers to tell them the good news. Sounds good?</p>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Motivation
This is similar to what @HebaruSan did in #331, except for source code repositories and on the mod page.

The source code link is basically the last link in the mod info box that is displayed as is.
All other links are shortened if possible, both to make them prettier and to hide unnecessary detail, and to save some horizontal space, useful on mobile devices (although there's more that's broken currently).

## Changes
Now we try to get a short link text if it points to a GitHub or GitLab repository.
It's formatted like you usually shorten the names of repositories: `<Username>/<Repository>`
For example: `KSP-SpaceDock/SpaceDock` or `KSP-CKAN/CKAN` or `godarklight/DarkMultiPlayer`

It's matched using a regex. If it doesn't match (e.g. not hosted on GitHub/GitLab), we display the link as is. I thought about matching all links that look like `<scheme>://<host>/<part1>/<part2>`, but there's a risk of false positives, and honestly I don't know if there even is a single source code link not pointing to GitHub or GitLab (not even sure about GitLab, I know there's KSRSS hosted on it, but it's not on SpaceDock AFAIK).
	  
The calculation is currently redone on every request to the mod page. We might want to look at caching calculations like this in Redis at some point, it's already running for Celery.
But we should benchmark beforehand whether it's actually faster to retrieve a stored value from Redis than checking a simple regex.

Additionally I imprpoved the database queries for `/mod/<int:mod_id>` a bit, because I discovered a few potentially heavy, but unnecessary ones:
* We queried all referral events for a mod, but only ever used the top 10. Now the query is limited to 10.
* Similarly, we requested all GameVersions of the current game, but only used the latest one. Now the query uses `.first()`.
* To find out whether the mod is featured or not, we queried all rows with matching `mod.id` and checked with Python's `any()`. Now we only ask for the count and check if it's `> 0`.