### PR TITLE
Freeze dependencies on version they have at deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ local/
 
 config.ini
 alembic.ini
+.last_head
+.frozen-requirements.txt
 
 /storage
 /spacedock-db

--- a/KerbalStuff/middleware/profiler.py
+++ b/KerbalStuff/middleware/profiler.py
@@ -2,10 +2,11 @@ from sys import stdout
 from os import access, W_OK
 from typing import Optional, Iterable, Union, Callable, TextIO, List, TYPE_CHECKING
 
-from werkzeug.contrib.profiler import ProfilerMiddleware
+from werkzeug.middleware.profiler import ProfilerMiddleware
 
 if TYPE_CHECKING:
     from wsgiref.types import StartResponse, WSGIApplication, WSGIEnvironment
+
 
 class ConditionalProfilerMiddleware(ProfilerMiddleware):
     def __init__(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,10 @@ services:
       - FLASK_RUN_HOST=0.0.0.0
       - FLASK_ENV=development
       - FLASK_DEBUG=1
+      - SQLALCHEMY_WARN_20=1
       - CONNECTION_STRING=${CONNECTION_STRING}
     command: >
-      flask run
+      python3 -W default -m flask run
     ports:
       - 9999:9999
     volumes:

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
+# Compares the current git HEAD with the one of the previous deployment.
+# If it is the same, install the same requirements version as last time.
+# If it differs, upgrade all packages to the latest version.
+
 set -e
 
-# works inside SpaceDock folder on alpha/beta, which is a venv
-bin/pip3 install --no-cache-dir -U -r requirements.txt
+if [[ -f .last_head ]]; then
+    LAST_HEAD=$(cat .last_head)
+else
+    LAST_HEAD=""
+fi
 
-./build-frontend.sh
+HEAD=$(git rev-parse HEAD)
+
+# Make sure we've got the latest pip, to benefit of security and relationship resolver fixes.
+bin/pip3 install -U pip
+
+if [[ "$LAST_HEAD" != "$HEAD" || ! -f .frozen-requirements.txt ]]; then
+  echo "HEAD at last deployment: $LAST_HEAD - Current HEAD: $HEAD"
+  # works inside SpaceDock folder on alpha/beta, which is a venv
+  bin/pip3 install --no-cache-dir -U -r requirements.txt
+  bin/pip3 freeze > .frozen-requirements.txt
+
+  # Frontend only needs to be rebuilt if the commit changed
+  ./build-frontend.sh
+else
+  bin/pip3 install --no-cache-dir -r .frozen-requirements.txt
+fi
+
+echo "$HEAD" > .last_head

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -1,30 +1,30 @@
 alembic
-bcrypt>=3.1.0
+bcrypt>=3.1.0 # We use 3.1 specific functions, make sure no other dependency downgrades it
 bleach
 bleach-allowlist
 celery
 click
 dnspython
-flask
-flask-login
-flask-markdown
-flask-oauthlib
-gunicorn
+flameprof
+Flask<2 # Needs testing before upgrading
+Flask-Login
+Flask-Markdown
+Flask-OAuthlib
 future
-jinja2
-markdown
-markupsafe
-oauthlib==2.0.6
+gunicorn
+Jinja2<3 # See Flask
+Markdown
+MarkupSafe
+oauthlib
 packaging
-pillow
+Pillow
 psycopg2-binary
 PyGithub
 python-daemon
 redis
 requests
-requests-oauthlib==0.8.0
-sqlalchemy
-sqlalchemy_utils
+requests-oauthlib
+SQLAlchemy>=1.4,<2 # 1.4 shows deprecation warnings for 2.0, 2.0 would break our backend as of now
+SQLAlchemy-Utils
 urllib3
-werkzeug==0.16.1
-flameprof
+Werkzeug

--- a/requirements-celery.txt
+++ b/requirements-celery.txt
@@ -1,2 +1,2 @@
-gitpython
+GitPython
 billiard

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,1 +1,1 @@
-uwsgi
+uWSGI


### PR DESCRIPTION
## Problem
Right now, every restart of the production instance (or alpha/beta as well) upgrades all Python dependencies to their very latest version, if unpinned (and most of them are).
On alpha, this lead to the backend not coming back up again recently, because it silently upgraded to Flask 2.0, but stayed at Werkzeug 0.16.1 because it is pinned, while Flask 2.0 needs Werkzeug >=2.0 to work.

This could be mitigated by upgrading the installed pip (20.0.2) to the latest version, since [pip 20.3 gained a new, fixed dependency resolver](https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020), which now installs the latest Flask that still works with Werkzeug 0.16.1 (1.1.4).
If we didn't have Werkzeug pinned, alpha would've been broken as well:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 240, in locate_app
    __import__(module_name)
  File "/opt/spacedock/KerbalStuff/app.py", line 62, in <module>
    from .middleware.profiler import ConditionalProfilerMiddleware
  File "/opt/spacedock/KerbalStuff/middleware/profiler.py", line 5, in <module>
    from werkzeug.contrib.profiler import ProfilerMiddleware
ModuleNotFoundError: No module named 'werkzeug.contrib'
```
Werkzeug moved `profiler` to `werkzeug.middleware` in 1.0.

Nothing prevents production to fail from similar package updates at any time.
for example, SqlAlchemy will drop soon-ish, and thanks to deprecation warnings I've turned on (see below), I know that our backend will break.

## Considerations
We need some way to "pin" package versions on production.
Pinning them to a single version in `requirements.txt` would be very ugly and probably keep us from every updating any package again.
Bots like dependabot are really annoying.

Not running upgrading packages on production doesn't really work either, otherwise production will always stay at ancients versions, except if we start to specify minimum versions. 

Limiting the maximum version isn't very safe either, nothing prevents dependencies from introducing breaking changes in minor version updates (even if they shouldn't).

If we deployed Docker images, this would be a solved problem. The image always keeps whatever dependencies were at when building and testing the image. They're basically baked in and never change, unless a new image gets built, tested and deployed.
Well, we don't deploy Docker containers. So here's my best attempt to mimic it:
Let's upgrade the packages whenever we deploy new changes, but not when simply restarting the server!

## Changes
Let's freeze dependencies at whatever version they're at when deploying new production updates.
`prepare.sh` now checks the commit hash of the last time we restarted production (reading from `.last_head`), and compares it with the new/current one.
* If they don't match, i.e. we're deploying new changes to production: install and upgrade all packages from `requirements.txt`, echo the output of `pip freeze` into a `.frozen-requirements.txt` file.
* If they do match: don't upgrade, but install all packages from this `.frozen-requirements.txt` instead of `requirements.txt`.
Afterwards, put the current commit hash into`.last_head` for the next time.

Additionally, we're also upgrading pip in `prepare.sh`, to make sure we benefit from any potential security or bug fixes. I really hope that pip itself doesn't change its basic commandline interface...
  
It _might_ be enough to just leave out the `--upgrade` / `-U` in the second scenario, instead of saving and reading the package versions in a file. But for one I don't fully trust pip, and it would also lead to upgraded packages if we ever removed the venv library for some reason.

This should make sure that package versions on production at least somewhat resemble the state we've tested locally/on alpha/beta / in CI. Sure, there's not guarantee that a breaking update released in the time between we tested things and we deploy on production, or that we actually have the latest dependencies installed in our dev environments, but we're pretty limited in our possibilities here.
It's probably the closest we can get to an idempotent deployment.

**Further changes**
- Unpin Werkzeug 0.16.1 – this was done due to an old Flask version being incompatible with Werkzeug 1.0, but newer Flask versions have been fixed (even in the 1.x series).
- Pin Flask to <2.0, we should do some testing before letting anything upgrade to it.
- Unping oauthlib 2.0.6 and requests-oauthlib 0.8.0, I have no idea why this was done, but it happened during Alista's great restructuring efforts a long time ago. I think we have all oauth functionality disabled anyway.
- Pin SQLAlchemy to >=1.4,<2, 1.4 gives us all the deprecation warnings for 2.0, and 2.0 will drop soon-ish and would definitely break.

- Change the import path of `ProfilerMiddleware` to fix the above import error
- Turn on SqlAlchemy 2.0 deprecation warnings when running the Docker stack for development. Can be seen in the backend logs. Had to change the CMD to make the Python binary call the Flask module with `-W default`, running the Flask binary directly didn't output any warnings. It also ouputs deprecation warnings from other modules now.

---

Sorry, the PR description got kinda long. But I wanted to make sure that anybody who wants to can understand the problem, and that if we go down this route, future maintainers can re-read why we did what we did back then.