### PR TITLE
Run database migrations after pulling changes

### DIFF
--- a/KerbalStuff/celery.py
+++ b/KerbalStuff/celery.py
@@ -3,6 +3,8 @@ from types import FrameType
 from typing import List, Iterable, Any
 
 from celery import Celery
+import alembic.command
+import alembic.config
 
 from .common import with_session
 from .config import _cfg, _cfgi, _cfgb, site_logger
@@ -83,6 +85,8 @@ def update_from_github(working_directory: str, branch: str, restart_command: str
                 return
         else:
             site_logger.info('Pulled latest changes from origin/%s', branch)
+        # Try to run database migrations
+        alembic.command.upgrade(alembic.config.Config('alembic.ini'), 'head')
         # run restart command in a subprocess to daemonize it from there
         # and avoid its killing by restart process
         from billiard import Process

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -16,7 +16,7 @@ from .database import Base
 
 class Following(Base):  # type: ignore
     __tablename__ = 'mod_followers'
-    __table_args__ = (PrimaryKeyConstraint('user_id', 'mod_id'), )
+    __table_args__ = (PrimaryKeyConstraint('user_id', 'mod_id', name='pk_mod_followers'), )
     mod_id = Column(Integer, ForeignKey('mod.id'), index=True)
     mod = relationship('Mod', back_populates='followings')
     user_id = Column(Integer, ForeignKey('user.id'), index=True)

--- a/alembic/versions/2021_06_28_19_00_00-17fbd4ff8193.py
+++ b/alembic/versions/2021_06_28_19_00_00-17fbd4ff8193.py
@@ -28,7 +28,7 @@ class Mod(Base):  # type: ignore
 
 class Following(Base):  # type: ignore
     __tablename__ = 'mod_followers'
-    __table_args__ = (sa.PrimaryKeyConstraint('user_id', 'mod_id'), )
+    __table_args__ = (sa.PrimaryKeyConstraint('user_id', 'mod_id', name='pk_mod_followers'), )
     mod_id = sa.Column(sa.Integer, sa.ForeignKey('mod.id'))
     user_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'))
     send_update = sa.Column(sa.Boolean(), default=True)


### PR DESCRIPTION
## Motivation

After #369 was merged, the alpha server was left in a semi-functional state because its alembic migration wasn't executed. This command fixed it (I used the migration id in place of `head`, but I want to document the best version of it):

```
cd /SpaceDock
bin/alembic upgrade head
```

This happens automatically when you run `./start-server.sh`, via `./spacedock database migrate`:

https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/start-server.sh#L34

... which does this:

https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/spacedock#L12-L15

https://github.com/KSP-SpaceDock/SpaceDock/blob/ebb54cb85da0ea798cdbc3578e52b56fd04ee0c2/spacedock#L75-L79

## Changes

Now after the web hook pulls changes from GitHub, and before it restarts the sever, it also tries to run the alembic migrations.