### PR TITLE
Warn authors when changing version prefixes

### DIFF
--- a/frontend/coffee/update.coffee
+++ b/frontend/coffee/update.coffee
@@ -52,3 +52,72 @@ dropzone.options.uploader =
         alert = $("#error-alert")
         alert.text(errorMessage.reason)
         alert.removeClass('hidden')
+
+
+latest_begins_with_lowercase_v = window.mod_default_version_friendly.startsWith('v')
+latest_begins_with_uppercase_v = window.mod_default_version_friendly.startsWith('V')
+version_input = $('#version')
+warning_text = $('#version-warning')
+ok_button = $('#version-ok')
+
+version_input.on('input', () -> validate_version(false))
+ok_button.on('click', () -> validate_version(true))
+
+validate_version = (apply_change) ->
+    if version_input.val().length == 0
+        warning_text.addClass('hidden')
+        ok_button.addClass('hidden')
+    else if latest_begins_with_lowercase_v && !version_input.val().startsWith('v')
+        if version_input.val().startsWith('V')
+            if apply_change
+                version_input.val('v' + version_input.val().substring(1))
+                # Rerun to hide the warning or discover further issues (e.g. double v prefix)
+                validate_version(false)
+            else
+                warning_text.text('Your last version had a \'v\' prefix, change this version to match?')
+                warning_text.removeClass('hidden')
+                ok_button.removeClass('hidden')
+        else
+            if apply_change
+                version_input.val('v' + version_input.val())
+                validate_version(false)
+            else
+                warning_text.text('Your last version had a \'v\' prefix, change this version to match?')
+                warning_text.removeClass('hidden')
+                ok_button.removeClass('hidden')
+    else if latest_begins_with_uppercase_v && !version_input.val().startsWith('V')
+        if version_input.val().startsWith('v')
+            if apply_change
+                version_input.val('V' + version_input.val().substring(1))
+                validate_version(false)
+            else
+                warning_text.text('Your last version had a \'V\' prefix, change this version to match?')
+                warning_text.removeClass('hidden')
+                ok_button.removeClass('hidden')
+        else
+            if apply_change
+                version_input.val('V' + version_input.val())
+                validate_version(false)
+            else
+                warning_text.text('Your last version had a \'V\' prefix, change this version to match?')
+                warning_text.removeClass('hidden')
+                ok_button.removeClass('hidden')
+    else if !latest_begins_with_lowercase_v && version_input.val().startsWith('v')
+        if apply_change
+            version_input.val(version_input.val().substring(1))
+            validate_version(false)
+        else
+            warning_text.text('Your last version didn\'t have a \'v\' prefix, change this version to match?')
+            warning_text.removeClass('hidden')
+            ok_button.removeClass('hidden')
+    else if !latest_begins_with_uppercase_v && version_input.val().startsWith('V')
+        if apply_change
+            version_input.val(version_input.val().substring(1))
+            validate_version(false)
+        else
+            warning_text.text('Your last version didn\'t have a \'V\' prefix, change this version to match?')
+            warning_text.removeClass('hidden')
+            ok_button.removeClass('hidden')
+    else
+        warning_text.addClass('hidden')
+        ok_button.addClass('hidden')

--- a/templates/update.html
+++ b/templates/update.html
@@ -27,7 +27,10 @@
                 <h2 class="control-label">Mod version</h2>
             </div>
             <div class="col-md-8 form-group">
-                <input id="version" type="text" class="form-control input-block-level" placeholder="Version number" autofocus />
+                <input id="version" type="text" class="form-control input-block-level" placeholder="Version number" autofocus /><br>
+                <span>Previous: {{ mod.default_version.friendly_version }}</span>
+                <span id="version-warning" class="hidden text-warning"></span>
+                <button id="version-ok" class="hidden btn btn-success" style="margin-bottom: 0">OK</button>
             </div>
         </div>
         <div class="row">
@@ -84,6 +87,7 @@
 {% block scripts %}
     <script>
         window.mod_id = {{ mod.id }};
+        window.mod_default_version_friendly = "{{ mod.default_version.friendly_version }}"
     </script>
     <script src="/static/editor.js"></script>
     <script src="/static/marked.js"></script>


### PR DESCRIPTION
## Motivation
It happens quite regularly that mod authors get confused about their own versioning system.
They start with a version numbers that all have a `v`  prefix, but one day they decide to omit it (or more precisely: they forget about it). Of course it happens the other way around just as often, or sometimes even mixing lowercase `v`s with uppercase `v`s, or all sorts of variations thereof.

In theory you are supposed to decide for one format at the beginning, and then stick to it for the lifetime of your software.
Btw., did you know that [semver.org](https://semver.org/) suggests that only version numbers without `v` (or `V`) prefix [are considered semantic](https://semver.org/#is-v123-a-semantic-version)?

This trips up every system that tries to sort mod versions by their version number, for example CKAN.
While we've preparations at CKAN to catch when mod authors released a version that would sort below a previous version and automatically correct it, which are automated to a large degree, it still requires human review, and is annoying.

And it's ugly to look at in the changelog tab.

## Changes
Now the frontend analyzes whatever the user types into the version number text box, and compares it to the previous release's version number.
If it detects a mismatching `v`/`V` prefix, it shows a warning right below the text box, together with a "No!" button which tries to correct it.
It doesn't catch all possible misdeeds that authors tend to commit (for example prefixes besides `v`/`V` or a lower version number than the previous release), but it should catch about 95% of them.

Additionally we also show the latest version number on the left to give the author some orientation if it's been a while since the last release, or if they get confused because they also maintain another 300 mods. Or if someone adopts a mod of another author, although that only works if they get access to and update the same SpaceDock entry.

![image](https://user-images.githubusercontent.com/28812678/115283078-35abc200-a14b-11eb-982b-5314143c6a33.png)
![image](https://user-images.githubusercontent.com/28812678/115282984-1ad94d80-a14b-11eb-9f38-b6b4d7bc25cb.png)

When I'm writing "latest" or "previous" here, I actually mean `mod.default_version`. It is not always strictly poitning to the newest version of a mod since it can be changed; however it _is_ the case for almost all mods, and we treat it as "latest" in many other places as well.
CKAN _does_ consider the default version as the latest one and always tries to index that, so for CKAN it's the one that the prefix should be match with.