### PR TITLE
Add OpenGraph meta tags

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -312,6 +312,7 @@ def inject() -> Dict[str, Any]:
         'url_for': url_for,
         'strftime': strftime,
         'site_name': _cfg('site-name'),
+        'caption': _cfg('caption'),
         'support_mail': _cfg('support-mail'),
         'source_code': _cfg('source-code'),
         'support_channels': _cfgd('support-channels'),

--- a/config.ini.example
+++ b/config.ini.example
@@ -3,8 +3,12 @@
 environment=dev
 
 [dev]
+## Site settings ##
+
 # The displayed name of this site
 site-name=Spacedock.Info
+# Short abstract, displayed for example in OpenGraph embeds
+caption=A community modding site for Kerbal Space Program
 # The email where users who need help write to
 support-mail=support@spacedock.info
 # The email address that automatically activates people who send to it
@@ -19,15 +23,34 @@ donation-link=https://www.patreon.com/user?u=2903335&ty=p
 # If you have a donation link and want it displayed below the header, set this to 'true'
 donation-header-link=false
 
+# Set this to False to disable registration
+registration=True
+
+# Set this to the id of the Game that represents KSP.
+# Its GameVersions will automatically sync up with CKAN's KSP builds.json.
+ksp-game-id=
+
+# Thumbnail size in WxH format. Defaults to 320x195 if not set.
+# The better it matches the aspect ratio as it is displayed in the mod box, the better the quality.
+# It's somewhere between 16:9 and 16:10, but changes a bit based on client screen size.
+thumbnail_size=320x195
+# Thumbnail quality, between 0 and 100. Defaults to 80 if not set.
+thumbnail_quality=80
+
+## Web server settings ##
+
 # Change this to the actual location of your site
 protocol=http
 domain=localhost:5080
 # Change this value to something random and secret
 secret-key=hello world
 
-# Set this to the id of the Game that represents KSP.
-# Its GameVersions will automatically sync up with CKAN's KSP builds.json.
-ksp-game-id=
+# Redirect downloads to a CDN. Can also contain a partial path, without trailing slash.
+# The 'protocol' setting from above will also be used for the CDN.
+cdn-domain=
+# The internal hostname of the CDN / a reverse proxy in front of this server that caches mod files.
+# If set, the backend will send a PURGE request when a mod version gets deleted to clear it from the cache.
+cdn-internal=
 
 # Enable offloading of downloads to the reverse proxy server. Make sure the reverse proxy is set up!
 # valid values are:
@@ -35,9 +58,6 @@ ksp-game-id=
 # nginx - enable X-Accel headers
 # apache - enable X-Sendfile headers
 use-x-accel=false
-
-# Set this to False to disable registration
-registration=True
 
 # To send emails, fill out these details
 smtp-host=
@@ -49,6 +69,8 @@ smtp-tls=false
 error-to=
 error-from=
 
+## Database settings ##
+
 # SQL connection string
 connection-string=postgresql://postgres:somewhatsecretpassword@db/spacedock
 
@@ -59,12 +81,7 @@ redis-connection=redis://redis:6379/0
 # Absolute path to the directory you want to store mods in
 storage=/opt/spacedock/storage
 
-# Redirect downloads to a CDN. Can also contain a partial path, without trailing slash.
-# The 'protocol' setting from above will also be used for the CDN.
-cdn-domain=
-# The internal hostname of the CDN / a reverse proxy in front of this server that caches mod files.
-# If set, the backend will send a PURGE request when a mod version gets deleted to clear it from the cache.
-cdn-internal=
+## Automation and extensions settings ##
 
 # Set hook_secret and your GitHub web hook's secret to the same value to authenticate hooks
 # to trigger automatic redeployment.
@@ -87,13 +104,6 @@ google_analytics_id=
 google_analytics_domain=
 # Blog comments
 disqus_id=
-
-# Thumbnail size in WxH format. Defaults to 320x195 if not set.
-# The better it matches the aspect ratio as it is displayed in the mod box, the better the quality.
-# It's somewhere between 16:9 and 16:10, but changes a bit based on client screen size.
-thumbnail_size=320x195
-# Thumbnail quality, between 0 and 100. Defaults to 80 if not set.
-thumbnail_quality=80
 
 # URL to notify of mod creation
 create-url=

--- a/templates/game.html
+++ b/templates/game.html
@@ -2,6 +2,13 @@
 {% block styles %}
 <link rel="stylesheet" type="text/css" href="/static/index.css" />
 {% endblock %}
+{% block opengraph %}
+    <meta property="og:title" content="Mods for {{ ga.name }} on {{ site_name }}">
+    <meta property="og:type" content="website">
+    <meta property="og:description" content="Browse {{ mod_count }} mods for {{ ga.name }}">
+    {% set thumbnail = ga.background or "/static/background-s.png" -%}
+    <meta property="og:image" content="{{ thumbnail }}">
+{% endblock %}
 {% block body %}
 {% if user and len(yours) >= 1 %}
     <div class="well" style="margin-bottom: 0;">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,10 +4,21 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {%- block title %}
+            <title>{{ site_name }}</title>
+        {% endblock -%}
+        {%- block opengraph %}
+            <meta property="og:title" content="{{ site_name }}">
+            <meta property="og:type" content="website">
+            {% if caption -%}
+            <meta property="og:description" content="{{ caption }}">
+            {% endif -%}
+            <meta property="og:image" content="/static/og.png">
+        {% endblock -%}
+        <meta property="og:site_name" content="{{ site_name }}">
 
         <link rel="stylesheet" href="/static/font-awesome.min.css">
         <link rel="search" type="application/opensearchdescription+xml" title="{{ site_name }}" href="/static/opensearch.xml" />
-        <meta property="og:image" content="/static/og.png" />
         <link rel="apple-touch-icon" sizes="57x57" href="/static/57x57.png">
         <link rel="apple-touch-icon" sizes="60x60" href="/static/60x60.png">
         <link rel="apple-touch-icon" sizes="72x72" href="/static/72x72.png">
@@ -28,9 +39,6 @@
         <meta name="msapplication-TileImage" content="/static/144x144.png">
         <meta name="msapplication-config" content="/static/browserconfig.xml">
         <meta name="theme-color" content="#204499">
-        {% block title %}
-        <title>{{ site_name }}</title>
-        {% endblock %}
         <link href="/static/bootstrap.min.css" rel="stylesheet">
         <link href="/static/bootstrap-theme.css" rel="stylesheet">
         {% block styles %}

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -2,6 +2,19 @@
 {% block title %}
 <title>{{ mod.name }} on {{ site_name }}</title>
 {% endblock %}
+{% block opengraph %}
+    <meta property="og:title" content="{{ mod.name }} by {{ mod.user.username }}
+        {%- for author in mod.shared_authors if author.accepted -%}
+            {% if loop.last %} and {% else %}, {% endif -%}
+            {{ author.user.username }}
+        {%- endfor -%}
+    ">
+    <meta property="og:type" content="website">
+    <meta property="og:description" content="{{ latest.friendly_version }} for {{ ga.abbrev }} {{ latest_game_version.friendly_version }} | Download: {{ size_versions[latest.id] }} | Released on: {{ latest.created.strftime("%Y-%m-%d") }}
+{{ mod.short_description }}">
+    {% set thumbnail = mod.background_thumb() or "/static/background-s.png" -%}
+    <meta property="og:image" content="{{ thumbnail }}">
+{% endblock %}
 {% block styles %}
     <link rel="stylesheet" type="text/css" href="/static/mod.css"/>
 {% endblock %}

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -2,6 +2,14 @@
 {% block title %}
 <title>{{ mod_list.name }} on {{ site_name }}</title>
 {% endblock %}
+{% block opengraph %}
+    <meta property="og:title" content="{{ mod_list.name }} by {{ mod_list.user.username }}">
+    <meta property="og:type" content="website">
+    {# don't render the Markdown, keep it plain text -#}
+    <meta property="og:description" content="{{ mod_list.description | first_paragraphs | bleach }}">
+    {% set thumbnail = mod_list.background or "/static/background-s.png" -%}
+    <meta property="og:image" content="{{ thumbnail }}">
+{% endblock %}
 {% block styles %}
 <link rel="stylesheet" type="text/css" href="/static/mod.css" />
 {% endblock %}

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -5,6 +5,13 @@
 {% block title %}
 <title>{{ profile.username }} on {{ site_name }}</title>
 {% endblock %}
+{% block opengraph %}
+    <meta property="og:title" content="{{ profile.username }} on {{ site_name }}">
+    <meta property="og:type" content="profile">
+    <meta property="og:profile:username" content="{{ profile.username }}">
+    <meta property="og:description" content="See all mods made by {{ profile.username }}">
+    <meta property="og:image" content="/static/og.png">
+{% endblock %}
 {% block body %}
 {% if background %}
 <div class="header" style="background-image: url({{ background }});


### PR DESCRIPTION
Started working on this yesterday, and funnily enough today @V1TA5 suggested it in the Discord.

## Background
This pull request adds HTML meta tags according to the [Open Graph protocol](https://ogp.me/) to SpaceDock.
These tags are used by websites and programs to generate "embeds" / "cards" / previews of a shared link.
Among those are Discord, Facebook and Element (Matrix client).
Twitter requires their own custom meta tags, AFAIK. We can think about adding them too, once we've confirmed this works as intended.

Open Graph only defines the _declaration_ of meta tags, it does not define how they should be interpreted, used and rendered. This means that every software/service shows them a bit differently.

Right now there already is a single Open Graph tag present, which sets an image to display in the preview:
![image](https://user-images.githubusercontent.com/28812678/128771209-0179d898-304b-4e85-8fd7-65abc6b4ac37.png)

Better than nothing, but there's much more you can do with Open Graph:

## Changes
In `layout.html`, the base of all our HTML pages, a new `opengraph` block is defined. It contains a bunch of default tags, like the site name as title, the existing `og.png` as image, and a new configurable `caption` as description.

These tags can be overwritten as necessary in all pages, by redefining the `opengraph` block.
Right now I have set custom meta tags for mod pages (`mod.html`), mod packs (`mod_list.html`), and profiles (`view_profile.html`). See below for example images.
We can add some more page-specific tags later, but I'd like to test these first. And I think I got the most relevant.

There's one tag that is outside of the block in `layout.html`, so that it can not be overridden, which is the `og:site_name` tag. The site name should stay the same regardless of page.

A new `caption` key is added to the `config.ini`. I've set it to a string I found in `frontend/static/opensearch.xml`, it was better than anything I could come up with. And is there a better word than "caption"?
I've also sorted the keys in `config.ini` a bit, roughly by area which they configure.

## Deployment notes
Whenever this is deployed onto a new system (alpha, beta, production), a `caption` key should be set in `config.ini`.
Suggestion:
```
# Short abstract, displayed for example in OpenGraph embeds
caption=A community modding site for Kerbal Space Program
```

## Images
<details>
<summary>
As rendered by Discord. Click to expand
</summary>

![sd-embeds-discord-2](https://user-images.githubusercontent.com/28812678/128774673-354c4e56-2fde-4850-a157-38c7ddb096ab.png)

And an updated image for mods, now with mod and game version moved into description:
![image](https://user-images.githubusercontent.com/28812678/128776156-e41279c3-22d2-4a1b-b6f6-3e8b46a3e3ad.png)

And an image for game pages:
![image](https://user-images.githubusercontent.com/28812678/128782648-5f0d7498-8698-425d-9189-7249d39cf47f.png)

</details>