### PR TITLE
Speed up DownloadEvent queries

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         pip install mypy
+        pip install -r requirements-tests.txt
     - name: mypy
       run: |
         mypy KerbalStuff alembic/versions

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -735,6 +735,7 @@ def update_mod(mod_id: int) -> Tuple[Dict[str, Any], int]:
         if mod.versions:
             version.sort_index = max(v.sort_index for v in mod.versions) + 1
         version.mod = mod
+        version.download_size = os.path.getsize(full_path)
         mod.default_version = version
         mod.updated = datetime.now()
         db.commit()

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -521,7 +521,7 @@ def download(mod_id: int, mod_name: Optional[str], version: Optional[str]) -> Op
     if not mod_version:
         abort(404, 'Unfortunately we couldn\'t find the requested mod version. Maybe it got deleted?')
     download = DownloadEvent.query\
-        .filter(DownloadEvent.mod_id == mod.id, DownloadEvent.version_id == mod_version.id)\
+        .filter(DownloadEvent.version_id == mod_version.id)\
         .order_by(desc(DownloadEvent.created))\
         .first()
     storage = _cfg('storage')

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -252,23 +252,6 @@ def check_mod_editable(mod: Mod, abort_response: Optional[Union[int, werkzeug.wr
     return False
 
 
-def get_version_size(f: str) -> Optional[str]:
-    if not os.path.isfile(f):
-        return None
-
-    size = os.path.getsize(f)
-    if size < 1023:
-        return "%d %s" % (size, ("byte" if size == 1 else "bytes"))
-    elif size < 1048576:
-        return "%3.2f KiB" % (size/1024)
-    elif size < 1073741824:
-        return "%3.2f MiB" % (size/1048576)
-    elif size < 1099511627776:
-        return "%3.2f GiB" % (size/1073741824)
-    else:
-        return "%3.2f TiB" % (size/1099511627776)
-
-
 def jsonify_exception(e: Exception) -> werkzeug.wrappers.Response:
     if isinstance(e, HTTPException):
         # Start with the correct headers and status code from the error

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -5,7 +5,7 @@ import re
 
 import bcrypt
 from sqlalchemy import Column, Integer, String, Unicode, Boolean, DateTime, \
-    ForeignKey, Table, Float
+    ForeignKey, Table, Float, Index
 from sqlalchemy.orm import relationship, backref, reconstructor
 
 from . import thumbnail
@@ -255,6 +255,9 @@ class DownloadEvent(Base):  # type: ignore
                            backref=backref('downloads', order_by="desc(DownloadEvent.created)"))
     downloads = Column(Integer, default=0)
     created = Column(DateTime, default=datetime.now, index=True)
+
+    Index('ix_downloadevent_mod_id_created', mod_id, created)
+    Index('ix_downloadevent_version_id_created', version_id, created)
 
     def __repr__(self) -> str:
         return '<Download Event %r>' % self.id

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -247,12 +247,12 @@ class SharedAuthor(Base):  # type: ignore
 class DownloadEvent(Base):  # type: ignore
     __tablename__ = 'downloadevent'
     id = Column(Integer, primary_key=True)
-    mod_id = Column(Integer, ForeignKey('mod.id'))
+    mod_id = Column(Integer, ForeignKey('mod.id', ondelete='CASCADE'))
     mod = relationship('Mod',
-                       backref=backref('downloads', order_by="desc(DownloadEvent.created)"))
-    version_id = Column(Integer, ForeignKey('modversion.id'))
+                       backref=backref('downloads', passive_deletes=True, order_by="desc(DownloadEvent.created)"))
+    version_id = Column(Integer, ForeignKey('modversion.id', ondelete='CASCADE'))
     version = relationship('ModVersion',
-                           backref=backref('downloads', order_by="desc(DownloadEvent.created)"))
+                           backref=backref('downloads', passive_deletes=True, order_by="desc(DownloadEvent.created)"))
     downloads = Column(Integer, default=0)
     created = Column(DateTime, default=datetime.now, index=True)
 

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -2,6 +2,7 @@ import binascii
 import os.path
 from datetime import datetime
 import re
+from typing import Optional
 
 import bcrypt
 from sqlalchemy import Column, Integer, String, Unicode, Boolean, DateTime, \
@@ -306,6 +307,25 @@ class ModVersion(Base):  # type: ignore
     changelog = Column(Unicode(10000))
     sort_index = Column(Integer, default=0)
     download_count = Column(Integer, default=0)
+    download_size = Column(Integer)
+
+    def format_size(self, storage: str) -> Optional[str]:
+        try:
+            if not self.download_size:
+                self.download_size = os.path.getsize(os.path.join(storage, self.download_path))
+            size = self.download_size
+            if size < 1023:
+                return "%d %s" % (size, ("byte" if size == 1 else "bytes"))
+            elif size < 1048576:
+                return "%3.2f KiB" % (size / 1024)
+            elif size < 1073741824:
+                return "%3.2f MiB" % (size / 1048576)
+            elif size < 1099511627776:
+                return "%3.2f GiB" % (size / 1073741824)
+            else:
+                return "%3.2f TiB" % (size / 1099511627776)
+        except:
+            return None
 
     def __repr__(self) -> str:
         return '<Mod Version %r>' % self.id

--- a/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
+++ b/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
@@ -17,8 +17,16 @@ from alembic import op
 def upgrade() -> None:
     op.create_index(op.f('ix_downloadevent_mod_id_created'), 'downloadevent', ['mod_id', 'created'], unique=False)
     op.create_index(op.f('ix_downloadevent_version_id_created'), 'downloadevent', ['version_id', 'created'], unique=False)
+    op.drop_constraint('downloadevent_mod_id_fkey', 'downloadevent', type_='foreignkey')
+    op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
+    op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'], ondelete='CASCADE')
 
 
 def downgrade() -> None:
     op.drop_index(op.f('ix_downloadevent_mod_id_created'), table_name='downloadevent')
     op.drop_index(op.f('ix_downloadevent_version_id_created'), table_name='downloadevent')
+    op.drop_constraint('downloadevent_mod_id_fkey', 'downloadevent', type_='foreignkey')
+    op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
+    op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'])
+    op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'])

--- a/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
+++ b/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
@@ -1,0 +1,24 @@
+"""Index DownloadEvent columns
+
+Revision ID: c0e44e063159
+Revises: 73c9d707134b
+Create Date: 2021-06-09 19:00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c0e44e063159'
+down_revision = '73c9d707134b'
+
+from datetime import datetime
+from alembic import op
+
+
+def upgrade() -> None:
+    op.create_index(op.f('ix_downloadevent_mod_id_created'), 'downloadevent', ['mod_id', 'created'], unique=False)
+    op.create_index(op.f('ix_downloadevent_version_id_created'), 'downloadevent', ['version_id', 'created'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_downloadevent_mod_id_created'), table_name='downloadevent')
+    op.drop_index(op.f('ix_downloadevent_version_id_created'), table_name='downloadevent')

--- a/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
+++ b/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
@@ -12,6 +12,7 @@ down_revision = '73c9d707134b'
 
 from datetime import datetime
 from alembic import op
+import sqlalchemy as sa
 
 
 def upgrade() -> None:
@@ -21,6 +22,7 @@ def upgrade() -> None:
     op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
     op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
     op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'], ondelete='CASCADE')
+    op.add_column('modversion', sa.Column('download_size', sa.Integer()))
 
 
 def downgrade() -> None:
@@ -30,3 +32,4 @@ def downgrade() -> None:
     op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
     op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'])
     op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'])
+    op.drop_column('modversion', 'download_size')

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -49,7 +49,9 @@ class op:
                            source_table: str,
                            referent_table: str,
                            local_cols: List[str],
-                           remote_cols: List[str]) -> None: ...
+                           remote_cols: List[str],
+                           onupdate: Optional[str] = None,
+                           ondelete: Optional[str] = None) -> None: ...
 
     @classmethod
     def drop_constraint(cls,

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,3 +2,12 @@ pytest
 pytest-flask
 flask-api
 flask-testing
+types-Markdown
+types-bleach
+types-Flask
+types-Jinja2
+types-Markdown
+types-MarkupSafe
+types-Werkzeug
+types-bleach
+types-requests


### PR DESCRIPTION
## Problem

Flame graph profiling from #346 has revealed that accessing `DownloadEvent` is a substantial part of loading a mod page and especially starting a download:

![image](https://user-images.githubusercontent.com/1559108/121438206-3e4d9700-c949-11eb-97f9-08eeaf77f7bf.png)

![image](https://user-images.githubusercontent.com/1559108/121438247-545b5780-c949-11eb-8c36-f46a008c57ca.png)

![image](https://user-images.githubusercontent.com/1559108/121438130-152d0680-c949-11eb-923d-4c998468b9a4.png)

## Cause

`DownloadEvent` is a big table with a lot of rows, and we filter it by columns that aren't indexed (`mod_id` and `version_id`). This means the database engine has to search every row and check whether they match.

## Changes

- New multi-column index in `DownloadEvent`: `(mod_id, created)`, to be used for loading the mod page
- New multi-column index in `DownloadEvent`: `(version_id, created)`, to be used when starting downloads
- The download route now only filters by `DownloadEvent.version_id` since if this matches then `DownloadEvent.mod_id` will match as well, and both will now be indexed
- The download route previously retrieved `DownloadEvent.created` and checked whether it was more than 1 hour ago in Python code, but the check was somewhat wrong (it used `timedelta.seconds`, which only goes up to 86399 and so could satisfy the limit when it shouldn't). Now it enforces this limit in SQL, correctly.
- Cascade deletion is enabled or `DownloadEvent.mod_id` and `DownloadEvent.version_id` so download events are deleted from the database if their corresponding mod or version is removed
- A few calls to `isfile` are now removed to lighten the load on storage
- `ModVersion.download_size` now stores the size of the download file, again to lighten the load on storage
- The `featured.rss` routes no longer set properties on db objects and then call `db.rollback()` to undo, because those calls showed up in profiling as slow; the timezone offset is also now included in the RSS output because I think it's supposed to be there
  ![image](https://user-images.githubusercontent.com/1559108/122688486-057fae80-d1e2-11eb-9606-1b973ac44ba8.png)


This should speed up mod page loads and downloads somewhat noticeably in some cases.

Also mypy has changed again, so now we install type libs to satisfy it.