### PR TITLE
Cache results of common database queries

### DIFF
--- a/KerbalStuff/blueprints/accounts.py
+++ b/KerbalStuff/blueprints/accounts.py
@@ -48,7 +48,6 @@ def register() -> Union[str, werkzeug.wrappers.Response]:
             if username is not None:
                 kwargs['username'] = username
             kwargs['registration'] = _cfgb('registration')
-            print("test")
             return render_template("register.html", **kwargs)
         # All valid, let's make them an account
         user = User(username=username, email=email)

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -14,7 +14,7 @@ from werkzeug.utils import secure_filename
 
 from .accounts import check_password_criteria
 from ..ckan import send_to_ckan, notify_ckan
-from ..common import json_output, paginate_mods, with_session, get_mods, json_response, \
+from ..common import json_output, paginate_query, with_session, get_paginated_mods, json_response, \
     check_mod_editable, set_game_info, TRUE_STR, get_page
 from ..config import _cfg, _cfgi
 from ..database import db
@@ -334,14 +334,14 @@ def browse() -> Dict[str, Any]:
 @json_output
 def browse_new() -> Iterable[Dict[str, Any]]:
     mods = Mod.query.filter(Mod.published).order_by(desc(Mod.created))
-    mods, page, total_pages = paginate_mods(mods)
+    mods, page, total_pages = paginate_query(mods)
     return serialize_mod_list(mods)
 
 
 @api.route("/api/browse/top")
 @json_output
 def browse_top() -> Iterable[Dict[str, Any]]:
-    mods, *_ = get_mods()
+    mods, *_ = get_paginated_mods()
     return serialize_mod_list(mods)
 
 
@@ -349,7 +349,7 @@ def browse_top() -> Iterable[Dict[str, Any]]:
 @json_output
 def browse_featured() -> Iterable[Dict[str, Any]]:
     mods = Featured.query.order_by(desc(Featured.created))
-    mods, page, total_pages = paginate_mods(mods)
+    mods, page, total_pages = paginate_query(mods)
     return serialize_mod_list((f.mod for f in mods))
 
 

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -6,7 +6,7 @@ from flask_login import current_user
 from sqlalchemy import desc, or_
 import werkzeug.wrappers
 
-from ..common import loginrequired, with_session, get_game_info, paginate_mods
+from ..common import loginrequired, with_session, get_game_info, paginate_query
 from ..database import db
 from ..objects import Mod, ModList, ModListItem, Game
 
@@ -36,7 +36,7 @@ def packs(gameshort: Optional[str]) -> str:
         .order_by(desc(ModList.created))
     if game:
         query = query.filter(ModList.game_id == game.id)
-    packs, page, total_pages = paginate_mods(query, 15)
+    packs, page, total_pages = paginate_query(query, 15)
     return render_template("packs.html", ga=game, game=game, packs=packs, page=page, total_pages=total_pages)
 
 

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -2,6 +2,7 @@ alembic
 bcrypt>=3.1.0
 bleach
 bleach-allowlist
+cachetools
 celery
 click
 dnspython


### PR DESCRIPTION
## Motivation
Thanks to #346 we now have very valuable profiling data for our backend. After fixing the previous bottleneck, repeated template bytecode compilation due to disabled caching, the major part of most requests is now spent on database queries.
The answer: moar caching!

This PR does an initial step at caching the most common database queries (some of them executed on every request), that tend to not change at all or only very infrequently, or don't hurt if they are a bit out of date.
It's the low hanging fruit, there's still a lot more we should eventually cache, but those need some refactoring and other bigger changes, or careful planning. I preferred to get the easy stuff in first.

## Changes
We are caching all of the following requests in a `TTLCache`, that is s LRU cache with timeouts, using the `cachetools` library:
- https://github.com/tkem/cachetools
- https://cachetools.readthedocs.io/en/latest/

It allows caching the return values of a function by simply slapping a decorator on it, which makes it pretty easy to use.

### Cached lookups:
- The announcement blog post query done in `inject()` (executed for every request) cached for 30 minutes. If we create a new announcement or delete/edit an existing one, which happens very rarely, it doesn't hurt if it takes some time to be visible to all users.
  Caveat: it can happen that the workers get "out of sync" for up to 30 minutes, and the banner might change with every request depending on which worker your request goes to.
- All the mod lookups for `/browse`, `/browse/*.rss`, `/<gameshort>/browse`, `/<gameshort>`, `/<gameshort>/browse/*.rss` cached for 30 minutes. They are factored out into `get_*_mods()` functions in `common.py`, one for each of those categories (featured/new/updated/top). What changes most there are the new and updated mods, but they should be fine being 30 minutes behind as well.
- `/browse/all`, `/browse/top`, `/<gameshort>/browse/all`, `/<gameshort>/browse/top`, `/api/browse/top`, as well as `/search` and `/<gameshort>/search` through `search_mods()` cached for 10 minutes. I decided to give them a lower timeout, since mod searches also go through this function, and we don't really need to cache them. Maybe we should split the functions called by `*/top` and `*/search` at some point (and merge it with `get_top_mods()`).
  `search_mods()`  now takes a `Game.id` instead of the whole `Game`  object, since that's all it needed anyway, and the `Game`  objects change every time they're looked up from the database (i.e. with every request, they're never the same), which bypassed the cache.
- The queries for referrals, download stats and follow events in `/mod/<mod_id>`, `/mod/<mod_id>/<mod_name>/stats/(downloads|referrals|followers)` cached for 30 minutes.
  There _could_ be some issues due slightly mismatching 30 day time frames of the downloads/follows and `thirty_days_ago` which is then used by the graph workers. I might do some database manipulation to test it. But most likely we are fine there.

The cache times are a blind guess at what could be acceptable as lag behind current data and effectiveness of the cache.
The derivation of the cache sizes is documented in the code. I basically did a generous calculation of the amount of possible function argument combinations (since each combination gets its own key in the cache), then added or removed a bit depending on the situation.
Every cache size gets multiplied by 48 for the amoutnt of worker (and the actual size in bytes of the returned object), which needs to be considered.

I'm open for suggestions for better values of these two fields.

### Additional changes
- Renamed `get_mods()` to `get_paginated_mods()` and `paginate_mods()` to `paginate_query()` to help distinguishing them from each other (and `search_mods()`). Also `paginate_query()` could be used for other objects as well theoretically, not only mods.


## Some numbers
| Path | Before | After | Comment |
| ------ | -------- | ------- | ------------ |
| `/<gameshort>` | 115ms | 25ms | I think part of the reason this one and the one below (and `/browse`) were so bad is that we sorted by `Mod.download_count`, which is not indexed. |
| `/<gameshort>/browse` | 50ms | 12ms | |
| `/<gameshort>/browse/top` | 65ms | 20ms | |
| `/mod/<mod_id>` | 38ms | 35ms | Interestingly no relevant measurable improvement, maybe because we're still doing a ton of other SELECTs and UPDATEs |
| `/` | 10ms | 8ms |  |