### PR TITLE
Better messaging for descriptionless modpacks

### DIFF
--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -40,10 +40,18 @@
     <div class="container">
         {%- if mod_list.description -%}
             {{ mod_list.description | markdown | bleach }}
+        {%- elif editable -%}
+            {%- if mod_list.mods -%}
+                <p>Your mod pack has no description! You should
+                    <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}">edit it</a>
+                    to replace this text!</p>
+            {%- else -%}
+                <p>Your mod pack is empty! You should
+                    <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}">edit it</a>
+                    to add some mods. You can edit this text, too!</p>
+            {%- endif -%}
         {%- else -%}
-            <p>Your mod pack is empty right now! You should
-            <a href="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}">edit it</a>
-            to add some mods. You can edit this text, too!</p>
+            <em>No description.</em>
         {%- endif -%}
     </div>
 </div>


### PR DESCRIPTION
## Problem

If a user creates a modpack without a description, SpaceDock displays this message:

![screenshot](https://cdn.discordapp.com/attachments/763685596556165121/841757031773896704/unknown.png)

It's wrong in two ways:

1. The user is addressed as if they own the mod pack even if they aren't the creator and could not edit it
2. It suggests that there are no mods added, even if there are several added

## Cause

Just sloppiness in the `mod_list.html` template.

## Changes

- Now if you can't edit, the message just says "No description."
- Now if you can edit and there are mods, the message just mentions the description being missing
- Otherwise the current message is shown