### PR TITLE
Unify storage base path and fix background image URLs

### DIFF
--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -7,7 +7,7 @@ from sqlalchemy import desc
 from datetime import timezone
 
 from ..common import dumb_object, paginate_query, get_paginated_mods, get_game_info, get_games, \
-    get_featured_mods, get_top_mods, get_new_mods, get_updated_mods
+    get_featured_mods, get_top_mods, get_new_mods, get_updated_mods, sendfile
 from ..config import _cfg
 from ..database import db
 from ..objects import Featured, Mod, ModVersion, User
@@ -48,27 +48,7 @@ def content(path: str) -> werkzeug.wrappers.Response:
     if not storage:
         abort(404)
 
-    if _cfg('use-x-accel') == 'nginx':
-        response = make_response('')
-        response.headers['Content-Type'] = 'application/zip'
-        response.headers['Content-Disposition'] = f'attachment; filename={os.path.basename(path)}'
-        response.headers['X-Accel-Redirect'] = '/internal/' + path
-        return response
-
-    download_path = os.path.join(storage, path)
-
-    if _cfg('use-x-accel') == 'apache':
-        response = make_response('')
-        response.headers['Content-Type'] = 'application/zip'
-        response.headers['Content-Disposition'] = f'attachment; filename={os.path.basename(path)}'
-        response.headers['X-Sendfile'] = download_path
-        return response
-
-    else:
-        # No accelerator enabled, try to send it ourselves
-        if not os.path.isfile(download_path):
-            abort(404)
-        return make_response(send_file(download_path, as_attachment=True))
+    return sendfile(path, True)
 
 
 @anonymous.route("/browse")

--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -1,5 +1,5 @@
 import html
-from typing import Iterable, List, Dict, Optional
+from typing import Iterable, Optional
 
 from flask import url_for
 from jinja2 import Template

--- a/alembic/versions/2021_07_29_18_00_833ba1ee8c72.py
+++ b/alembic/versions/2021_07_29_18_00_833ba1ee8c72.py
@@ -1,0 +1,27 @@
+"""Add thumbnail column for mod table
+
+Revision ID: 833ba1ee8c72
+Revises: 17fbd4ff8193
+Create Date: 2021-07-29 18:50:08.327728+00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '833ba1ee8c72'
+down_revision = '17fbd4ff8193'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.execute("""UPDATE mod SET background = trim(LEADING '/content/' FROM background)
+                  WHERE background IS NOT NULL AND background != '' """)
+    op.execute("""UPDATE "user" SET "backgroundMedia" = trim(LEADING '/content/' FROM "backgroundMedia")
+                  WHERE "backgroundMedia" IS NOT NULL AND "backgroundMedia" != '' """)
+
+    op.add_column('mod', sa.Column('thumbnail', sa.String(length=512), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('mod', 'thumbnail')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       - 5443:443
     links:
       - backend
+    volumes:
+      - ./storage:/var/www/storage
     networks:
       - spacedock-net
 

--- a/frontend/coffee/edit_mod.coffee
+++ b/frontend/coffee/edit_mod.coffee
@@ -26,8 +26,8 @@ window.upload_bg = (files, box) ->
         else
             resp = JSON.parse(xhr.responseText)
             p.textContent = 'Done!'
-            document.getElementById('background').value = resp.path
-            document.getElementById('header-well').style.backgroundImage = 'url("' + resp.path + '")'
+            document.getElementById('header-well').style.backgroundImage =
+              'url("' + resp.path + '?nocache=' + new Date().getTime() + '")'
             setTimeout(() ->
                 box.removeChild(p)
                 box.querySelector('a').classList.remove('hidden')

--- a/frontend/coffee/profile.coffee
+++ b/frontend/coffee/profile.coffee
@@ -27,8 +27,8 @@ window.upload_bg = (files, box) ->
         else
             resp = JSON.parse(xhr.responseText)
             p.textContent = 'Done!'
-            document.getElementById('backgroundMedia').value = resp.path
-            document.getElementById('header-well').style.backgroundImage = 'url("' + resp.path + '")'
+            document.getElementById('header-well').style.backgroundImage =
+              'url("' + resp.path + '?nocache=' + new Date().getTime() + '")'
             setTimeout(() ->
                 box.removeChild(p)
                 box.querySelector('a').classList.remove('hidden')

--- a/frontend/configs/nginx.nginx
+++ b/frontend/configs/nginx.nginx
@@ -40,6 +40,14 @@ http {
             proxy_read_timeout 90;
             expires -1;
         }
+
+        location /internal {
+            internal;
+            alias /var/www/storage;
+            proxy_read_timeout 90;
+            expires 7d;
+            add_header Via "HTTP/1.1 nginx.sendfile";
+        }
         
         location / {
             proxy_pass http://backend:9999;

--- a/spacedock
+++ b/spacedock
@@ -158,9 +158,7 @@ def migrate_backgrounds():
             print("Handling {} ({} of {})".format(mod.name, index + 1, total))
             filetype = os.path.splitext(os.path.basename(mod.background))[1]
             filename = secure_filename(mod.name) + filetype
-            base_path = os.path.join(secure_filename(mod.user.username) + '_' + str(mod.user.id),
-                                     secure_filename(mod.name))
-            mod.background = _migrate_bg(mod.background, base_path, filename)
+            mod.background = _migrate_bg(mod.background, mod.base_path(), filename)
             db.commit()
 
 
@@ -173,8 +171,7 @@ def migrate_profiles():
             print("Handling {} ({} of {})".format(user.username, index + 1, total))
             filetype = os.path.splitext(os.path.basename(user.backgroundMedia))[1]
             filename = secure_filename(user.username) + filetype
-            base_path = os.path.join(secure_filename(user.username) + '_' + str(user.id))
-            user.backgroundMedia = _migrate_bg(user.backgroundMedia, base_path, filename)
+            user.backgroundMedia = _migrate_bg(user.backgroundMedia, user.base_path(), filename)
             db.commit()
 
 

--- a/templates/create.html
+++ b/templates/create.html
@@ -52,7 +52,7 @@
         </div>
         <div class="row">
             <div class="col-md-4">
-                <h2 class="control-label">Game and version</2>
+                <h2 class="control-label">Game and version</h2>
             </div>
             <div class="col-md-4 form-group">
                 <select id="mod-game" class="chosen-select">

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -9,11 +9,7 @@
 {% block body %}
 <form action="{{ url_for("mods.edit_mod", mod_id=mod.id, mod_name=mod.name) }}" method="POST">
     <div class="header upload-well scrollable" id="header-well" style="
-        {% if mod.background %}
-        background-image: url({{ mod.background }});
-        {% else %}
-        background-image: url(/static/background.jpg);
-        {% endif %}
+        background-image: url({{ background if background else '/static/background.jpg' }});
         background-position: 0 {% if mod.bgOffsetY %}{{ mod.bgOffsetY }}px{% else %}0{% endif %};
         background-color: #ddd;"
         data-event="upload_bg"

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -33,10 +33,7 @@
         {% endblock %}
         <link href="/static/bootstrap.min.css" rel="stylesheet">
         <link href="/static/bootstrap-theme.css" rel="stylesheet">
-
-
         {% block styles %}
-
         {% endblock %}
         <!-- Piwik -->
           {% if admin %}
@@ -68,16 +65,14 @@
                         <span class="icon-bar"></span>
                     </button>
                     <a class="navbar-brand space-left-right" id="pagetitle" href="/" style="display: inline;vertical-align: middle;padding-top: 2.5mm;margin-right: 0;padding-right: 0; width: auto; ">
-
-
-<span class="darker"><img class="logoimg" src="/static/logo4.png" alt="SpaceDock" border="0" height="85%"/> {% if ga %}<img class="sublogo" src="/static/sublogo.png" alt=">" border="0" height="85%"/>&nbsp;<a style="position: relative; top: 3mm;" class="gamename" href="/{{ ga.short }}">{{ ga.name }}</a>{% endif %}</span>
-
+                        <span class="darker">
+                            <img class="logoimg" src="/static/logo4.png" alt="SpaceDock" border="0" height="85%"/>
+                            {%- if ga -%}
+                            <img class="sublogo" src="/static/sublogo.png" alt=">" border="0" height="85%"/>&nbsp;
+                            <a style="position: relative; top: 3mm;" class="gamename" href="/{{ ga.short }}">{{ ga.name }}</a>
+                            {%- endif -%}
+                        </span>
                     </a>
-<!--
-                    {% if admin %}
-                    <p class="navbar-text" style="color: white">Admin</p>
-                    {% endif %}
--->
                 </div>
                 <div class="collapse navbar-collapse" id="navbar-collapse">
                     {% if not user %}

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -4,10 +4,11 @@
             <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}">
                 <a class="header-img-link" href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">
                     <div class="header-img" style="background-color: #000000;
-                    {%- if not mod.background -%}
+                    {%- set thumbnail = mod.background_thumb() -%}
+                    {%- if not thumbnail -%}
                         background-image: url(/static/background-s.png);
                     {%- else -%}
-                        background-image: url({{ mod.background_thumb() }});
+                        background-image: url({{ thumbnail }});
                     {%- endif -%}
                     "></div>
                 </a>

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" type="text/css" href="/static/mod.css"/>
 {% endblock %}
 {% block body %}
-{% if mod.background %}
-<div class="header" style="background-image: url({{ mod.background }});
+{% if background %}
+<div class="header" style="background-image: url({{ background }});
     background-position: 0 {% if mod.bgOffsetY %}{{ mod.bgOffsetY }}px{% else %}0{% endif %};"></div>
 {% else %}
 <div class="header" style="background-image: url(/static/background.jpg);"></div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -8,7 +8,7 @@
 {% block body %}
 <form action="/profile/{{ profile.username }}/edit" method="POST">
     <div class="header upload-well scrollable" id="header-well" style="
-        {%if profile.backgroundMedia%}background-image: url({{ profile.backgroundMedia }});{%endif%}
+        {% if background %}background-image: url({{ background }});{% endif %}
         background-position: 0 {% if profile.bgOffsetY %}{{ profile.bgOffsetY }}px{% else %}0{% endif %};
         background-color: #ddd;"
         data-event="upload_bg"
@@ -18,7 +18,6 @@
         <div class="upload-progress"></div>
         <div class="directions"><span class="glyphicon glyphicon-resize-vertical"></span>Click and drag to move <span class="glyphicon glyphicon-resize-vertical"></span></div>
     </div>
-    <input type="hidden" name="backgroundMedia" id="backgroundMedia" value="{{ profile.backgroundMedia }}">
     <input type="hidden" name="bg-offset-y" id="bg-offset-y" value="{% if profile.bgOffsetY %}{{ profile.bgOffsetY }}{% endif %}">
     <div class="container lead">
         <div class="row">

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -6,8 +6,8 @@
 <title>{{ profile.username }} on {{ site_name }}</title>
 {% endblock %}
 {% block body %}
-{% if profile.backgroundMedia %}
-<div class="header" style="background-image: url({{ profile.backgroundMedia }});
+{% if background %}
+<div class="header" style="background-image: url({{ background }});
     background-position: 0 {% if profile.bgOffsetY %}{{ profile.bgOffsetY }}px{% else %}0{% endif %};"></div>
 {% endif %}
 <div class="container lead">


### PR DESCRIPTION
Sorry, this ended up way bigger than I hoped, due to the background image URL issue.

## Problems
Our content path handling is currently all over the place. Every function that saves or accesses some user content from disk has its own implementation to find the location.

Profile background images are not saved in the user folder, but instead we create a new folder per upload, with the timestamp in the folder name. When a profile background is deleted, the folder stays behind, empty:
```
├── HebaruSan-1622467520.5473514_1
├── HebaruSan-1622467781.61281_1
├── HebaruSan-1622467793.0606115_1
│   └── HebaruSan.jpg
├── HebaruSan_1
│   └── CKAN_Publish_Test
│       └── CKAN_Publish_Test-12345.zip
```

---

The background image URL handling is pretty awful right now:
When uploading background images (mods and profiles), we first save the storage-relative path in the db (like we do for mod zips).
https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/KerbalStuff/blueprints/api.py#L483
But to the user, we return a path prefixed with a hard-coded `/content/`.
https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/KerbalStuff/blueprints/api.py#L484
Then, when the user hits "Save Changes", we overwrite the path in the db with this `/content/...` path.
https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/KerbalStuff/blueprints/profile.py#L83
And in the template, we embed this `/content/...` URL as is, which makes everything work again.
https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/templates/profile.html#L11

The `/content/` prefix is not something the backend should ever deal with. We should be able to set whatever `cdn-domain` we want in `config.ini` (e.g. `spacedock.bigcdnprovider.com/usercontent/`), without the site breaking because it tries to point everyone to `/content/`.

---

When deleting a mod, it doesn't delete the referral events. Also we delete the mod first, before deleting rows of other tables referencing it, which theoretically could lead to those other rows not being removed because the foreign key was updated to NULL beforehand. Fortunately, SqlAlchemy seems to reorder the statements so they work:
```sql
UPDATE referralevent SET mod_id=NULL WHERE referralevent.id = 18
DELETE FROM featured WHERE featured.id = 4
UPDATE mod SET default_version_id=NULL WHERE mod.id = 10014
DELETE FROM modversion WHERE modversion.id = 100021
DELETE FROM modversion WHERE modversion.id = 100022
DELETE FROM mod WHERE mod.id = 10014
COMMIT
```

## Changes

There is a  new `User.base_path()` and a new `Mod.base_path()` method, which returns the base path for all user content relative to the storage root (e.g. `user_1` `user_2/mod_name`).
They are used wherever we need to store or access files in the storage.

Profile images are now saved in the user folder (`User.base_path()`), the format of the file names is `{username}-header-{upload_time}`, where `upload_time` no longer is a float to the nanoseconds, but an int to the seconds.

---

When clicking "Save Changes" after updating a background image for your profile or a mod, the background image path is no longer overwritten, but stays in the storage-relative form. 
Old data in the db with `/content/` prefixed is fixed in the migration.

This means that we need to translate the image paths to proper URLs before embedding the links into the HTML.
This is done in new `Mod.background_url()` and `User.background_url()` methods. They either return the URL concatenated with `cdn-domain` if it's set, or fall back to new `/mods/<mod_id>/<mod_name>/background` or `/profile/<username>/background` routes. That's slightly different to how we handle it for mod downloads, where we always point to the `/mod/<mod_id>/<mod_name>/download` URL, and then redirect based on settings. But this redirection would break client-side caching, which I definitely want to keep, especially for thumbnails.
`thumbnail.get_or_create()`, which is used to calculate the thumbnail URLs from the background image paths is adjusted accordingly, and also returns an URL either for the CDN or to the new `/mods/<mod_id>/<mod_name>/thumb` route.
We also save the thumbnail path in the database now, to remove the `isfile` call to the storage.

These three new routes can serve the files via X-Sendfile, if configured. The "X-Sendfile with fallback to serve-from-gunicorn" logic has been factored out into a common `sendfile()` function.
Since it also sees images now, the `Content-Type` header is no longer hard-coded, but instead we use the Python stdlib `mimetypes` package to guess the mime type _from the file extension_. We definitely want to avoid a disk access there, even if it means the file type could theoretically be incorrect (it's good enough for our use case).

To simplify testing all this, I've also committed a change to `nginx.nginx`, so it can handle X-Sendfile.

---

ReferralEvents that reference a mod that's about to be deleted are removed from the database as well.
The mod deletion now happens after all the other deletes, so we don't rely on SqlAlchemy being smart:
```sql
DELETE FROM featured WHERE featured.id = 5
DELETE FROM referralevent WHERE referralevent.id = 19
UPDATE mod SET default_version_id=NULL WHERE mod.id = 10015
DELETE FROM modversion WHERE modversion.id = 100023
DELETE FROM modversion WHERE modversion.id = 100024
DELETE FROM mod WHERE mod.id = 10015
COMMIT
```

The API/JSON error handling is updated to no longer leak potentially confidential error messages, if the server is not running in debug mode.

Aaand the PURGE request to purge cached zips from ATS when a mod release is deleted is now surrounded by try-catch, since it fails in the docker dev environment with nginx, and it should also not cancel the deletion if Apache complains on production.

## Deployment note
Run the following command after this is deployed on production, to get rid of all existing empty profile background directories:
```bash
find /storage/sdmods/ -empty -type d -delete
```