### PR TITLE
Revert caching of database queries

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import requests
 import werkzeug.wrappers
-from cachetools import TTLCache, cached
 from flask import Flask, render_template, g, url_for, Response, request
 from flask_login import LoginManager, current_user
 from flaskext.markdown import Markdown
@@ -310,6 +309,5 @@ def inject() -> Dict[str, Any]:
     }
 
 
-@cached(cache=TTLCache(maxsize=1, ttl=1800))
 def get_announcement_posts() -> List[BlogPost]:
     return BlogPost.query.filter(BlogPost.announcement == True).order_by(desc(BlogPost.created)).all()

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -10,7 +10,6 @@ from typing import Union, List, Any, Optional, Callable, Tuple, Iterable
 import bleach
 import werkzeug.wrappers
 from bleach_allowlist import bleach_allowlist
-from cachetools import cached, TTLCache
 from flask import jsonify, redirect, request, Response, abort, session
 from flask_login import current_user
 from markupsafe import Markup
@@ -158,8 +157,6 @@ def get_paginated_mods(ga: Game = None, query: str = '', page_size: int = 30) ->
     return mods, page, total_pages
 
 
-# (2 games + None) * (limit 6 + limit 30) = 6 argument combinations
-@cached(cache=TTLCache(maxsize=10, ttl=1800))
 def get_featured_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     mods = Featured.query.outerjoin(Mod).filter(Mod.published).order_by(desc(Featured.created))
     if game_id:
@@ -167,7 +164,6 @@ def get_featured_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     return mods.limit(limit).all()
 
 
-@cached(cache=TTLCache(maxsize=10, ttl=1800))
 def get_top_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     mods = Mod.query.filter(Mod.published).order_by(desc(Mod.score))
     if game_id:
@@ -175,7 +171,6 @@ def get_top_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     return mods.limit(limit).all()
 
 
-@cached(cache=TTLCache(maxsize=10, ttl=1800))
 def get_new_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     mods = Mod.query.filter(Mod.published).order_by(desc(Mod.created))
     if game_id:
@@ -183,7 +178,6 @@ def get_new_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     return mods.limit(limit).all()
 
 
-@cached(cache=TTLCache(maxsize=10, ttl=1800))
 def get_updated_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id))\
         .order_by(desc(Mod.updated))
@@ -192,8 +186,6 @@ def get_updated_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     return mods.limit(limit).all()
 
 
-# (3000 mods) * (limit 10 + limit None (rare)) = 6000 argument combinations
-@cached(cache=TTLCache(maxsize=1000, ttl=1800))
 def get_referral_events(mod_id: int, limit: Optional[int] = None) -> List[ReferralEvent]:
     events = ReferralEvent.query\
         .filter(ReferralEvent.mod_id == mod_id)\
@@ -204,8 +196,6 @@ def get_referral_events(mod_id: int, limit: Optional[int] = None) -> List[Referr
 
 
 # Returns all download events for this mod, optionally within a timeframe from now()-timeframe to now()
-# (3000 mods) * (timeframe 30d + timeframe None (rare)) = 6000 argument combinations
-@cached(cache=TTLCache(maxsize=1000, ttl=1800))
 def get_download_events(mod_id: int, timeframe: Optional[timedelta] = None) -> List[DownloadEvent]:
     events = DownloadEvent.query\
         .filter(DownloadEvent.mod_id == mod_id)\
@@ -217,7 +207,6 @@ def get_download_events(mod_id: int, timeframe: Optional[timedelta] = None) -> L
 
 
 # Returns all follow events for this mod, optionally within a timeframe from now()-timeframe to now()
-@cached(cache=TTLCache(maxsize=1000, ttl=1800))
 def get_follow_events(mod_id: int, timeframe: Optional[timedelta] = None) -> List[FollowEvent]:
     events = FollowEvent.query\
         .filter(FollowEvent.mod_id == mod_id)\
@@ -228,8 +217,6 @@ def get_follow_events(mod_id: int, timeframe: Optional[timedelta] = None) -> Lis
     return events.all()
 
 
-# Returns the list of active games, sorted by creation date
-@cached(cache=TTLCache(maxsize=1, ttl=1800))
 def get_games() -> List[Game]:
     return Game.query.filter(Game.active).order_by(desc(Game.created)).all()
 

--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -2,7 +2,6 @@ import math
 from datetime import datetime
 from typing import List, Iterable, Tuple, Optional
 
-from cachetools import TTLCache, cached
 from packaging import version
 from sqlalchemy import and_, or_, desc
 
@@ -64,8 +63,6 @@ def game_versions(game: Game) -> Iterable[version.Version]:
             pass
 
 
-# (2 games + None) * (limit 30) * (empty search + infinite user searches) * (100 pages) = 300+
-@cached(cache=TTLCache(maxsize=600, ttl=600))
 def search_mods(game_id: Optional[int], text: str, page: int, limit: int) -> Tuple[List[Mod], int]:
     terms = text.split(' ')
     query = db.query(Mod).join(Mod.user).join(Mod.game)

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -2,7 +2,6 @@ alembic
 bcrypt>=3.1.0
 bleach
 bleach-allowlist
-cachetools
 celery
 click
 dnspython


### PR DESCRIPTION
A partial revert of #349, see https://github.com/KSP-SpaceDock/SpaceDock/pull/349#issuecomment-836572854

SqlAlchemy doesn't like its returned objects to be cached, due to its lazy loading behaviour.
Eager loading isn't an option for `Mod` objects, since they have a ton of relationships that kill the database when queried at once.

Maybe there's a solution for this somewhere, but I haven't found one yet. Let's revert the caching, to make the site stable again.