### PR TITLE
Fall back to unprofiled if profile dir is unwritable

### DIFF
--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -83,6 +83,9 @@ def query_term_matches(term: str, profiling: Dict[str, Any]) -> bool:
             # Started on or before this date
             max_date = datetime.date(*map(int, term[4:].split('-')))
             return max_date >= profiling['timestamp'].date()
+        elif term.startswith('!'):
+            # Match the route, inverted
+            return term[1:] not in profiling.get('route', '')
         else:
             # Match the route
             return term in profiling.get('route', '')

--- a/KerbalStuff/middleware/profiler.py
+++ b/KerbalStuff/middleware/profiler.py
@@ -27,8 +27,8 @@ class ConditionalProfilerMiddleware(ProfilerMiddleware):
 
     def __call__(self, environ: "WSGIEnvironment", start_response: "StartResponse") -> List[bytes]:
 
-        if (self._profile_dir and not access(self._profile_dir, W_OK)
-            or self._sampling_function and not self._sampling_function(environ)):
+        if (self._sampling_function and not self._sampling_function(environ)
+            or self._profile_dir and not access(self._profile_dir, W_OK)):
             # Run without profiling
             response_body: List[bytes] = []
             app_iter = self._app(environ, start_response)

--- a/templates/admin-page-nav.html
+++ b/templates/admin-page-nav.html
@@ -4,18 +4,18 @@
             <!-- first page -->
             {% if page != 1 %}
             <li style="display:inline">
-                <a href="{{ url_for(base_url, page=1) }}" aria-label="First"><span aria-hidden="true">&laquo;</span></a>
+                <a href="{{ url_for(base_url, page=1, query=query) }}" aria-label="First"><span aria-hidden="true">&laquo;</span></a>
             </li>
             <!-- previous page -->
             <li style="display:inline">
-                <a href="{{ url_for(base_url, page=page - 1) }}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a>
+                <a href="{{ url_for(base_url, page=page - 1, query=query) }}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a>
             </li>
             {% endif %}
             <!-- all page numbers -->
             {% for page_num in range([1, page - 3] | max, [total_pages + 1, page + 7] | min) %}
                 {% if page_num != page %}
                     <li style="display:inline">
-                        <a href="{{ url_for(base_url, page=page_num) }}">{{ page_num }}</a>
+                        <a href="{{ url_for(base_url, page=page_num, query=query) }}">{{ page_num }}</a>
                     </li>
                 {% else %}
                     <li class="active" style="display:inline">
@@ -26,10 +26,10 @@
             <!-- next page -->
             {% if page != total_pages %}
             <li style="display:inline">
-                <a href="{{ url_for(base_url, page=page + 1) }}" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a>
+                <a href="{{ url_for(base_url, page=page + 1, query=query) }}" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a>
             </li>
             <li style="display:inline">
-                <a href="{{ url_for(base_url, page=total_pages) }}" aria-label="Last"><span aria-hidden="true">&raquo;</span></a>
+                <a href="{{ url_for(base_url, page=total_pages, query=query) }}" aria-label="Last"><span aria-hidden="true">&raquo;</span></a>
             </li>
             {% endif %}
         </ul>


### PR DESCRIPTION
## Problems

- When #346 first deployed on `alpha`, only unprofiled pages would load. The rest were non-functional, and there was almost no logging or debugging output that we could find to explain why.
- If you perform a search in the admin pages, it might be multiple pages, but clicking to go to another page will discard the search. This makes it very hard to browse long searches.

## Cause

I made the profile dir manually, and I forgot to chown/chmod it so the `www-data` user could write to it. This made the profiler's base class throw on this line:

https://github.com/pallets/werkzeug/blob/248a79cf9292a4a5e1deec4906a1f5296f151172/src/werkzeug/middleware/profiler.py#L128

The right thing to do was **not** make the dir, because the code will make it if needed, with the right permissions.

This should be a rare situation, but it's a pretty serious failure, so some precautions are warranted.

And the admin page nav wasn't passing the query along.

## Considered and not done

Ideally, we would catch that exception. However, I tried that, and it doesn't work. I think the profiled run "uses up" the valid state of the `environ` and `start_response` input parameters, such that an unprofiled retry can't also use them to run properly.

## Changes

- Now we don't attempt a profiled run if the profile dir is set and unwritable. This way if there's a problem with the dir, the mystery to solve will be, "Why aren't we getting any profiling data?" rather than, "Why is the site completely unresponsive?"
- Now the admin page nav preserves the query, so you can go from one page of results to another
- Now the profiling list supports a new syntax for its searches:
  - `!term` - Only return searches that **do not** contain "term" in their routes