### PR TITLE
Boost scores for mods in other users' mod packs

### DIFF
--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -12,6 +12,7 @@ from .objects import Mod, ModVersion, User, Game, GameVersion
 def get_mod_score(mod: Mod) -> int:
     # Factors considered, * indicates important factors:
     # High followers and high downloads get bumped*
+    # Mods that other users include in their mod packs get bumped
     # Mods with a long version history get bumped
     # Mods with lots of screenshots or videos get bumped
     # Mods with a short description get docked
@@ -22,8 +23,9 @@ def get_mod_score(mod: Mod) -> int:
     score = 0
     if mod.default_version is None:
         return score
-    score += mod.follower_count * 10
     score += mod.download_count
+    score += 10 * mod.follower_count
+    score += 15 * len({itm.mod_list for itm in mod.mod_list_items if itm.mod_list.user_id != mod.user_id})
     score += len(mod.versions) // 5
     score += len(mod.media)
     if len(mod.description) < 100:


### PR DESCRIPTION
## Motivation

Mod scores are the default sort when browsing mods and are meant to reflect the overall quality or popularity of a mod. Since that's a broad concept, the scores pull from many different fields, primarily downloads, but also follower counts, how filled-in the mod's data is, how old and up to date the mod is, etc.

If a user puts another user's mod in a mod pack, this is implicitly an endorsement of that mod, but currently we don't take advantage of this knowledge.

## Changes

Now each time another user adds a mod to a mod pack, the equivalent of 15 downloads is added to that mod's score.

For comparison, following a mod contributes the equivalent of 10 downloads. I felt that clicking the Follow button or a star icon is a much easier action than creating a mod pack, typing a name, clicking Add, then saving the mod pack, so the latter should count for slightly more.

Adding your own mod to your own mod pack will not affect your mod's score, since that would be cheesy and not very meaningful.