### PR TITLE
Add long description to mod creation page

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -605,6 +605,7 @@ def create_mod() -> Tuple[Dict[str, Any], int]:
         return {'error': True, 'reason': 'Only users with public profiles may create mods.'}, 403
     mod_name = request.form.get('name')
     short_description = request.form.get('short-description')
+    description = request.form.get('description', default_description)
     mod_friendly_version = secure_filename(request.form.get('version', ''))
     # 'game' is deprecated, but kept for compatibility
     game_id = request.form.get('game-id') or request.form.get('game')
@@ -662,7 +663,7 @@ def create_mod() -> Tuple[Dict[str, Any], int]:
         mod = Mod(user=current_user,
                   name=mod_name,
                   short_description=short_description,
-                  description=default_description,
+                  description=description,
                   license=mod_licence,
                   ckan=(request.form.get('ckan', '').lower() in TRUE_STR),
                   game=game,

--- a/frontend/coffee/create.coffee
+++ b/frontend/coffee/create.coffee
@@ -1,3 +1,5 @@
+editor = new Editor()
+editor.render()
 dropzone = require('dropzone')
 
 error = (name) ->
@@ -10,6 +12,7 @@ valid = ->
 
     error('mod-name') if $("#mod-name").val() == ''
     error('mod-short-description') if $("#mod-short-description").val() == ''
+    error('description') if editor.codemirror.getValue() == ''
     error('mod-license') if $("#mod-license").val() == ''
     error('mod-version') if $("#mod-version").val() == ''
     error('mod-game') if $("#mod-game").val() == null
@@ -42,6 +45,7 @@ dropzone.options.uploader =
             'dzchunkindex': chunk.index,
             'name': $("#mod-name").val(),
             'short-description': $("#mod-short-description").val(),
+            'description': editor.codemirror.getValue(),
             'version': $("#mod-version").val(),
             'game-id': $('#mod-game').val(),
             'game-version': $('#mod-game-version').val(),

--- a/frontend/styles/create.scss
+++ b/frontend/styles/create.scss
@@ -55,6 +55,14 @@
     padding-bottom: 50px;
 }
 
+.row .CodeMirror {
+    height: 12em;
+}
+
+.has-error .CodeMirror {
+    border: 1px solid #a94442;
+}
+
 .upload-mod {
     border: 5px dotted #ccc;
     background: inherit;

--- a/templates/create.html
+++ b/templates/create.html
@@ -39,7 +39,7 @@
                 <h2 class="control-label">Short description</h2>
             </div>
             <div class="col-md-8 form-group">
-                <input id="mod-short-description" class="form-control input-lg" type="text" maxLength=1000 />
+                <input id="mod-short-description" class="form-control input-lg" type="text" placeholder="A few words summarizing this mod" maxLength=1000 />
             </div>
         </div>
         <div class="row">
@@ -75,10 +75,16 @@
             <div class="col-md-8 form-group">
                 <select id="mod-license" class="chosen-select">
                     <option value="MIT" selected>MIT</option>
-                    <option value="BSD">BSD</option>
-                    <option value="GPLv2">GPLv2</option>
-                    <option value="GPLv3">GPLv3</option>
+                    <option value="CC-BY">CC-BY</option>
+                    <option value="CC-BY-SA">CC-BY-SA</option>
+                    <option value="CC-BY-ND">CC-BY-ND</option>
+                    <option value="CC-BY-NC-SA">CC-BY-NC-SA</option>
+                    <option value="CC-BY-NC-ND">CC-BY-NC-ND</option>
+                    <option value="CC0">CC0</option>
+                    <option value="GPL-2.0">GPL-2.0</option>
+                    <option value="GPL-3.0">GPL-3.0</option>
                     <option value="LGPL">LGPL</option>
+                    <option value="BSD">BSD</option>
                     <option value="Other">Other</option>
                 </select>
                 <input id="mod-other-license" type="text" class="form-control input-lg hidden"
@@ -94,6 +100,15 @@
                     <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="left"
                         title="This makes it so that users can automate the installation of your mod. Your mod won't be added to CKAN until you publish it."></span>
                 </label>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-4">
+                <h2 class="control-label">Long description</h2>
+            </div>
+            <div class="col-md-8 form-group">
+                <a target="_blank" href="/markdown">Markdown</a> is supported here.
+                <textarea class="form-control input-block-level" name="description" id="description"></textarea>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
## Motivation

Some mods have very long short decriptions, including such things as previous maintainers and dependencies. Looking at it from a user experience point of view, we suspect this is because the short description field is the only description field on the mod creation page, so the user may not know that a long description field exists and will be available later.

## Changes

Now the long description field is added to the mod creation page. In addition, the short description now has a placeholder:

![image](https://user-images.githubusercontent.com/1559108/120341026-25474500-c2bc-11eb-824d-a7ccc17ba290.png)

Together, these will hopefully encourage users to enter the long detailed info in the long description instead of the short description.

I tried to add a placeholder for the long description, but I was not able to get that to work. I think the CodeMirror editor requires an add-on to do it, but we're using an old version of it, and I don't know where to get the old add-ons.

Fixes #366.