### PR TITLE
Eliminate anonymous session cookies

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -26,6 +26,7 @@ from .blueprints.lists import lists
 from .blueprints.login_oauth import list_defined_oauths, login_oauth
 from .blueprints.mods import mods
 from .blueprints.profile import profiles
+from .middleware.session_interface import OnlyLoggedInSessionInterface
 from .celery import update_from_github
 from .common import first_paragraphs, many_paragraphs, json_output, jsonify_exception, dumb_object, sanitize_text
 from .config import _cfg, _cfgb, _cfgd, _cfgi, site_logger
@@ -54,6 +55,7 @@ app.jinja_env.filters['bleach'] = sanitize_text
 app.jinja_env.auto_reload = app.debug
 app.secret_key = _cfg("secret-key")
 app.json_encoder = CustomJSONEncoder
+app.session_interface = OnlyLoggedInSessionInterface()
 Markdown(app, extensions=[KerbDown(), 'fenced_code'])
 login_manager = LoginManager(app)
 

--- a/KerbalStuff/middleware/session_interface.py
+++ b/KerbalStuff/middleware/session_interface.py
@@ -1,0 +1,13 @@
+from typing import Union
+from flask import session
+from flask.sessions import SecureCookieSessionInterface
+from flask_login import current_user
+
+class OnlyLoggedInSessionInterface(SecureCookieSessionInterface):
+
+    """Don't send session cookies for anonymous users"""
+    def save_session(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        if not current_user:
+            # Tell client to delete the session cookie
+            session.clear()
+        return super().save_session(*args, **kwargs)


### PR DESCRIPTION
## Motivation

We were brainstorming ways to use @V1TA5's Apache Traffic Server to speed things up, and one idea that came up was to cache anonymous requests. If you are logged in, then several parts of each page depend dynamically on your user context. But if you're **not** logged in, then you and every other anonymous user will see pretty much the same thing for every page. Currently those requests go all the way to the backend, hit the database, render a Jinja2 template, etc., just to regenerate the same page that everyone else sees who is not logged in.

## Problem

Currently there's no way for anyone other than the backend to tell the difference between a logged in and logged out user. They all have a `session` cookie that contains some little bits of data, probably from here, maybe also some places in Flask itself:

https://github.com/KSP-SpaceDock/SpaceDock/blob/9d6dadd3dda66e2ece6298b4e4c8e2b76f782b8f/KerbalStuff/common.py#L173-L177

Only after Flask reads and parses that cookie do we find out whether or not `current_user` is `False`-y.

## Changes

Now if you log out, your session cookie will be deleted. The client will then not send it in future requests, so the traffic server will have the opportunity to tell the difference between logged in and logged out users. Note that this would require additional configuration work; all we are doing in this pull request is making it _possible_ to draw the distinction.

I tried doing this by removing `set_game_info`, but the session cookie persisted. Clearing it in the session interface's `save_session` worked, though.

### Future configuration

Brainstorming the details of what ATS should do:

- If a request has a session cookie, don't cache it
- If a request uses POST, don't cache it (so anonymous users can still log in and _get_ a session cookie)
- If a request is to any `/mod/` route, don't cache it (so download and referral stats will still be accurate)
- If a request is to any `/api/` route, don't cache it (to make sure the CKAN bot gets up to date info)
- Otherwise cache requests for 5 minutes

That should reduce the backend to mostly handling requests for logged in users, with occasional anonymous requests poking through to keep the cache from getting too out of date.