### PR TITLE
Checkbox to hide a blog post or announcement from anonymous users

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -280,7 +280,9 @@ def inject() -> Dict[str, Any]:
     if request.cookies.get('dismissed_donation') is not None:
         dismissed_donation = True
     return {
-        'announcements': get_announcement_posts(),
+        'announcements': (get_all_announcement_posts()
+                          if current_user
+                          else get_non_member_announcement_posts()),
         'many_paragraphs': many_paragraphs,
         'analytics_id': _cfg("google_analytics_id"),
         'analytics_domain': _cfg("google_analytics_domain"),
@@ -309,5 +311,11 @@ def inject() -> Dict[str, Any]:
     }
 
 
-def get_announcement_posts() -> List[BlogPost]:
-    return BlogPost.query.filter(BlogPost.announcement == True).order_by(desc(BlogPost.created)).all()
+def get_all_announcement_posts() -> List[BlogPost]:
+    return BlogPost.query.filter(BlogPost.announcement).order_by(desc(BlogPost.created)).all()
+
+
+def get_non_member_announcement_posts() -> List[BlogPost]:
+    return BlogPost.query.filter(
+        BlogPost.announcement, BlogPost.members_only != True
+    ).order_by(desc(BlogPost.created)).all()

--- a/KerbalStuff/blueprints/blog.py
+++ b/KerbalStuff/blueprints/blog.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, abort
 import werkzeug.wrappers
 from typing import Union
+from flask_login import current_user
 
 from ..common import adminrequired, with_session, json_output, TRUE_STR
 from ..database import db
@@ -11,7 +12,9 @@ blog = Blueprint('blog', __name__, template_folder='../../templates/blog')
 
 @blog.route("/blog")
 def index() -> str:
-    posts = BlogPost.query.order_by(BlogPost.created.desc()).all()
+    posts = (BlogPost.query.order_by(BlogPost.created.desc()).all()
+             if current_user
+             else BlogPost.query.filter(BlogPost.members_only != True).order_by(BlogPost.created.desc()).all())
     return render_template("blog_index.html", posts=posts)
 
 
@@ -22,10 +25,12 @@ def post_blog() -> werkzeug.wrappers.Response:
     title = request.form.get('post-title')
     body = request.form.get('post-body')
     announcement = (request.form.get('announcement', '') in TRUE_STR)
+    members_only = (request.form.get('members_only', '') in TRUE_STR)
     post = BlogPost()
     post.title = title
     post.text = body
     post.announcement = announcement
+    post.members_only = members_only
     db.add(post)
     db.commit()
     return redirect("/blog/" + str(post.id))
@@ -44,6 +49,7 @@ def edit_blog(id: str) -> Union[str, werkzeug.wrappers.Response]:
         post.title = request.form.get('post-title')
         post.text = request.form.get('post-body')
         post.announcement = (request.form.get('announcement', '') in TRUE_STR)
+        post.members_only = (request.form.get('members_only', '') in TRUE_STR)
         return redirect("/blog/" + str(post.id))
 
 

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -33,7 +33,8 @@ class BlogPost(Base):  # type: ignore
     id = Column(Integer, primary_key=True)
     title = Column(Unicode(1024))
     text = Column(Unicode(65535))
-    announcement = Column(Boolean(), index=True, nullable=True, default=False)
+    announcement = Column(Boolean(), index=True, nullable=False, default=False)
+    members_only = Column(Boolean(), index=True, nullable=False, default=False)
     created = Column(DateTime, default=datetime.now, index=True)
 
     def __repr__(self) -> str:

--- a/alembic/versions/2021_06_23_12_00_00-426e0b848d77.py
+++ b/alembic/versions/2021_06_23_12_00_00-426e0b848d77.py
@@ -1,0 +1,33 @@
+"""Add BlogPost.members_only
+
+Revision ID: 426e0b848d77
+Revises: c0e44e063159
+Create Date: 2021-06-23 12:00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '426e0b848d77'
+down_revision = 'c0e44e063159'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    # First create nullable column
+    op.add_column('blog', sa.Column('members_only', sa.Boolean(), nullable=True, default=False))
+    # Set existing rows to False, using raw SQL for simplicity
+    op.execute("UPDATE blog SET members_only = false")
+    # Set NULL announcement rows to false as well
+    op.execute("UPDATE blog SET announcement = false WHERE announcement is NULL")
+    # Make columns non-nullable
+    op.alter_column('blog', 'members_only', nullable=False)
+    op.alter_column('blog', 'announcement', nullable=False)
+    op.create_index(op.f('ix_blog_members_only'), 'blog', ['members_only'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_blog_members_only'), table_name='blog')
+    op.drop_column('blog', 'members_only')
+    op.alter_column('blog', 'announcement', nullable=True)

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -32,6 +32,12 @@ class op:
                     column: str) -> None: ...
 
     @classmethod
+    def alter_column(cls,
+                    table_name: str,
+                    column_name: str,
+                    nullable: Optional[bool] = None) -> None: ...
+
+    @classmethod
     def create_index(cls,
                      index_name: str,
                      table_name: str,
@@ -58,3 +64,7 @@ class op:
                         constraint_name: str,
                         table_name: str,
                         type_: Optional[str] = None) -> None: ...
+
+    @classmethod
+    def execute(cls,
+                sqltext: str) -> None: ...

--- a/templates/admin-blog.html
+++ b/templates/admin-blog.html
@@ -18,6 +18,12 @@
                     Global announcement at top of all pages
                 </label>
             </div>
+            <div class="checkbox">
+                <label>
+                    <input id="members_only" name="members_only" type="checkbox">
+                    Only show this to logged in users
+                </label>
+            </div>
             <input type="submit" class="btn btn-primary btn-block" value="Publish">
         </form>
     </div>

--- a/templates/edit_blog.html
+++ b/templates/edit_blog.html
@@ -28,6 +28,13 @@
                 Global announcement at top of all pages
             </label>
         </div>
+        <div class="checkbox">
+            <label>
+                <input id="members_only" name="members_only" type="checkbox"
+                    {%- if post.members_only %} checked{% endif -%} >
+                Only show this to logged in users
+            </label>
+        </div>
         <div class="row">
             <div class="col-md-6">
                 <input type="submit" class="btn btn-primary btn-block" value="Save">


### PR DESCRIPTION
## Background

Today we put this in production to help decide whether to move forward with #348:

![image](https://user-images.githubusercontent.com/1559108/117735413-007b1880-b1bb-11eb-8f5f-b6d35cfc9f7d.png)

## Motivation

I thought using an announcement for this was so clever, but it's going to pull in users without accounts who have no idea that SpaceDock has "follow" functionality or email notifications already. That will add some noise to the discussion; it would be better if we could target logged in users only.

## Changes

Now a new "Only show this to logged in users" checkbox is available when creating or editing a blog post, which saves to a new Boolean column. If this column is True, then you have to be logged in to see that row, whether you're looking at the blog index or as an announcement. This way things that pertain only to logged in users can be flagged as such.