### PR TITLE
Let users choose which emails to receive

### DIFF
--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -5,7 +5,7 @@ from flask import url_for
 from jinja2 import Template
 from werkzeug.utils import secure_filename
 
-from .objects import User, Mod, ModVersion
+from .objects import User, Mod, ModVersion, Following
 from .celery import send_mail
 from .config import _cfg, _cfgd
 
@@ -80,7 +80,9 @@ def send_grant_notice(mod: Mod, user: User) -> None:
 
 
 def send_update_notification(mod: Mod, version: ModVersion, user: User) -> None:
-    followers = [u.email for u in mod.followers]
+    followers = (fol.user.email for fol
+                 in Following.query.filter(Following.mod_id == mod.id,
+                                           Following.send_update == True))
     changelog = version.changelog
     if changelog:
         changelog = '\n'.join(['    ' + line for line in changelog.split('\n')])
@@ -100,12 +102,14 @@ def send_update_notification(mod: Mod, version: ModVersion, user: User) -> None:
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
             'changelog': changelog
         }))
-    subject = user.username + " has just updated " + mod.name + "!"
+    subject = f'{user.username} has just updated {mod.name}!'
     send_mail.delay(_cfg('support-mail'), targets, subject, message)
 
 
 def send_autoupdate_notification(mod: Mod) -> None:
-    followers = [u.email for u in mod.followers]
+    followers = (fol.user.email for fol
+                 in Following.query.filter(Following.mod_id == mod.id,
+                                           Following.send_autoupdate == True))
     changelog = mod.default_version.changelog
     if changelog:
         changelog = '\n'.join(['    ' + line for line in changelog.split('\n')])
@@ -123,8 +127,7 @@ def send_autoupdate_notification(mod: Mod) -> None:
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
             'changelog': changelog
         }))
-    subject = mod.name + " is compatible with " + \
-              mod.game.name + mod.versions[0].gameversion.friendly_version + "!"
+    subject = f'{mod.name} is compatible with {mod.game.name} {mod.default_version.gameversion.friendly_version}!'
     send_mail.delay(_cfg('support-mail'), targets, subject, message)
 
 

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -6,15 +6,30 @@ from typing import Optional
 
 import bcrypt
 from sqlalchemy import Column, Integer, String, Unicode, Boolean, DateTime, \
-    ForeignKey, Table, Float, Index, BigInteger
+    ForeignKey, Float, Index, BigInteger, PrimaryKeyConstraint
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship, backref, reconstructor
 
 from . import thumbnail
 from .database import Base
 
-mod_followers = Table('mod_followers', Base.metadata,
-                      Column('mod_id', Integer, ForeignKey('mod.id')),
-                      Column('user_id', Integer, ForeignKey('user.id')))
+
+class Following(Base):  # type: ignore
+    __tablename__ = 'mod_followers'
+    __table_args__ = (PrimaryKeyConstraint('user_id', 'mod_id'), )
+    mod_id = Column(Integer, ForeignKey('mod.id'), index=True)
+    mod = relationship('Mod', back_populates='followings')
+    user_id = Column(Integer, ForeignKey('user.id'), index=True)
+    user = relationship('User', back_populates='followings')
+    send_update = Column(Boolean(), default=True, nullable=False)
+    send_autoupdate = Column(Boolean(), default=True, nullable=False)
+
+    def __init__(self, mod: Optional['Mod'] = None, user: Optional['User'] = None,
+                 send_update: Optional[bool] = True, send_autoupdate: Optional[bool] = True) -> None:
+        self.mod = mod
+        self.user = user
+        self.send_update = send_update
+        self.send_autoupdate = send_autoupdate
 
 
 class Featured(Base):  # type: ignore
@@ -63,7 +78,10 @@ class User(Base):  # type: ignore
     backgroundMedia = Column(String(512), default='')
     bgOffsetX = Column(Integer, default=0)
     bgOffsetY = Column(Integer, default=0)
-    following = relationship('Mod', secondary=mod_followers, backref='followers')
+    # List of Following objects
+    followings = relationship('Following', back_populates='user')
+    # List of mods the user follows
+    following = association_proxy('followings', 'mod')
     dark_theme = Column(Boolean, default=False)
 
     def set_password(self, password: str) -> None:
@@ -193,6 +211,10 @@ class Mod(Base):  # type: ignore
     follower_count = Column(Integer, nullable=False, default=0)
     download_count = Column(Integer, nullable=False, default=0)
     ckan = Column(Boolean)
+    # List of Following objects
+    followings = relationship('Following', back_populates='mod')
+    # List of users that follow this mods
+    followers = association_proxy('followings', 'user')
 
     def background_thumb(self) -> str:
         return thumbnail.get_or_create(self.background)

--- a/alembic/versions/2021_06_28_19_00_00-17fbd4ff8193.py
+++ b/alembic/versions/2021_06_28_19_00_00-17fbd4ff8193.py
@@ -1,0 +1,73 @@
+"""Add indexes and new columns to mod_followers
+
+Revision ID: 17fbd4ff8193
+Revises: 426e0b848d77
+Create Date: 2021-06-28 19:00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '17fbd4ff8193'
+down_revision = '426e0b848d77'
+
+from alembic import op
+import sqlalchemy as sa
+
+Base = sa.ext.declarative.declarative_base()
+
+
+class User(Base):  # type: ignore
+    __tablename__ = 'user'
+    id = sa.Column(sa.Integer, primary_key=True)
+
+
+class Mod(Base):  # type: ignore
+    __tablename__ = 'mod'
+    id = sa.Column(sa.Integer, primary_key=True)
+
+
+class Following(Base):  # type: ignore
+    __tablename__ = 'mod_followers'
+    __table_args__ = (sa.PrimaryKeyConstraint('user_id', 'mod_id'), )
+    mod_id = sa.Column(sa.Integer, sa.ForeignKey('mod.id'))
+    user_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'))
+    send_update = sa.Column(sa.Boolean(), default=True)
+    send_autoupdate = sa.Column(sa.Boolean(), default=True)
+
+
+def upgrade() -> None:
+    # Remove any broken rows
+    op.execute("DELETE FROM mod_followers WHERE mod_id is NULL OR user_id is NULL")
+    # Make new primary key columns non-nullable
+    op.alter_column('mod_followers', 'mod_id',  existing_type=sa.INTEGER(), nullable=False)
+    op.alter_column('mod_followers', 'user_id', existing_type=sa.INTEGER(), nullable=False)
+
+    # Create indices
+    op.create_index(op.f('ix_mod_followers_mod_id'), 'mod_followers', ['mod_id'], unique=False)
+    op.create_index(op.f('ix_mod_followers_user_id'), 'mod_followers', ['user_id'], unique=False)
+    op.create_primary_key('pk_mod_followers', 'mod_followers', ['mod_id', 'user_id'])
+
+    # Add new columns, nullable
+    op.add_column('mod_followers', sa.Column('send_update', sa.Boolean()))
+    op.add_column('mod_followers', sa.Column('send_autoupdate', sa.Boolean()))
+
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+    for following in session.query(Following).all():
+        following.send_update = True
+        following.send_autoupdate = True
+    session.commit()
+
+    # Make new columns non-nullable
+    op.alter_column('mod_followers', 'send_update',     existing_type=sa.INTEGER(), nullable=False)
+    op.alter_column('mod_followers', 'send_autoupdate', existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column('mod_followers', 'send_update')
+    op.drop_column('mod_followers', 'send_autoupdate')
+    op.drop_index(op.f('ix_mod_followers_user_id'), table_name='mod_followers')
+    op.drop_index(op.f('ix_mod_followers_mod_id'), table_name='mod_followers')
+    op.drop_constraint('pk_mod_followers', 'mod_followers')
+    op.alter_column('mod_followers', 'mod_id',  existing_type=sa.INTEGER(), nullable=True)
+    op.alter_column('mod_followers', 'user_id', existing_type=sa.INTEGER(), nullable=True)

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -9,13 +9,15 @@
 """
 
 from typing import List, Optional
-from sqlalchemy import sa
+
+import sqlalchemy.sql.type_api
+import sqlalchemy as sa
 
 
 class op:
 
     @classmethod
-    def get_bind(cls) -> None: ...
+    def get_bind(cls) -> sa.engine.Connection: ...
 
     @classmethod
     def f(cls,
@@ -35,6 +37,7 @@ class op:
     def alter_column(cls,
                     table_name: str,
                     column_name: str,
+                    existing_type: Optional[sa.sql.type_api.TypeEngine] = None,
                     nullable: Optional[bool] = None) -> None: ...
 
     @classmethod
@@ -58,6 +61,12 @@ class op:
                            remote_cols: List[str],
                            onupdate: Optional[str] = None,
                            ondelete: Optional[str] = None) -> None: ...
+
+    @classmethod
+    def create_primary_key(cls,
+                           constraint_name: str,
+                           table_name: str,
+                           columns: List[str]) -> None: ...
 
     @classmethod
     def drop_constraint(cls,

--- a/frontend/coffee/profile.coffee
+++ b/frontend/coffee/profile.coffee
@@ -1,3 +1,6 @@
+editor = new Editor()
+editor.render()
+
 # Background Uploading
 window.upload_bg = (files, box) ->
     file = files[0]
@@ -94,3 +97,8 @@ resetPasswordModalDialog = () ->
         button.removeAttribute('disabled')
 
 $('#change-password').on('hidden.bs.modal', resetPasswordModalDialog)
+
+$('#check-all-updates'      ).on('click', () -> $('[id^=updates-]'    ).prop('checked', true))
+$('#uncheck-all-updates'    ).on('click', () -> $('[id^=updates-]'    ).prop('checked', false))
+$('#check-all-autoupdates'  ).on('click', () -> $('[id^=autoupdates-]').prop('checked', true))
+$('#uncheck-all-autoupdates').on('click', () -> $('[id^=autoupdates-]').prop('checked', false))

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -193,3 +193,16 @@
         border-radius: 0;
     }
 }
+
+.profile-right-half .CodeMirror {
+    height: 16em;
+}
+
+.following-mods-list {
+    max-height: 15em;
+    overflow-y: auto;
+}
+
+.row.following-mod:nth-of-type(odd) {
+    background-color: #f5f5f5;
+}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -104,7 +104,7 @@
                     </div>
                 </div>
 
-                <div class="col-md-6">
+                <div class="col-md-6 profile-right-half">
                     <h3 style="margin: 0; padding: 0; padding-bottom: 5px;">Your description <small><a target="_blank" href="/markdown">Markdown</a> supported</small></h3>
                     <link rel="stylesheet" href="/static/editor.css">
                     <textarea name="description"
@@ -115,13 +115,55 @@
             </div>
         </div>
     </div>
+
+    {% if following %}
+    <div class="container lead">
+        <div class="row">
+            <div class="col-xs-12 col-md-3">
+                <h2>Email Settings</h2>
+            </div>
+            <div class="col-xs-6 col-md-2">
+                <button type="button" id="check-all-updates" class="btn btn-xs">Check all</button>
+                <button type="button" id="uncheck-all-updates" class="btn btn-xs">Uncheck all</button>
+            </div>
+            <div class="col-xs-6 col-md-2">
+                <button type="button" id="check-all-autoupdates" class="btn btn-xs">Check all</button>
+                <button type="button" id="uncheck-all-autoupdates" class="btn btn-xs">Uncheck all</button>
+            </div>
+        </div>
+        <div class="row following-mods-list">
+            {% for fol in following %}
+            <div class="row following-mod">
+                <div class="col-xs-12 col-md-3 space-left-right"><small>{{ fol.mod.name }}</small></div>
+                <div class="col-xs-6 col-md-2">
+                    <label for="updates-{{fol.mod_id}}" class="text-muted">
+                        <input type="checkbox" {% if fol.send_update %}checked{% endif %}
+                               id="updates-{{fol.mod_id}}"
+                               name="updates-{{fol.mod_id}}">
+                        New releases
+                    </label>
+                </div>
+                <div class="col-xs-6 col-md-2">
+                    <label for="autoupdates-{{fol.mod_id}}" class="text-muted">
+                        <input type="checkbox" {% if fol.send_autoupdate %}checked{% endif %}
+                               id="autoupdates-{{fol.mod_id}}"
+                               name="autoupdates-{{fol.mod_id}}">
+                        Compatibility changes
+                    </label>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
 </form>
 
 {%if not hide_login %}
 <div class="container lead">
     <div class="row">
         <div class="col-md-12">
-            <h2 title="change-password">Change Password</h2>
+            <h2>Change Password</h2>
         </div>
     </div>
     <div class="row">
@@ -134,7 +176,7 @@
 <div class="container lead">
     <div class="row">
         <div class="col-md-8">
-            <h2 title="Login">Connected Accounts</h2>
+            <h2>Connected Accounts</h2>
         </div>
 
     </div>


### PR DESCRIPTION
## Motivation

Currently if you follow a mod, you receive all email notifications for it. Some users might not want to receive notifications for compatibility updates.

## Changes

Fixes #333 (the part about ignoring the auto-update email).

### UI

Now if you edit your profile, a new section lists the mods you follow, with two checkboxes for each. The rows are striped to make it easier to pick out the associations between the contents of each row:

![image](https://user-images.githubusercontent.com/1559108/120527112-94e23080-c39f-11eb-9283-b8788843cf3e.png)

If you uncheck a checkbox (and save your changes), you won't receive that notification for that mod anymore. Each column of checkboxes has "Check all" and "Uncheck all" buttons that check and uncheck all the checkboxes in that column, so users can easily disable all notifications of a particular type.

Admins are allowed to edit these settings for other users in case someone requests it and can't figure out how to do it.

### Data model

To make this possible, the `mod_followers` table has two new bool columns, both set to True for all old rows:

- `send_update` - True to send regular update notifications, False to suppress them
- `send_autoupdate` - True to send auto-update notifications, False to suppress them

In addition, `mod_followers` now has three new indices:

- `mod_id` to make it faster to find all of the followers of a mod
- `user_id` to make it faster to find all the mods a user follows
- `(user_id, mod_id)` to make it faster to find a particular user's follow row for a particular mod

### Side fixes

The user description field in the profile edit screen now uses the rich text editor; the field has always supported markdown, but the rich text editor wasn't enabled before.