### PR TITLE
Centralize password check as method of 'User' objects

### DIFF
--- a/KerbalStuff/blueprints/accounts.py
+++ b/KerbalStuff/blueprints/accounts.py
@@ -138,7 +138,7 @@ def login() -> Union[str, werkzeug.wrappers.Response]:
             return render_template("login.html", username=username, errors='Your username or password is incorrect.')
         if user.confirmation != '' and user.confirmation is not None:
             return redirect("/account-pending")
-        if not bcrypt.hashpw(password.encode('utf-8'), user.password.encode('utf-8')) == user.password.encode('utf-8'):
+        if not user.check_password(password):
             return render_template("login.html", username=username, errors='Your username or password is incorrect.')
         login_user(user, remember=remember)
         if 'return_to' in request.form and request.form['return_to']:

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -363,8 +363,7 @@ def login() -> Union[Dict[str, Any], Tuple[Dict[str, Any], int]]:
     user = User.query.filter(User.username.ilike(username)).first()
     if not user:
         return {'error': True, 'reason': 'Username or password is incorrect'}, 401
-    if not bcrypt.hashpw(password.encode('utf-8'),
-                         user.password.encode('utf-8')) == user.password.encode('utf-8'):
+    if not user.check_password(password):
         return {'error': True, 'reason': 'Username or password is incorrect'}, 401
     if user.confirmation and user.confirmation is not None:
         return {'error': True, 'reason': 'User is not confirmed'}, 403
@@ -439,7 +438,7 @@ def change_password(username: str) -> Union[Dict[str, Any], Tuple[Union[str, Any
     new_password = request.form.get('new-password', '')
     new_password_confirm = request.form.get('new-password-confirm', '')
 
-    if not bcrypt.hashpw(old_password.encode('utf-8'), current_user.password.encode('utf-8')) == current_user.password.encode('utf-8'):
+    if not current_user.check_password(old_password):
         return {'error': True, 'reason': 'The old password you entered doesn\'t match your current account password.'}
 
     pw_valid, pw_message = check_password_criteria(new_password, new_password_confirm)

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -67,6 +67,9 @@ class User(Base):  # type: ignore
     def set_password(self, password: str) -> None:
         self.password = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
 
+    def check_password(self, password: str) -> bool:
+        return bcrypt.checkpw(password.encode('utf-8'), self.password.encode('utf-8'))
+
     def create_confirmation(self) -> None:
         self.confirmation = binascii.b2a_hex(os.urandom(20)).decode('utf-8')
 

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -1,5 +1,5 @@
 alembic
-bcrypt
+bcrypt>=3.1.0
 bleach
 bleach-allowlist
 celery

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
-from .test_version import *
 from .test_api_browse import *
 from .test_api_mod import *
 from .test_api_errors import *
 from .test_errors import *
+from .test_objects_user import *
+from .test_version import *

--- a/tests/test_objects_user.py
+++ b/tests/test_objects_user.py
@@ -1,0 +1,17 @@
+from KerbalStuff.objects import User
+
+
+def test_objects_user() -> None:
+    # Arrange
+    # Create new user
+    user = User(username="Test User", email="test_user@example.com")
+    password_clear_text = "deRp*qnEX&<6i`=<oFy3j+%ww3<-k*:4"
+    user.set_password(password_clear_text)
+
+    # Act
+    correct_password_match = user.check_password(password_clear_text)
+    incorrect_password_match = user.check_password("password1!")
+
+    # Assert
+    assert correct_password_match is True, "user.check_password should return True for matching passwords"
+    assert incorrect_password_match is False, "user.check_password should return False for nonmatching passwords"


### PR DESCRIPTION
## Motivation
Checking passwords (and setting passwords) is something that must be rock-solid.
For this it makes sense to keep as much logic of it at a single place, so you don't have to rewrite it half a dozen times with the risk of introducing a nasty bug each time.

Also bcrypt 3.1.0 introduced a new `bcrypt.checkpw(<input to check>, <hashed password>)` function that is way more intuitive than the old `bcrypt.hashpw(<input>, <hashed password>) == <hashed password>`.
If you are wondering how the old one works, `bcrypt.hashpw()` reads the salt from the hashed password (bcrypt hashes save the salt in front of the actual pw hash) and hashes the clear text input using this salt. Then we compare the output with the actual hash.
The new method basically still does the same in the background, but we don't need to care about it anymore, it's much more readable.

## Changes
Create a new `User.check_password(<input>)`, which takes care of encoding the input strings with UTF-8 to give bcrypt the byte array it wants, and calling `bcrypt.checkpw()`. It returns `True` for a matching password and `False` for incorrect ones.
All places where we had the complicated `bcrypt.hashpw()` construct now simply call `checkpw()` on a `User` object.

If we ever need to change the hash function for passwords, this should simplify the process.

I've also added a basic test to make sure we aren't doing something majorly wrong in this method.

I've specified the minimum version of `bcrypt` we now need in the `requirements-backend.txt`.

Please review carefully to make sure I didn't accidentally drop a vital `not` or something in the password checks.