### PR TITLE
Modernize Youtube embeds and exempt from Bleach cleaning, abandon Imgur embeds

### DIFF
--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -23,12 +23,22 @@ from .custom_json import CustomJSONEncoder
 from .database import db, Base
 from .objects import Game, Mod, Featured, ModVersion, ReferralEvent, DownloadEvent, FollowEvent
 from .search import search_mods
+from .kerbdown import EmbedInlineProcessor
 
 TRUE_STR = ('true', 'yes', 'on')
 PARAGRAPH_PATTERN = re.compile('\n\n|\r\n\r\n')
 
-cleaner = bleach.Cleaner(tags=bleach_allowlist.markdown_tags,
-                         attributes=bleach_allowlist.markdown_attrs,
+def allow_iframe_attr(tagname: str, attrib: str, val: str) -> bool:
+    return (any(val.startswith(prefix) for prefix in EmbedInlineProcessor.IFRAME_SRC_PREFIXES)
+            if attrib == 'src' else
+            attrib in EmbedInlineProcessor.IFRAME_ATTRIBS)
+
+
+cleaner = bleach.Cleaner(tags=bleach_allowlist.markdown_tags + ['iframe'],
+                         attributes={  # type: ignore[arg-type]
+                             **bleach_allowlist.markdown_attrs,
+                             'iframe': allow_iframe_attr
+                         },
                          filters=[bleach.linkifier.LinkifyFilter])
 
 

--- a/KerbalStuff/kerbdown.py
+++ b/KerbalStuff/kerbdown.py
@@ -1,69 +1,75 @@
 import urllib.parse
 from urllib.parse import parse_qs, urlparse
-from typing import Dict, Any, Match
+from typing import Dict, Any, Match, Tuple
 
 from markdown import Markdown
 from markdown.extensions import Extension
-from markdown.inlinepatterns import Pattern
+from markdown.inlinepatterns import InlineProcessor
 from markdown.util import etree
 
-EMBED_RE = r'\[\[(?P<url>.+?)\]\]'
 
+class EmbedInlineProcessor(InlineProcessor):
+    # Don't worry about re.compiling this, markdown.inlinepatterns.Pattern.__init__ does that for us
+    EMBED_RE = r'\[\[(?P<url>.+?)\]\]'
 
-def embed_youtube(link: urllib.parse.ParseResult) -> etree.Element:
-    q = parse_qs(link.query)
-    v = q['v'][0]
-    el = etree.Element('iframe')
-    el.set('width', '100%')
-    el.set('height', '600')
-    el.set('frameborder', '0')
-    el.set('allowfullscreen', '')
-    el.set('src', '//www.youtube-nocookie.com/embed/' + v + '?rel=0')
-    return el
+    # Prefixes of the iframe src attributes we generate
+    YOUTUBE_SRC_PREFIX = '//www.youtube-nocookie.com/embed/'
+    IMGUR_SRC_PREFIX = '//imgur.com/a/'
+    IFRAME_SRC_PREFIXES = [YOUTUBE_SRC_PREFIX, IMGUR_SRC_PREFIX]
 
+    # Other iframe attributes we generate
+    IFRAME_ATTRIBS = ['width', 'height', 'frameborder', 'allowfullscreen']
 
-def embed_imgur(link: urllib.parse.ParseResult) -> etree.Element:
-    a = link.path.split('/')[2]
-    el = etree.Element('iframe')
-    el.set('width', '100%')
-    el.set('height', '550')
-    el.set('frameborder', '0')
-    el.set('allowfullscreen', '')
-    el.set('src', '//imgur.com/a/' + a + '/embed')
-    return el
-
-
-class EmbedPattern(Pattern):
-    def __init__(self, pattern: str, m: Markdown, configs: Dict[str, Any]) -> None:
-        super(EmbedPattern, self).__init__(pattern, m)
+    def __init__(self, md: Markdown, configs: Dict[str, Any]) -> None:
+        super().__init__(self.EMBED_RE, md)
         self.config = configs
 
-    def handleMatch(self, m: Match[str]) -> etree.Element:
+    def handleMatch(self, m: Match[str], data: str) -> Tuple[etree.Element, int, int]:  # type: ignore[override]
         d = m.groupdict()
         url = d.get('url')
         if not url:
             el = etree.Element('span')
             el.text = "[[]]"
-            return el
+            return el, m.start(0), m.end(0)
         try:
             link = urlparse(url)
             host = link.hostname
         except:
             el = etree.Element('span')
             el.text = "[[" + url + "]]"
-            return el
+            return el, m.start(0), m.end(0)
         el = None
         try:
             if host == 'youtube.com' or host == 'www.youtube.com':
-                el = embed_youtube(link)
+                el = self._embed_youtube(link)
             if host == 'imgur.com' or host == 'www.imgur.com':
-                el = embed_imgur(link)
+                el = self._embed_imgur(link)
         except:
             pass
         if el is None:
             el = etree.Element('span')
             el.text = "[[" + url + "]]"
-            return el
+        return el, m.start(0), m.end(0)
+
+    def _embed_youtube(self, link: urllib.parse.ParseResult) -> etree.Element:
+        q = parse_qs(link.query)
+        v = q['v'][0]
+        el = etree.Element('iframe')
+        el.set('width', '100%')
+        el.set('height', '600')
+        el.set('frameborder', '0')
+        el.set('allowfullscreen', '')
+        el.set('src', self.YOUTUBE_SRC_PREFIX + v + '?rel=0')
+        return el
+
+    def _embed_imgur(self, link: urllib.parse.ParseResult) -> etree.Element:
+        a = link.path.split('/')[2]
+        el = etree.Element('iframe')
+        el.set('width', '100%')
+        el.set('height', '550')
+        el.set('frameborder', '0')
+        el.set('allowfullscreen', '')
+        el.set('src', self.IMGUR_SRC_PREFIX + a + '/embed')
         return el
 
 
@@ -75,5 +81,5 @@ class KerbDown(Extension):
     # noinspection PyMethodOverriding
     def extendMarkdown(self, md: Markdown) -> None:
         # BUG: the base method signature is INVALID, it's a bug in flask-markdown
-        md.inlinePatterns['embeds'] = EmbedPattern(EMBED_RE, md, self.config) # type: ignore[attr-defined]
+        md.inlinePatterns.register(EmbedInlineProcessor(md, self.config), 'embed', 200)
         md.registerExtension(self)

--- a/KerbalStuff/kerbdown.py
+++ b/KerbalStuff/kerbdown.py
@@ -14,8 +14,7 @@ class EmbedInlineProcessor(InlineProcessor):
 
     # Prefixes of the iframe src attributes we generate
     YOUTUBE_SRC_PREFIX = '//www.youtube-nocookie.com/embed/'
-    IMGUR_SRC_PREFIX = '//imgur.com/a/'
-    IFRAME_SRC_PREFIXES = [YOUTUBE_SRC_PREFIX, IMGUR_SRC_PREFIX]
+    IFRAME_SRC_PREFIXES = [YOUTUBE_SRC_PREFIX]
 
     # Other iframe attributes we generate
     IFRAME_ATTRIBS = ['width', 'height', 'frameborder', 'allowfullscreen']
@@ -42,8 +41,6 @@ class EmbedInlineProcessor(InlineProcessor):
         try:
             if host == 'youtube.com' or host == 'www.youtube.com' or host == 'youtu.be':
                 el = self._embed_youtube(self._get_youtube_id(link))
-            if host == 'imgur.com' or host == 'www.imgur.com':
-                el = self._embed_imgur(link)
         except:
             pass
         if el is None:
@@ -62,16 +59,6 @@ class EmbedInlineProcessor(InlineProcessor):
         el.set('frameborder', '0')
         el.set('allowfullscreen', '')
         el.set('src', self.YOUTUBE_SRC_PREFIX + vid_id + '?rel=0')
-        return el
-
-    def _embed_imgur(self, link: urllib.parse.ParseResult) -> etree.Element:
-        a = link.path.split('/')[2]
-        el = etree.Element('iframe')
-        el.set('width', '100%')
-        el.set('height', '550')
-        el.set('frameborder', '0')
-        el.set('allowfullscreen', '')
-        el.set('src', self.IMGUR_SRC_PREFIX + a + '/embed')
         return el
 
 

--- a/KerbalStuff/kerbdown.py
+++ b/KerbalStuff/kerbdown.py
@@ -40,8 +40,8 @@ class EmbedInlineProcessor(InlineProcessor):
             return el, m.start(0), m.end(0)
         el = None
         try:
-            if host == 'youtube.com' or host == 'www.youtube.com':
-                el = self._embed_youtube(link)
+            if host == 'youtube.com' or host == 'www.youtube.com' or host == 'youtu.be':
+                el = self._embed_youtube(self._get_youtube_id(link))
             if host == 'imgur.com' or host == 'www.imgur.com':
                 el = self._embed_imgur(link)
         except:
@@ -51,15 +51,17 @@ class EmbedInlineProcessor(InlineProcessor):
             el.text = "[[" + url + "]]"
         return el, m.start(0), m.end(0)
 
-    def _embed_youtube(self, link: urllib.parse.ParseResult) -> etree.Element:
-        q = parse_qs(link.query)
-        v = q['v'][0]
+    def _get_youtube_id(self, link: urllib.parse.ParseResult) -> str:
+        return (link.path if link.netloc == 'youtu.be'
+                else parse_qs(link.query)['v'][0])
+
+    def _embed_youtube(self, vid_id: str) -> etree.Element:
         el = etree.Element('iframe')
         el.set('width', '100%')
         el.set('height', '600')
         el.set('frameborder', '0')
         el.set('allowfullscreen', '')
-        el.set('src', self.YOUTUBE_SRC_PREFIX + v + '?rel=0')
+        el.set('src', self.YOUTUBE_SRC_PREFIX + vid_id + '?rel=0')
         return el
 
     def _embed_imgur(self, link: urllib.parse.ParseResult) -> etree.Element:

--- a/templates/markdown.html
+++ b/templates/markdown.html
@@ -57,5 +57,6 @@ This is a very neat mod I wrote that lets you do *super cool things*.
     <pre>![](http://example.com/image.png)</pre>
     <p>You can also embed YouTube videos and Imgur albums by wrapping the URL in brackets (specific to {{ site_name }}):</p>
     <pre>[[https://www.youtube.com/watch?v=T4rfHAqs9EI]]</pre>
+    <pre>[[https://youtu.be/dQw4w9WgXcQ]]</pre>
 </div>
 {% endblock %}

--- a/templates/markdown.html
+++ b/templates/markdown.html
@@ -55,8 +55,9 @@ This is a very neat mod I wrote that lets you do *super cool things*.
     <h2>Embedding videos and images</h2>
     <p>You can easily embed a single image like so (this came from the Markdown spec):</p>
     <pre>![](http://example.com/image.png)</pre>
-    <p>You can also embed YouTube videos and Imgur albums by wrapping the URL in brackets (specific to {{ site_name }}):</p>
-    <pre>[[https://www.youtube.com/watch?v=T4rfHAqs9EI]]</pre>
-    <pre>[[https://youtu.be/dQw4w9WgXcQ]]</pre>
+    <p>You can also embed YouTube videos by wrapping the URL in brackets (specific to {{ site_name }}):</p>
+    <pre>[[https://www.youtube.com/watch?v=T4rfHAqs9EI]]
+
+[[https://youtu.be/dQw4w9WgXcQ]]</pre>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Problem

https://spacedock.info/markdown says:

> You can also embed YouTube videos and Imgur albums by wrapping the URL in brackets (specific to SpaceDock):
> 
> `[[https://www.youtube.com/watch?v=T4rfHAqs9EI]]`

However, if you try to use this currently, it just renders as an escaped inline `<iframe>`:

https://spacedock.info/mod/141/scatterer

![image](https://user-images.githubusercontent.com/1559108/128616410-7a80f80c-00cc-4121-834e-b8dada1abbdf.png)

## Cause

#336 added a Bleach sanitization pass to our Markdown rendering, which only allows certain tags and attributes to be included in the rendered HTML. Currently `iframe` is not on the allowed list, and the above embedding functionality works by generating an `iframe` element.

## Changes

Now `iframe` is allowed, but we apply extra validation to it. Only the attributes generated by SD's embed code are allowed, and for `src` specifically, only values beginning with the URL prefixes we use are allowed. If someone tries to use an `iframe` with an unauthorized URL, it will just show up as empty:

![image](https://user-images.githubusercontent.com/1559108/128616436-87097869-c95c-4006-876a-962f4e4df42a.png)

Fixes #383.

### Side fixes

The embedding functionality was using a deprecated API (assigning a `Pattern` directly to a member of `md.inlinePatterns`) and is now updated to the newer `register` API. As part of this the KerbDown-related classes are refactored somewhat to put certain values and functions in the classes where they belong.

If you click "SHARE" on Youtube, it presents you with a link in the format `https://youtu.be/video_id`. Now we support embedding this format.

Imgur's embedding hasn't worked in a long time, and shows no signs of ever being fixed. Now it's removed from the code and from the markdown help page.