### PR TITLE
Fix (un)follow buttons

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -30,7 +30,7 @@ from ..config import _cfg
 from ..database import db
 from ..email import send_autoupdate_notification, send_mod_locked
 from ..objects import Mod, ModVersion, DownloadEvent, FollowEvent, ReferralEvent, \
-    Featured, Media, GameVersion, Game
+    Featured, Media, GameVersion, Game, Following
 from ..search import get_mod_score
 
 mods = Blueprint('mods', __name__, template_folder='../../templates/mods')
@@ -407,7 +407,7 @@ def unfollow(mod_id: int) -> Dict[str, Any]:
         event.events += 1
     mod.follower_count -= 1
     mod.score = get_mod_score(mod)
-    current_user.following = [m for m in current_user.following if m.id != int(mod_id)]
+    Following.query.filter(Following.mod_id == mod.id, Following.user_id == current_user.id).delete()
     return {"success": True}
 
 

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -65,24 +65,32 @@ link.addEventListener('click', (e) ->
         xhr.setRequestHeader('Accept', 'application/json')
         e.target.classList.remove('follow-mod-button')
         e.target.classList.remove('not-following-mod')
-        e.target.classList.remove('glyphicon-star-empty')
+        if $(e.target).parents('.modbox').length > 0
+            # This is the follow star in a mod box
+            e.target.classList.remove('glyphicon-star-empty')
+            e.target.classList.add('glyphicon-star')
+            $(".modbox-#{mod_id}-following").show()
+        else
+            # This is the big follow button on the mod page
+            e.target.text = "Unfollow"
         e.target.classList.add('unfollow-mod-button')
         e.target.classList.add('following-mod')
-        e.target.classList.add('glyphicon-star')
         e.target.title = "Unfollow"
         follow = true
-        $("#modbox-#{mod_id}-following").show()
     else
         xhr.open('POST', "/mod/#{mod_id}/unfollow")
         xhr.setRequestHeader('Accept', 'application/json')
         e.target.classList.remove('unfollow-mod-button')
         e.target.classList.remove('following-mod')
-        e.target.classList.remove('glyphicon-star')
+        if $(e.target).parents('.modbox').length > 0
+            e.target.classList.remove('glyphicon-star')
+            e.target.classList.add('glyphicon-star-empty')
+            $(".modbox-#{mod_id}-following").hide()
+        else
+            e.target.text = "Follow"
         e.target.classList.add('follow-mod-button')
         e.target.classList.add('not-following-mod')
-        e.target.classList.add('glyphicon-star-empty')
         e.target.title = "Follow"
-        $("#modbox-#{mod_id}-following").hide()
     xhr.onload = () ->
         try
             JSON.parse(this.responseText)

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -1,7 +1,7 @@
 <div class="item col-md-2 modbox">
     <div class="flip-container" ontouchstart="this.classList.toggle('hover');">
         <div class="changer">
-            <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}">
+            <div class="thumbnail front modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}">
                 <a class="header-img-link" href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">
                     <div class="header-img" style="background-color: #000000;
                     {%- if not mod.background -%}
@@ -18,7 +18,7 @@
                     </div>
                 {% endif %}
                 <div class="mod-ftr">
-                    <a class="following-mod glyphicon glyphicon-star" id="modbox-{{ mod.id }}-following" style="display:{%- if following_mod(mod) -%}block{%- else -%}none{%- endif -%}"></a>
+                    <a class="following-mod glyphicon glyphicon-star modbox-{{ mod.id }}-following" style="display:{%- if following_mod(mod) -%}block{%- else -%}none{%- endif -%}"></a>
                 </div>
                 <div class="caption">
                     <h2 class="group inner list-group-item-heading">
@@ -26,7 +26,7 @@
                     </h2>
                 </div>
             </div>
-            <div class="thumbnail back" id="modbox-{{ mod.id }}-desc" data-umodid="{{ mod.id }}">
+            <div class="thumbnail back modbox-{{ mod.id }}-desc" data-umodid="{{ mod.id }}">
                 <a class="header-img-link" href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}" style="text-decoration: none; color: #333333;">
                     <div class="header-img" style="display:block;overflow: hidden;text-overflow: ellipsis;background-color: #07acd2;color: #FFFFFF;">
                         <span style="padding:2.5mm">{{ mod.short_description }}</span>


### PR DESCRIPTION
## Problems
- Trying to unfollow returns
   ```
   500 Internal Server Error: Dependency rule tried to blank-out primary key column 'mod_followers.user_id' on instance '<Following at 0x7f5c90a31190>'
   ```
- Clicking follow or unfollow on mod pages adds this weird symbol to the buttons:
   ![image](https://user-images.githubusercontent.com/28812678/127530627-4310f488-01b8-4b1a-902f-742c5831fead.png)
- (Un)following on one of the browse/overview pages using the small star button only toggles the star for that mod box, but not for other mod boxes of the same mod.

## Causes
- With the database changes from #369, the code in `mods.unfollow()` no longer works. It was kinda weird anyways.
- With the mod box redesign from #343 the code for (un)follow buttons has been changed in a way that assumes it would only be called for the mod box star buttons, however it's still executed for the big (un)follow buttons on the mod pages. It tries to add the (empty) star glyphicon to the button, which fails to render correctly.
- The JS code tries to select the follow buttons in the mod boxes by id, however the id selector will only ever return up to one element, as more than one element with the same id is invalid HTML: https://api.jquery.com/id-selector/

## Changes
- Now we do a proper query on the `mod_followers`/`Following` table, and delete all rows with for that mod and user (hopefully there's only one,, but it handles any case fine).
- The JS code for follow buttons behaves differently based on whether we are inside a modbox or not, detected by checking if any of the parents have the `modbox` class. Based on that we either toggle the glyphicon, or change the text.
- All the `id` attributes in `mod-box.html` are moved to classes, as none of them would ever be unique on a page. The follow button code queries and toggles the stars based on the class, not id.
  I couldn't find any use of the other `modbox-*-*` ids in any code, so nothing else should need adjusting.