### PR TITLE
Allow http or nothing in forum links

### DIFF
--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -51,8 +51,8 @@
                                         <span class="text-muted">
                                             Forums:
                                         </span>
-                                        {% if forum_url_username %}
-                                            <a target="_blank" href="{{profile.forumUsername}}">
+                                        {% if forum_url and forum_url_username %}
+                                            <a target="_blank" href="{{forum_url}}">
                                                 {{forum_url_username}}
                                             </a>
                                         {% else %}


### PR DESCRIPTION
## Problem

In #331, we added automatic parsing of forum links on the profile page to make them more easily clickable.

However, thanks to #345, we are able to easily jump back to the very earliest accounts, which predate the ubiquity of HTTPS on the interwebs, so their forum links start with `http://`:

- https://spacedock.info/profile/SpaceIsBig42
- https://spacedock.info/profile/Snark
- https://spacedock.info/profile/daniel_l
- https://spacedock.info/profile/erendrake
- https://spacedock.info/profile/simon56modder

One user even left off that part of the URL completely:

- https://spacedock.info/profile/theJesuit

Currently these profiles do not benefit from the parsing and formatting of #331.

## Cause

The regex for parsing the links starts with `https`. This is unnecessarily restrictive.

## Changes

Now the regex allows `http://` links or just `forum....`