### PR TITLE
Handle missing default mod version, don't close db before rendering templates

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,8 @@
 name: Mypy
 
-on: [push, pull_request]
+on:
+- push
+- pull_request
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,8 @@
 name: PyTest
 
-on: [push, pull_request]
+on:
+- push
+- pull_request
 
 jobs:
   build:

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -118,7 +118,7 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
             editable = True
     if not mod.published and not editable:
         abort(403, 'Unfortunately we couldn\'t display the requested mod. Maybe it\'s not public yet?')
-    latest = mod.default_version
+    latest = mod.default_version or (mod.versions[0] if len(mod.versions) > 0 else None)
     referral = request.referrer
     if referral:
         host = urlparse(referral).hostname

--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -2,7 +2,7 @@ import threading
 import requests
 import re
 from flask import url_for
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Optional
 
 from .config import _cfg
 from .objects import Mod, Game, GameVersion
@@ -58,7 +58,7 @@ def import_ksp_versions_from_ckan(ksp_game_id: int) -> None:
             db.commit()
 
 
-def ksp_versions_from_ckan() -> Iterable[str]:
+def ksp_versions_from_ckan() -> Iterable[Optional[str]]:
     builds = requests.get(CKAN_BUILDS_URL).json()
     for _, full_version in builds['builds'].items():
         m = MAJOR_MINOR_PATCH_PATTERN.match(full_version)

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -66,7 +66,7 @@ def with_session(f: Callable[..., Any]) -> Callable[..., Any]:
             return ret
         except:
             db.rollback()
-            db.close()
+            # Session will be closed in app.teardown_request so templates can be rendered
             raise
 
     return go
@@ -96,7 +96,7 @@ def adminrequired(f: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def json_response(obj: Any, status: int = None) -> werkzeug.wrappers.Response:
+def json_response(obj: Any, status: Optional[int] = None) -> werkzeug.wrappers.Response:
     data = json.dumps(obj, cls=CustomJSONEncoder, separators=(',', ':'))
     return Response(data, status=status, mimetype='application/json')
 
@@ -151,7 +151,7 @@ def get_page() -> int:
         return 1
 
 
-def get_paginated_mods(ga: Game = None, query: str = '', page_size: int = 30) -> Tuple[Iterable[Mod], int, int]:
+def get_paginated_mods(ga: Optional[Game] = None, query: str = '', page_size: int = 30) -> Tuple[Iterable[Mod], int, int]:
     page = get_page()
     mods, total_pages = search_mods(ga.id if ga else None, query, page, page_size)
     return mods, page, total_pages

--- a/KerbalStuff/config.py
+++ b/KerbalStuff/config.py
@@ -33,7 +33,7 @@ def _cfgb(k: str, default: bool = False) -> bool:
     return strtobool(val) == 1 if val is not None else default
 
 
-def _cfgd(k: str, default: Dict[str, str] = None) -> Dict[str, str]:
+def _cfgd(k: str, default: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     if default is None:
         default = {}
     val = _cfg(k)

--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -1,5 +1,5 @@
 import html
-from typing import Iterable, List, Dict
+from typing import Iterable, List, Dict, Optional
 
 from flask import url_for
 from jinja2 import Template
@@ -10,7 +10,7 @@ from .celery import send_mail
 from .config import _cfg, _cfgd
 
 
-def send_confirmation(user: User, followMod: str = None) -> None:
+def send_confirmation(user: User, followMod: Optional[str] = None) -> None:
     site_name = _cfg('site-name')
     if site_name:
         with open("emails/confirm-account") as f:

--- a/KerbalStuff/stubs/jinja2.pyi
+++ b/KerbalStuff/stubs/jinja2.pyi
@@ -1,0 +1,8 @@
+
+from jinja2.environment import Template as Template
+
+class Undefined:
+    ...
+
+class ChainableUndefined(Undefined):
+    ...

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -11,6 +11,7 @@ Flask-Login
 Flask-Markdown
 Flask-OAuthlib
 future
+GitPython
 gunicorn
 Jinja2<3 # See Flask
 Markdown

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -58,7 +58,7 @@
     </head>
     <body class="{% if user %}logged-in{% endif %}">
         {% block nav %}
-        <nav class="navbar navbar-default navbar-fixed-top {% if user and user.admin %}navbar-admin{% endif %}" role="navigation" >
+        <nav class="navbar navbar-default navbar-fixed-top {% if admin %}navbar-admin{% endif %}" role="navigation" >
             <div class="container">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -96,7 +96,9 @@
                                     <span class="text-muted">
                                         Game Version:
                                     </span>
-                                    {{ latest.gameversion.friendly_version }}
+                                    {% if latest -%}
+                                        {{ latest.gameversion.friendly_version }}
+                                    {%- endif %}
                                 </h2>
                             </div>
                         </div>


### PR DESCRIPTION
## Problem

If a logged in admin user tries to open https://spacedock.info/mod/1967 , a 500 error occurs:

![image](https://user-images.githubusercontent.com/1559108/126831235-1c6e1d4f-699c-4669-9920-2798ec1e526f.png)

We found this in the server log:

```
2021-07-23 15:22:54,835 ERROR Backend:496 Exception on /mod/1967 [GET]
Traceback (most recent call last):
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/common.py", line 64, in go
    ret = f(*args, **kwargs)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/blueprints/mods.py", line 185, in mod
    return render_template("mod.html",
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/templating.py", line 137, in render_template
    return _render(
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/templating.py", line 120, in _render
    rv = template.render(context)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/../templates/mod.html", line 1, in top-level template code
    {% extends "layout.html" %}
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/../templates/layout.html", line 180, in top-level template code
    {% block body %}{% endblock %}
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/../templates/mod.html", line 99, in block "body"
    {{ latest.gameversion.friendly_version }}
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'None' has no attribute 'gameversion'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 1822, in handle_user_exception
    return handler(e)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/app.py", line 173, in handle_generic_exception
    return render_template("error_5XX.html", error=e), e.code or 500
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/templating.py", line 136, in render_template
    ctx.app.update_template_context(context)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/flask/app.py", line 838, in update_template_context
    context.update(func())
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/app.py", line 295, in inject
    'admin': is_admin(),
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/helpers.py", line 8, in is_admin
    return current_user.admin
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 480, in __get__
    return self.impl.get(state, dict_)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 926, in get
    value = state._load_expired(state, passive)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/sqlalchemy/orm/state.py", line 675, in _load_expired
    self.manager.expired_attribute_loader(self, toload, passive)
  File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/lib/python3.8/site-packages/sqlalchemy/orm/loading.py", line 1343, in load_scalar_attributes
    raise orm_exc.DetachedInstanceError(
sqlalchemy.orm.exc.DetachedInstanceError: Instance <User at 0x7f6ba3187400> is not bound to a Session; attribute refresh operation cannot proceed (Background on this error at: http://sqlalche.me/e/14/bhk3)
2021-07-23 15:22:55,340 ERROR SpaceDock:496 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
```

## Causes

1. The mod is unpublished, so only admin users would see the mod template rendered, others get the 403 screen
2. The mod has no `default_version`, so the mod template throws an exception when it tries to access a property of `latest`
3. While handling this exception, the `with_session` wrapper closes the db session, which makes `current_user` an invalid object (it is a rich sqlalchemy object which is stripped of its db connection at close)
4. The template for 500 errors is rendered, but it uses `layout.html` which raises `DetachedInstanceError` because `current_user` is invalid

## Changes

- Now if `Mod.default_version` is not set, the backend code will default to using the one at the top of the list for the main compatibility field
- Now the mod template checks whether `latest` is null before using it, so the first exception won't be thrown
- Now `with_session` and `handle_generic_exception` no longer close the db; instead this is moved to `teardown_request`, which is called after the request is handled, so the 500 error template can be rendered with a valid `current_user` object instead of throwing an exception
  https://pythonise.com/series/learning-flask/python-before-after-request

### Unsuccessful investigation

I was hoping that we could update our mypy configuration to catch this class of template errors; a `latest.game_version.friendly_version` reference in the backend Python code would have raised mypy errors because `latest` is of type `Optional[Mod]`, which may be `None`.

Sadly, this does not seem to be an option. I found just two pages even coming close to the idea of type checking for jinja2 templates:

- https://www.eyrie.org/~eagle/journal/2019-11/001.html
  A discussion of the problems that can slip through static type checking when jinja2 templates are involved:
  > Forget to pass in owner? Exception or silent failure during template rendering depending on your Jinja2 options. Pass in the name of a service when the template was expecting a rich object? Exception or silent failure. Typo in the name of the parameter? Exception or silent failure. Better hope your test suite is thorough.

  Unfortunately the proposed solution is to create a "dataclass" for each template, with two downsides:
    1. A lot of extra code to maintain in addition to the templates
    2. No way to check if the dataclass is correct, you just have to trust that it accurately represents the template

  This seems like a non-solution to me.
- https://jinja2schema.readthedocs.io/en/latest/
  https://github.com/aromanovich/jinja2schema
  Parses a jinja2 template and outputs a representation of the types of its inputs. But not in a format usable by mypy, and the project is idle for 4-7 years.

Unfortunately it appears that no one has gone all the way to integrating jinja2 with mypy, so we will have to continue handling these one case at a time.

We looked into adding a `pytype` test to the GitHub workflows, but it can't handle `ChainableUndefined`, so that is left out of this pull request.
https://github.com/google/pytype