### PR TITLE
Escape mod name in mod pack typeahead

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from functools import wraps
 from typing import Dict, Any, Callable, Optional, Tuple, Iterable, List, Union
 
-import bcrypt
 from flask import Blueprint, url_for, current_app, request, abort
 from flask_login import login_user, current_user
 from sqlalchemy import desc, asc
@@ -61,7 +60,7 @@ def mod_info(mod: Mod) -> Dict[str, Any]:
         "author": mod.user.username,
         "default_version_id": mod.default_version.id,
         "shared_authors": list(),
-        "background": mod.background,
+        "background": mod.background_url(_cfg('protocol'), _cfg('cdn-domain')),
         "bg_offset_y": mod.bgOffsetY,
         "license": mod.license,
         "website": mod.external_link,

--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -1,4 +1,3 @@
-import os
 import re
 from typing import Union
 from itertools import groupby

--- a/frontend/coffee/edit_pack.coffee
+++ b/frontend/coffee/edit_pack.coffee
@@ -51,6 +51,10 @@ enableDisableAddModButton = ->
 
 enableDisableAddModButton()
 
+# https://stackoverflow.com/a/22706073
+escape_html = (str) ->
+    return new Option(str).innerHTML
+
 engine = new Bloodhound({
     name: 'mods',
     remote: "/api/typeahead/mod?game_id=#{window.game_id}&query=%QUERY",
@@ -62,7 +66,7 @@ engine.initialize()
         $("#mod-typeahead").typeahead({
             highlight: true,
         }, {
-            displayKey: 'name',
+            displayKey: (mod) -> escape_html(mod.name),
             source: engine.ttAdapter()
         }).on("typeahead:selected typeahead:autocompleted", (e, m) ->
             new_mod = m


### PR DESCRIPTION
## Problem
While we worked on #384, I also created a mod with a name that contains valid HTML with valid JavaScript.
I was relieved that I didn't find any place where this JavaScript is executed, it looked like we / the browser correctly escapes it everywhere (it does so inside header tags like `<h1>` for example).

Well, now I was looking at #380 and trying it out, and it turns out that the typeahead library does not escape HTML in its preview drop down:

![image](https://user-images.githubusercontent.com/28812678/129350201-a1ff165d-b760-46e2-ae17-a5029804c226.png)

You could argue this is a bug in the library, and they did actually fix it in release 0.11.0 (we're at 0.10.2):
- https://github.com/twitter/typeahead.js/issues/964
- https://github.com/twitter/typeahead.js/pull/1182

But at the same time I'd argue that our API (or at least the frontend that consumes it) should do sanitization as well. After asking in the Discord, VITAS responded that it should be done in the API, HebaruSan favors the frontend.

## Changes
Now we run the mod name through a `escape_html()` function, as suggested [here on SO](https://stackoverflow.com/a/22706073), before passing it to the typeahead library to display it.

We might also want to update the library at some point, however I spotted breaking changes while looking through the docs, and this library is also unmaintained got 6 years now anyway, so maybe we should switch to something else entirely.

&nbsp;

Also the background image link in the mod API response is fixed, after #374 this would've caused the file paths instead of web URLs to be returned.