### PR TITLE
Fix follow buttons

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -29,7 +29,7 @@ from ..config import _cfg
 from ..database import db
 from ..email import send_autoupdate_notification, send_mod_locked
 from ..objects import Mod, ModVersion, DownloadEvent, FollowEvent, ReferralEvent, \
-    Featured, Media, GameVersion, Game
+    Featured, Media, GameVersion, Game, Following
 from ..search import get_mod_score
 from ..thumbnail import thumb_path_from_background_path
 
@@ -451,7 +451,7 @@ def unfollow(mod_id: int) -> Dict[str, Any]:
         event.events += 1
     mod.follower_count -= 1
     mod.score = get_mod_score(mod)
-    current_user.following = [m for m in current_user.following if m.id != int(mod_id)]
+    Following.query.filter(Following.mod_id == mod.id, Following.user_id == current_user.id).delete()
     return {"success": True}
 
 

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -55,42 +55,43 @@ if $(".dropdown-toggle").length > 0
         , false)
 )(box) for box in document.querySelectorAll('.upload-well')
 
+# Don't remove the follow alert from the DOM on dismiss so we can show it again
+$('#alert-follow').on 'close.bs.alert', () ->
+    $('#alert-follow').addClass 'hidden'
+    return false
+
 link.addEventListener('click', (e) ->
     e.preventDefault()
     xhr = new XMLHttpRequest()
-    follow = false
     mod_id = e.target.dataset.mod
-    if e.target.classList.contains('follow-mod-button')
-        xhr.open('POST', "/mod/#{mod_id}/follow")
-        xhr.setRequestHeader('Accept', 'application/json')
-        e.target.classList.remove('follow-mod-button')
-        e.target.classList.remove('not-following-mod')
-        e.target.classList.remove('glyphicon-star-empty')
-        e.target.classList.add('unfollow-mod-button')
-        e.target.classList.add('following-mod')
-        e.target.classList.add('glyphicon-star')
-        e.target.title = "Unfollow"
-        follow = true
-        $("#modbox-#{mod_id}-following").show()
-    else
-        xhr.open('POST', "/mod/#{mod_id}/unfollow")
-        xhr.setRequestHeader('Accept', 'application/json')
-        e.target.classList.remove('unfollow-mod-button')
-        e.target.classList.remove('following-mod')
-        e.target.classList.remove('glyphicon-star')
-        e.target.classList.add('follow-mod-button')
-        e.target.classList.add('not-following-mod')
-        e.target.classList.add('glyphicon-star-empty')
-        e.target.title = "Follow"
-        $("#modbox-#{mod_id}-following").hide()
+    xhr.open 'POST', "/mod/#{mod_id}/follow"
+    xhr.setRequestHeader 'Accept', 'application/json'
     xhr.onload = () ->
+        $(".mod-#{mod_id}").removeClass 'not-following-mod'
+        $(".mod-#{mod_id}").addClass 'following-mod'
         try
-            JSON.parse(this.responseText)
-            document.getElementById('alert-follow').classList.remove('hidden') if follow
-        catch
+            JSON.parse this.responseText
+            $('#alert-follow').removeClass 'hidden'
+        catch exc
             window.location.href = '/register'
     xhr.send()
-, false) for link in document.querySelectorAll('.follow-mod-button, .unfollow-mod-button')
+, false) for link in document.querySelectorAll('.follow-mod-button')
+
+link.addEventListener('click', (e) ->
+    e.preventDefault()
+    xhr = new XMLHttpRequest()
+    mod_id = e.target.dataset.mod
+    xhr.open 'POST', "/mod/#{mod_id}/unfollow"
+    xhr.setRequestHeader 'Accept', 'application/json'
+    xhr.onload = () ->
+        $(".mod-#{mod_id}").removeClass 'following-mod'
+        $(".mod-#{mod_id}").addClass 'not-following-mod'
+        try
+            JSON.parse this.responseText
+        catch exc
+            window.location.href = '/register'
+    xhr.send()
+, false) for link in document.querySelectorAll('.unfollow-mod-button')
 
 link.addEventListener('click', (e) ->
     e.preventDefault()

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -55,9 +55,12 @@ if $(".dropdown-toggle").length > 0
         , false)
 )(box) for box in document.querySelectorAll('.upload-well')
 
-# Don't remove the follow alert from the DOM on dismiss so we can show it again
+# Don't remove alerts from the DOM on dismiss so we can show them again
 $('#alert-follow').on 'close.bs.alert', () ->
     $('#alert-follow').addClass 'hidden'
+    return false
+$('#alert-error').on 'close.bs.alert', () ->
+    $('#alert-error').addClass 'hidden'
     return false
 
 link.addEventListener('click', (e) ->
@@ -65,15 +68,16 @@ link.addEventListener('click', (e) ->
     xhr = new XMLHttpRequest()
     mod_id = e.target.dataset.mod
     xhr.open 'POST', "/mod/#{mod_id}/follow"
-    xhr.setRequestHeader 'Accept', 'application/json'
+    xhr.setRequestHeader 'Accept', 'application/*.coffee'
     xhr.onload = () ->
-        $(".mod-#{mod_id}").removeClass 'not-following-mod'
-        $(".mod-#{mod_id}").addClass 'following-mod'
-        try
-            JSON.parse this.responseText
+        response = JSON.parse this.responseText
+        if response.success
+            $(".mod-#{mod_id}").removeClass 'not-following-mod'
+            $(".mod-#{mod_id}").addClass 'following-mod'
             $('#alert-follow').removeClass 'hidden'
-        catch exc
-            window.location.href = '/register'
+        else
+            $('#alert-error-text').text response.reason
+            $('#alert-error').removeClass 'hidden'
     xhr.send()
 , false) for link in document.querySelectorAll('.follow-mod-button')
 
@@ -84,12 +88,13 @@ link.addEventListener('click', (e) ->
     xhr.open 'POST', "/mod/#{mod_id}/unfollow"
     xhr.setRequestHeader 'Accept', 'application/json'
     xhr.onload = () ->
-        $(".mod-#{mod_id}").removeClass 'following-mod'
-        $(".mod-#{mod_id}").addClass 'not-following-mod'
-        try
-            JSON.parse this.responseText
-        catch exc
-            window.location.href = '/register'
+        response = JSON.parse this.responseText
+        if response.success
+            $(".mod-#{mod_id}").removeClass 'following-mod'
+            $(".mod-#{mod_id}").addClass 'not-following-mod'
+        else
+            $('#alert-error-text').text response.reason
+            $('#alert-error').removeClass 'hidden'
     xhr.send()
 , false) for link in document.querySelectorAll('.unfollow-mod-button')
 

--- a/frontend/styles/listing.scss
+++ b/frontend/styles/listing.scss
@@ -79,16 +79,24 @@
         border-radius: 0;
     }
 
-    .following-mod, .not-following-mod, .download-link {
+    .follow-mod-button, .unfollow-mod-button, .download-link, .following-mod-indicator {
         text-decoration: none;
         font-size: 20px;
         margin-top: -2px;
-    }
-    .not-following-mod, .following-mod, .download-link {
         color: #07acd2;
     }
-    .following-mod, .not-following-mod {
+    .follow-mod-button, .unfollow-mod-button, .following-mod-indicator {
         float: left;
+    }
+    .following-mod-indicator,
+    .unfollow-mod-button,
+    .follow-mod-button {
+        display: none;
+    }
+    &.following-mod .following-mod-indicator,
+    &.following-mod .unfollow-mod-button,
+    &.not-following-mod .follow-mod-button {
+        display: block;
     }
     .front .following-mod, .front .not-following-mod {
         text-shadow: 0 0 4px rgba(0, 17, 22, 0.7);

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -214,3 +214,14 @@
 .form-group.has-error .help-block {
     display: block;
 }
+
+.following-mod-indicator,
+.unfollow-mod-button,
+.follow-mod-button {
+    display: none;
+}
+.following-mod .following-mod-indicator,
+.following-mod .unfollow-mod-button,
+.not-following-mod .follow-mod-button {
+    display: block;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -174,6 +174,10 @@
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             <strong>Done!</strong> You'll get emailed updates for this mod.
         </div>
+        <div class="alert alert-danger alert-dismissable alert-fixed hidden" id="alert-error">
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            <div id="alert-error-text"></div>
+        </div>
         {% if donation_header_link %}
         <div class="centered alert alert-danger alert-dismissable no-margin" id="alert-donate">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -1,7 +1,7 @@
-<div class="item col-md-2 modbox">
+<div class="item col-md-2 modbox mod-{{ mod.id }} {% if following_mod(mod) %}following-mod{% elif user %}not-following-mod{% endif %}">
     <div class="flip-container" ontouchstart="this.classList.toggle('hover');">
         <div class="changer">
-            <div class="thumbnail front" id="modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}">
+            <div class="thumbnail front modbox-{{ mod.id }}-pic" data-modid="{{ mod.id }}">
                 <a class="header-img-link" href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}">
                     <div class="header-img" style="background-color: #000000;
                     {%- set thumbnail = mod.background_thumb() -%}
@@ -19,7 +19,7 @@
                     </div>
                 {% endif %}
                 <div class="mod-ftr">
-                    <a class="following-mod glyphicon glyphicon-star" id="modbox-{{ mod.id }}-following" style="display:{%- if following_mod(mod) -%}block{%- else -%}none{%- endif -%}"></a>
+                    <a class="following-mod-indicator glyphicon glyphicon-star"></a>
                 </div>
                 <div class="caption">
                     <h2 class="group inner list-group-item-heading">
@@ -27,18 +27,15 @@
                     </h2>
                 </div>
             </div>
-            <div class="thumbnail back" id="modbox-{{ mod.id }}-desc" data-umodid="{{ mod.id }}">
+            <div class="thumbnail back modbox-{{ mod.id }}-desc" data-umodid="{{ mod.id }}">
                 <a class="header-img-link" href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}" style="text-decoration: none; color: #333333;">
                     <div class="header-img" style="display:block;overflow: hidden;text-overflow: ellipsis;background-color: #07acd2;color: #FFFFFF;">
                         <span style="padding:2.5mm">{{ mod.short_description }}</span>
                     </div>
                 </a>
                 <div class="mod-ftr">
-                    {% if following_mod(mod) %}
-                        <a href="#" title="Unfollow" class="following-mod unfollow-mod-button glyphicon glyphicon-star" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
-                    {% elif user %}
-                        <a href="#" title="Follow" class="not-following-mod follow-mod-button glyphicon glyphicon-star-empty" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
-                    {% endif %}
+                    <a href="#" title="Unfollow" class="unfollow-mod-button glyphicon glyphicon-star" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
+                    <a href="#" title="Follow" class="follow-mod-button glyphicon glyphicon-star-empty" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
 
                     <a href='{{url_for("mods.download", mod_id=mod.id, mod_name=mod.name)}}' title="Download" class="download-link glyphicon glyphicon-save-file"></a>
                 </div>

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -66,12 +66,9 @@
                 Download {% if latest.id in size_versions and size_versions[latest.id] is not none %} ({{ size_versions[latest.id] }}) {% endif %}</a>
         </div>
         {% if user %}
-        <div class="col-md-2">
-            {% if following_mod(mod) %}
+        <div class="col-md-2 mod-{{ mod.id }} {% if following_mod(mod) %}following-mod{% elif user %}not-following-mod{% endif %}">
             <a href="#" class="unfollow-mod-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
-            {% else %}
             <a href="#" class="follow-mod-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
-            {% endif %}
         </div>
         {% endif %}
     </div>

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -68,6 +68,7 @@
         {% if user %}
         <div class="col-md-2 mod-{{ mod.id }} {% if following_mod(mod) %}following-mod{% elif user %}not-following-mod{% endif %}">
             <a href="#" class="unfollow-mod-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Unfollow</a>
+            <div class="hidden">{# dummy to stop Bootstrap from adding margin to the second button #}</div>
             <a href="#" class="follow-mod-button btn btn-block btn-lg btn-warning" data-mod="{{ mod.id }}" data-id="{{ mod.id }}">Follow</a>
         </div>
         {% endif %}


### PR DESCRIPTION
## Motivation

I've wanted to rework the very janky follow/unfollow buttons since KSP-SpaceDock/SpaceDock#343, but that pull request had a lot of other things going on and I did not want to increase its scope. KSP-SpaceDock/SpaceDock#379 focused exclusively on the follow buttons, and this pull request replaces that one.

Too much of the visual and style info about the follow/unfollow buttons has been encoded into client script code. The `click` event handler manipulates the text, tooltips, glyphicon classes, etc., to transform a follow button into an unfollow button and vice versa. This essentially means the client script code needs to know everything about how these buttons are supposed to appear, which is hard to maintain and prone to bugs.

## Problems

- Trying to unfollow returns
   ```
   500 Internal Server Error: Dependency rule tried to blank-out primary key column 'mod_followers.user_id' on instance '<Following at 0x7f5c90a31190>'
   ```
- Clicking follow or unfollow on mod pages adds this weird symbol to the buttons:
   ![image](https://user-images.githubusercontent.com/28812678/127530627-4310f488-01b8-4b1a-902f-742c5831fead.png)
- (Un)following on one of the browse/overview pages using the small star button only toggles the star for that mod box, but not for other mod boxes of the same mod.
- If a mod appears multiple times on the screen and you click the star to follow it, all copies of it appear to receive the solid star following indicator, but when you hover them, all except the one you clicked appear to reset to unfollowed (empty star)
- If you click the follow button once, an alert tells you that you will receive emails. If you dismiss this alert and then follow again, you will be taken to the `/register` page.

## Causes

- With the database changes from #369, the code in `mods.unfollow()` no longer works. It was kinda weird anyways.
- With the mod box redesign from #343 the code for (un)follow buttons has been changed in a way that assumes it would only be called for the mod box star buttons, however it's still executed for the big (un)follow buttons on the mod pages. It tries to add the (empty) star glyphicon to the button, which fails to render correctly.
- The JS code tries to select the follow buttons in the mod boxes by id, however the id selector will only ever return up to one element, as more than one element with the same id is invalid HTML: https://api.jquery.com/id-selector/
- The `click` handler of the follow button updates the solid star indicator for all copies of a mod in the page, but for everything else it only modifies the element you clicked on
- Bootstrap removes alerts from the DOM when they are dismissed:
  https://getbootstrap.com/docs/4.0/components/alerts/

  Method | Description
  -- | --
  `$().alert('close')` | Closes an alert **by removing it from the DOM**. If the .fade and .show classes are present on the element, the alert will fade out before it is removed.

  So the next time we try to show that alert, its element is no longer available; an exception is thrown, and the `click` handler interprets this as the user not being logged in and redirects them to `/register`.

## Changes

- Now we do a proper query on the `mod_followers`/`Following` table, and delete all rows with for that mod and user (hopefully there's only one, but it handles any case fine).
- All the `id` attributes in `mod-box.html` are moved to classes, as none of them would ever be unique on a page. The follow button code queries and toggles the stars based on the class, not id.
  I couldn't find any use of the other `modbox-*-*` ids in any code, so nothing else should need adjusting.
- Now the templates render both the follow and unfollow buttons and rely on classes from the stylesheets to show and hide them. When you click one, we replace `.not-following-mod` with `.following-mod` or vice versa for all elements that match `.mod-{{mod.id}}`, which is intended to be any element that depends on following or not-following state. Instead of manipulating the details of the elements' attributes, we're just telling them whether the mod should show a following state, and stylesheet rules take care of what should be shown or hidden. This makes the toggle work properly for all copies of a mod that are in the page, and means that we can freely change how the buttons look in the templates without the client script code missing them up.
- Now we override the follow alert's close handler to just add the `hidden` stylesheet class rather than removing it from the DOM (suppressed by returning false). This way it remains available in case we want to show it again.