### PR TITLE
Profiling with admin visualization for the backend

### DIFF
--- a/KerbalStuff/middleware/profiler.py
+++ b/KerbalStuff/middleware/profiler.py
@@ -1,0 +1,38 @@
+from sys import stdout
+from typing import Optional, Iterable, Union, Callable, TextIO, List, TYPE_CHECKING
+
+from werkzeug.contrib.profiler import ProfilerMiddleware
+
+if TYPE_CHECKING:
+    from wsgiref.types import StartResponse, WSGIApplication, WSGIEnvironment
+
+class ConditionalProfilerMiddleware(ProfilerMiddleware):
+    def __init__(
+        self,
+        app: "WSGIApplication",
+        stream: Optional[TextIO] = stdout,
+        sort_by: Iterable[str] = ("time", "calls"),
+        restrictions: Iterable[Union[str, int, float]] = (),
+        profile_dir: Optional[str] = None,
+        filename_format: str = "{method}.{path}.{elapsed:.0f}ms.{time:.0f}.prof",
+        sampling_function: Optional[Callable[["WSGIEnvironment"], bool]] = None,
+    ) -> None:
+        super().__init__(app=app,
+                         stream=stream, sort_by=sort_by, # type: ignore[arg-type]
+                         restrictions=restrictions, profile_dir=profile_dir, filename_format=filename_format)
+        self._app = app
+        self._sampling_function = sampling_function
+
+    def __call__(self, environ: "WSGIEnvironment", start_response: "StartResponse") -> List[bytes]:
+
+        if self._sampling_function and not self._sampling_function(environ):
+            # Run without profiling
+            response_body: List[bytes] = []
+            app_iter = self._app(environ, start_response)
+            response_body.extend(app_iter)
+            if hasattr(app_iter, "close"):
+                app_iter.close() # type: ignore[attr-defined]
+            return [b"".join(response_body)]
+
+        else:
+            return super().__call__(environ, start_response)

--- a/KerbalStuff/profiling.py
+++ b/KerbalStuff/profiling.py
@@ -1,0 +1,14 @@
+import random
+from typing import TYPE_CHECKING
+
+from .config import _cfgi
+
+if TYPE_CHECKING:
+    from wsgiref.types import StartResponse, WSGIEnvironment
+
+def sampling_function(environ: "WSGIEnvironment") -> bool:
+    # Don't bother profiling admin pages or static files
+    if environ.get('PATH_INFO', '').startswith(("/admin", "/content", "/static")):
+        return False
+    max = _cfgi('requests-per-profile', 1)
+    return random.randrange(0, max) == 0

--- a/config.ini.example
+++ b/config.ini.example
@@ -100,3 +100,8 @@ create-url=
 
 # URL to notify of mod updates
 notify-url=
+
+# Path to store profiling runs, leave blank to turn off profiling
+profile-dir=
+# If set to an integer, profile approximately 1 out of every this many requests (default 1)
+requests-per-profile=

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -27,3 +27,4 @@ sqlalchemy
 sqlalchemy_utils
 urllib3
 werkzeug==0.16.1
+flameprof

--- a/templates/admin-profiling-viz.html
+++ b/templates/admin-profiling-viz.html
@@ -1,0 +1,27 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="profiling">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            {% set base_url = 'admin.profiling_viz' %}
+            <h2>
+                {{profiling.route}}
+                <small>{{profiling.timestamp}}, {{ (profiling.duration.total_seconds() * 1000) | int }}ms</small>
+            </h2>
+        </div>
+        <div class="row">
+
+            <object type="image/svg+xml" data="{{profiling.svg_url}}"
+                    style="width: 1216px; height: 1888px;">
+                <div class="alert alert-danger centered" id="error-alert">
+                    Failed to load flame graph!
+                </div>
+            </object>
+        </div>
+
+    </div>
+</div>
+<script type="text/javascript">
+    document.getElementById('adm-link-profiling').classList.add('active')
+</script>
+{% endblock %}

--- a/templates/admin-profiling.html
+++ b/templates/admin-profiling.html
@@ -1,0 +1,43 @@
+{% extends "admin.html" %}
+{% block admin_content %}
+<div class="tab-pane active" id="profiling">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            {% set base_url = 'admin.profiling' %}
+            {% include 'admin-page-nav.html' %}
+            <div class="col-sm-4">
+                <form class="navbar-form navbar-search" role="search" action="{{ url_for("admin.profiling", page=1) }}" method="GET">
+                    <div class="form-group">
+                        <label for="profiling-search">Search profilings:</label>
+                        <input id="profiling-search" type="text" class="form-control search-box" name="query" {% if query %}value="{{ query }}"{% else %}placeholder="Search profilings..."{% endif %}>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <div class="row table-responsive bootstrap-table space-left-right">
+            <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
+                <thead>
+                <tr>
+                    <th>Route</th>
+                    <th>Started at</th>
+                    <th>Duration (ms)</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                {% for profiling in profilings %}
+                <tr>
+                    <td><a href="{{ url_for("admin.profiling_viz", name=profiling.name) }}">{{ profiling.route }}</a></td>
+                    <td>{{ profiling.timestamp }}</td>
+                    <td>{{ (profiling.duration.total_seconds() * 1000) | int }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    document.getElementById('adm-link-profiling').classList.add('active')
+</script>
+{% endblock %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -14,6 +14,7 @@
 <div id="content">
     <div class="centered admin-nav box panel panel-default" style="margin: 2.5mm">
         <ul class="nav nav-pills nav-justified panel-content">
+            <li id="adm-link-profiling"><a href="{{ url_for("admin.profiling", page=1) }}">Profiling</a></li>
             <li id="adm-link-users"><a href="{{ url_for("admin.users", page=1) }}">Users</a></li>
             <li id="adm-link-publishers"><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
             <li id="adm-link-games"><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>


### PR DESCRIPTION
## Motivation

The production server has performance slowdowns when it's the evening in the US. We want to capture profiling information to figure out why this happens.

## Changes

Now there are two new configuration parameters:

https://github.com/KSP-SpaceDock/SpaceDock/blob/50a089024ba52f768f5a18ba59f6824874d580f6/config.ini.example#L104-L107

If you set `profile-dir` before starting the server (or set it and restart), then it will begin outputting profiling data to the given folder. The second parameter can be used to control how often profiling happens; to profile 1 out of 100 requests, set it to 100; to profile 1 out of 1000 requests, set it to 1000. By default all requests would be profiled, so you should probably set this setting. Admin pages are never profiled.

The captured profiling data can be viewed in the admin pages, where it is available under a new Profiling tab. The available captures are displayed in a paginated list that shows their routes, start time, and duration.

The search box supports several types of search terms, separated by spaces if you want to combine them:

- `<100` - Runs taking equal to or less than 100 milliseconds
- `>100` - Runs taking equal to or more than 100 milliseconds
- `start:2021-04-30` - Runs on or after April 30, 2021
- `end:2021-04-30` - Runs on or before April 30, 2021
- Anything else is treated a substring to find in the routes

![listing](https://cdn.discordapp.com/attachments/763685596556165121/837422248692023306/unknown.png)

The routes are links which you can click to view a "flame graph" of the request, which is a way to see the call stack over time and understand what the system is doing.

![flamegraph](https://cdn.discordapp.com/attachments/763685596556165121/837422072481185822/unknown.png)

This will help us to understand what is happening on the server when it slows down, as well as find ways to optimize in general. For example, we're currently not sure whether the jinja2 templates are recompiled every time; profiling data and flame graphs from production will answer this question for us.

Fixes #344.