### PR TITLE
Allow editing names of mods and modpacks

### DIFF
--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -93,14 +93,18 @@ def edit_list(list_id: str, list_name: str) -> Union[str, werkzeug.wrappers.Resp
                                    'ga': ga
                                })
     else:
+        name = request.form.get('name', '')
         description = request.form.get('description')
         background = request.form.get('background')
         bgOffsetY = request.form.get('bg-offset-y', 0)
         mods = json.loads(request.form.get('mods', ''))
+        if not name or len(name) > 100:
+            abort(400)
         if any(mod_list.game != Mod.query.get(mod_id).game for mod_id in mods):
             # The client validates this in a more friendly way,
             # we just need to make sure nobody bypasses it
             abort(400)
+        mod_list.name = name
         mod_list.description = description
         if background and background != '':
             mod_list.background = background

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -218,8 +218,9 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
         return render_template("edit_mod.html", mod=mod, original=original,
                                new=request.args.get('new') is not None and original)
     else:
-        short_description = request.form.get('short-description')
-        license = request.form.get('license')
+        name = request.form.get('name', '')
+        short_description = request.form.get('short-description', '')
+        license = request.form.get('license', '')
         donation_link = request.form.get('donation-link')
         external_link = request.form.get('external-link')
         source_link = request.form.get('source-link')
@@ -227,6 +228,11 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
         ckan = request.form.get('ckan')
         background = request.form.get('background')
         bgOffsetY = request.form.get('bg-offset-y', 0)
+        if not name or len(name) > 100 \
+            or not short_description or len(short_description) > 1000 \
+            or not license or len(license) > 128:
+            abort(400)
+        mod.name = name
         mod.license = license
         mod.donation_link = donation_link
         mod.external_link = external_link

--- a/templates/edit_list.html
+++ b/templates/edit_list.html
@@ -36,8 +36,12 @@
 
     <div class="container lead">
         <div class="row">
+            <h1>Edit Modpack</h1>
+        </div>
+        <div class="row">
             <div class="col-md-8">
-                <h1 title="{{ mod_list.name }}">Edit {{ mod_list.name }}</h1>
+                <label for="name" class="text-muted">Name:</label>
+                <input type="text" class="form-control input-lg" name="name" maxlength="100" value="{{mod_list.name}}" />
             </div>
             <div class="col-md-4">
                 <input type="submit" class="btn btn-primary btn-block" value="Save Changes" />

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -52,9 +52,14 @@
 
     <div class="container lead">
         <div class="row">
+            <h1>Edit Mod</h1>
+        </div>
+        <div class="row">
             <div class="col-md-8">
-                <h1 title="{{ mod.name }}">Edit {{ mod.name }}</h1>
-                <input type="text" class="form-control input-block-level" name="short-description" value="{{ mod.short_description }}" placeholder="Short description..." />
+                <label for="name" class="text-muted">Name:</label>
+                <input type="text" class="form-control input-lg" name="name" maxlength="100" value="{{mod.name}}" />
+                <label for="short-description" class="text-muted">Description:</label>
+                <input type="text" class="form-control" name="short-description" maxlength="1000" value="{{ mod.short_description }}" placeholder="Short description..." />
             </div>
             <div class="col-md-4">
                 <input type="submit" class="btn btn-primary btn-block" value="Save Changes" />
@@ -82,7 +87,7 @@
                                         <span class="text-muted">
                                             License:
                                         </span>
-                                        <input type="text" class="form-control" name="license" value="{{ mod.license }}">
+                                        <input type="text" class="form-control" name="license" maxlength="128" value="{{ mod.license }}">
                                     </h2>
                                 </div>
                             </div>

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -16,14 +16,11 @@
 <div class="container lead">
     <div class="row">
         <div class="col-md-8">
-            <h3 title="{{ mod_list.name }}">
-                {{ mod_list.name }}
-                <br/>
-                <small>
-                    for {{ mod_list.game.name }},
-                    from <a href='{{url_for("profile.view_profile", username=mod_list.user.username)}}'>{{ mod_list.user.username }}</a>
-                </small>
-            </h3>
+            <h1 title="{{ mod_list.name }}">{{ mod_list.name }}</h1>
+            <h3><small>
+                for {{ mod_list.game.name }},
+                from <a href='{{url_for("profile.view_profile", username=mod_list.user.username)}}'>{{ mod_list.user.username }}</a>
+            </small></h3>
         </div>
         {% if editable %}
             <div class="col-md-4">


### PR DESCRIPTION
## Motivation

After a mod is created, its name is locked in permanently and can't be edited. If the author notices an error in the name and wants to fix it, they can't. This leads some authors to delete a mod and create a "new" mod to replace it, which is not great since all the releases up to that point are deleted and must be re-uploaded if they are to be available under the new entry.

Modpack names also can't be edited.

This is a strange and very unforgiving way for a web site to work, demanding perfection on the first edit. It may originally have been done this way because of how uploaded files were named at some point, but now the storage path is saved to the `ModVersion` row and can be found regardless of the current name.

### Known real world examples 

Non-exhaustive list of known cases where a mod is stuck with a name that would be beneficial to be able to change: 

- Someday this mod will no longer be a work in progress, but it will still have `[WIP]` permanently stamped into its name:
  https://spacedock.info/mod/2626/TrekDrive%20by%20ShadowWorks%20%5BWIP%5D
- This mod will probably release a version for KSP 1.12 someday, but its name will forever suggest it only goes up to 1.11:
  https://spacedock.info/mod/2761/Electron%20strong%20back%20erector%20mod%20%28for%20KSP%201.8.x-1.11.x%29
- A combination of the two above, this mod will likely leave the WIP status at some point, and also release a version for KSP 1.12:
  https://spacedock.info/mod/2716/%281.11x%29%28WIP%29%20Titania%20A%20New%20Moon%20To%20Kerbin%20Between%20The%20Mun%20And%20Minmus
- This mod will probably release more versions, but it will forever say "v1.0.0" in its name:
  https://spacedock.info/mod/2718/Ziegler%20Launch%20System%20v1.0.0
- This mod has a typo in its name and @linuxgurugamer would like to fix it:
  https://spacedock.info/mod/1869/ABFW%20Revived%20(Windows%20version)
  Deleting is not a viable option because the release history would be lost
- This mod has both "(WIP)" and the compatibility in the name: https://spacedock.info/mod/2716/%281.11x%29%28WIP%29%20Titania%20A%20New%20Moon%20To%20Kerbin%20Between%20The%20Mun%20And%20Minmus
- This mod is likely going to leave alpha state at some point:
  https://spacedock.info/mod/2810/RSS%20launchsites%20alpha

Known cases where mods have been deleted and replaced solely to fix the name:

- KSP-CKAN/NetKAN#8524 was submitted for this mod:
  https://spacedock.info/mod/2734/CollectingSP%27s%20U.S.%20Ribbons%20Pack
  ... which was then deleted so the name could be changed (see https://github.com/KSP-CKAN/NetKAN#8525):
  https://spacedock.info/mod/2744/CollectingSP%27s%20U.S.%20Ribbons%20Pack%20%28For%20Final%20Frontier%29
- KSP-CKAN/NetKAN#8244 was submitted for this mod:
  https://spacedock.info/mod/2513/Kerbalism%20Kompanion%20Kalkulator
  ... which was then deleted and replaced because the name accidentally referenced a notorious US hate group:
  https://spacedock.info/mod/2580/Kerbalism%20Companion%20Calculator
- KSP-CKAN/NetKAN/pull/8635 was submitted for this mod:
  https://spacedock.info/mod/2807/Kerbin%20Sider%20Remastered%20-%20The%20Life%20Aquatic
  ... which was then deleted and replaced because the name had a typo:
  https://spacedock.info/mod/2808/Kerbin%20Side%20Remastered%20-%20The%20Life%20Aquatic

## Considered and not done

It has been suggested that we might indicate previous names of a mod in the mod page:

![image](https://user-images.githubusercontent.com/1559108/119719405-5b08ab80-be2e-11eb-9d9a-bc1d287cd8b7.png)

That is **not** part of this PR, because it does not address any known use cases and is counter-indicated by most of them. If a mod's name previously had a typo or accidentally referenced a hate group, including that name in parentheses under the current name is counter-productive rather than helpful.

Similarly, an icon to indicate that the name was changed has been suggested. That's also **not** part of this PR, because we don't know of any case where it would be useful.

It's been suggested that users might be confused if the name embedded in an old SpaceDock URL is not identical to the one currently on that page. I would propose that the user would be able to understand, "Oh, this mod was renamed."

## Changes

- Now the pages for editing mods and modpacks have an editable Name text box
- The editing page is now subject to the same length limits as mod creation (100 characters for the name, 1000 for the description, 128 for the license)

Fixes #62.