### PR TITLE
Make download_size a BigInteger

### DIFF
--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import bcrypt
 from sqlalchemy import Column, Integer, String, Unicode, Boolean, DateTime, \
-    ForeignKey, Table, Float, Index
+    ForeignKey, Table, Float, Index, BigInteger
 from sqlalchemy.orm import relationship, backref, reconstructor
 
 from . import thumbnail
@@ -307,7 +307,7 @@ class ModVersion(Base):  # type: ignore
     changelog = Column(Unicode(10000))
     sort_index = Column(Integer, default=0)
     download_count = Column(Integer, default=0)
-    download_size = Column(Integer)
+    download_size = Column(BigInteger)
 
     def format_size(self, storage: str) -> Optional[str]:
         try:

--- a/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
+++ b/alembic/versions/2021_06_09_19_00_00-c0e44e063159.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     op.drop_constraint('downloadevent_version_id_fkey', 'downloadevent', type_='foreignkey')
     op.create_foreign_key('downloadevent_mod_id_fkey', 'downloadevent', 'mod', ['mod_id'], ['id'], ondelete='CASCADE')
     op.create_foreign_key('downloadevent_version_id_fkey', 'downloadevent', 'modversion', ['version_id'], ['id'], ondelete='CASCADE')
-    op.add_column('modversion', sa.Column('download_size', sa.Integer()))
+    op.add_column('modversion', sa.Column('download_size', sa.BigInteger()))
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Problem

After #370, this mod gives a 500 status:

- https://alpha.spacedock.info/mod/3/Test%20download%20path

Server says:

`sqlalchemy.exc.DataError: (psycopg2.errors.NumericValueOutOfRange) integer out of range
[SQL: UPDATE modversion SET download_size=%(download_size)s WHERE modversion.id = %(modversion_id)s]
[parameters: {'download_size': 2147831870, 'modversion_id': 29}]`

## Cause

The type of `ModVersion.download_size` is `sqlalchemy.Integer` (SQL's INT), which can only support downloads up to 2 GiB. That file and some mods are bigger.

## Changes

Now we use `BigInteger` (BIGINT) instead.
Note that the migration is changed in-place, so it will have to be downgraded manually on alpha. I'm told this has been done already.