### PR TITLE
Fewer modpacks per page, hide modpacks without mods

### DIFF
--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -32,11 +32,11 @@ def _get_mod_list(list_id: str) -> Tuple[ModList, Game, bool]:
 def packs(gameshort: Optional[str]) -> str:
     game = None if not gameshort else get_game_info(short=gameshort)
     query = ModList.query \
-        .filter(or_(ModList.mods.any(), ModList.description != '')) \
+        .filter(ModList.mods.any()) \
         .order_by(desc(ModList.created))
     if game:
         query = query.filter(ModList.game_id == game.id)
-    packs, page, total_pages = paginate_query(query, 15)
+    packs, page, total_pages = paginate_query(query, 9)
     return render_template("packs.html", ga=game, game=game, packs=packs, page=page, total_pages=total_pages)
 
 


### PR DESCRIPTION
## Problems

The mod packs listing looks a bit better now, but you have to scroll down to get to the next/previous page buttons.

- https://spacedock.info/packs/kerbal-space-program

Also this morning we found that 3 of the 4 Balsa mod packs on production were advertisements from those user accounts about having someone do your homework or free laptops or finding European women to date.

## Cause

Mods are shown in pages of 5 rows each.

Mod packs are likewise shown in pages of 5 rows each, even though they are twice as tall.

Mod packs were shown in the listing if they had zero mods and a description. This was intended to allow users to list mods that aren't on SpaceDock in the description, but that turned out to enable abuse.

## Changes

Now we show 9 mod packs per page instead of 15. This will be 3 rows, and fit the available space better.

Now a mod pack must have at least 1 mod in it to show up in the packs listing.