### PR TITLE
Remove ga parameter from post-action mod URLs

### DIFF
--- a/KerbalStuff/blueprints/accounts.py
+++ b/KerbalStuff/blueprints/accounts.py
@@ -17,7 +17,7 @@ from ..email import send_confirmation, send_password_reset
 from ..objects import Mod, User
 from ..search import get_mod_score
 
-accounts = Blueprint('accounts', __name__, template_folder='../../templates/accounts')
+accounts = Blueprint('accounts', __name__)
 
 
 @accounts.route("/register", methods=['GET', 'POST'])

--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -17,7 +17,7 @@ from ..database import db
 from ..email import send_bulk_email
 from ..objects import Mod, GameVersion, Game, Publisher, User
 
-admin = Blueprint('admin', __name__, template_folder='../../templates/admin')
+admin = Blueprint('admin', __name__)
 ITEMS_PER_PAGE = 10
 
 

--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -12,7 +12,7 @@ from ..config import _cfg
 from ..database import db
 from ..objects import Featured, Mod, ModVersion, User
 
-anonymous = Blueprint('anonymous', __name__, template_folder='../../templates/anonymous')
+anonymous = Blueprint('anonymous', __name__)
 
 
 @anonymous.route("/")

--- a/KerbalStuff/blueprints/blog.py
+++ b/KerbalStuff/blueprints/blog.py
@@ -7,7 +7,7 @@ from ..common import adminrequired, with_session, json_output, TRUE_STR
 from ..database import db
 from ..objects import BlogPost
 
-blog = Blueprint('blog', __name__, template_folder='../../templates/blog')
+blog = Blueprint('blog', __name__)
 
 
 @blog.route("/blog")

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -10,7 +10,7 @@ from ..common import loginrequired, with_session, get_game_info, paginate_query
 from ..database import db
 from ..objects import Mod, ModList, ModListItem, Game
 
-lists = Blueprint('lists', __name__, template_folder='../../templates/lists')
+lists = Blueprint('lists', __name__)
 
 
 def _get_mod_list(list_id: str) -> Tuple[ModList, Game, bool]:

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -33,7 +33,7 @@ from ..objects import Mod, ModVersion, DownloadEvent, FollowEvent, ReferralEvent
 from ..search import get_mod_score
 from ..thumbnail import thumb_path_from_background_path
 
-mods = Blueprint('mods', __name__, template_folder='../../templates/mods')
+mods = Blueprint('mods', __name__)
 
 SOURCE_REPOSITORY_URL_PATTERN = re.compile(
     r'^https://git(hub|lab).com/(?P<repo_short>[^/]+/[^/]+)/?'

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -319,7 +319,7 @@ def edit_mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Respons
             mod.bgOffsetY = int(bgOffsetY)
         except:
             pass
-        return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name, ga=game))
+        return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))
 
 
 @mods.route("/create/mod")
@@ -634,7 +634,7 @@ def delete_version(mod_id: int, version_id: str) -> werkzeug.wrappers.Response:
     db.delete(version[0])
     mod.versions = [v for v in mod.versions if v.id != int(version_id)]
     db.commit()
-    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name, ga=game))
+    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))
 
 
 def create_connection_cdn_purge(address: Tuple[str, Union[str, int, None]], *args: str, **kwargs: int) -> socket:
@@ -666,7 +666,7 @@ def edit_version(mod_id: int, mod_name: str) -> werkzeug.wrappers.Response:
         abort(404)
     version = versions[0]
     version.changelog = changelog
-    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name, ga=game))
+    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))
 
 
 @mods.route('/mod/<int:mod_id>/autoupdate', methods=['POST'])
@@ -682,4 +682,4 @@ def autoupdate(mod_id: int) -> werkzeug.wrappers.Response:
     mod.score = get_mod_score(mod)
     send_autoupdate_notification(mod)
     notify_ckan(mod, 'version-update')
-    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name, ga=game))
+    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))

--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -11,7 +11,7 @@ from ..common import loginrequired, with_session, sendfile, TRUE_STR
 from ..config import _cfg
 from ..objects import User, Following
 
-profiles = Blueprint('profile', __name__, template_folder='../../templates/profiles')
+profiles = Blueprint('profile', __name__)
 
 FORUM_PROFILE_URL_PATTERN = re.compile(
     r'^(?P<prefix>https?://)?forum.kerbalspaceprogram.com/index.php\?/profile/(?P<id>[0-9]+)-(?P<name>[^/]+)')

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -381,7 +381,7 @@
                     <h3>Top Referrers</h3>
                     <ol>
                     {% for ref in referrals %}
-                    <li><a href="http://{{ ref.host }}">{{ ref.host }}</a></li>
+                    <li><a href="https://{{ ref.host }}">{{ ref.host }}</a></li>
                     {% endfor %}
                     </ol>
                     <h3>Export Raw Stats</h3>


### PR DESCRIPTION
## Problem

If you edit a mod and save your changes, a `ga=<Game+3102+'Kerbal+Space+Program'>` parameter is appended to the URL. This parameter is not needed for that URL, and these stray parameters are sometimes seen [pasted into the forum](https://forum.kerbalspaceprogram.com/index.php?/search/&q=Game%2B3102&quick=1) or CKAN:

![image](https://user-images.githubusercontent.com/1559108/130995491-198e921f-c2ab-43a5-8feb-aad3640394de.png)
![image](https://user-images.githubusercontent.com/1559108/134374297-b87d5755-2847-4d90-af46-44dbd9abeb62.png)
![image](https://user-images.githubusercontent.com/1559108/134383004-d06d0eb1-62ff-48f3-9aa9-3fbbb4e9032b.png)
![image](https://user-images.githubusercontent.com/1559108/134383045-233e9943-2ce9-4d84-b7bd-f8847e2d0c8d.png)
![image](https://user-images.githubusercontent.com/1559108/134383099-ac700020-cc9c-424d-bcf0-a10b3e10e65a.png)
![image](https://user-images.githubusercontent.com/1559108/134383132-422b6487-cc87-474f-9df7-0c0165ca225d.png)
![image](https://user-images.githubusercontent.com/1559108/134383166-ab5bad17-59e8-4bf1-aa8a-f20b6ab9e105.png)
![image](https://user-images.githubusercontent.com/1559108/134383199-3013f667-1240-4557-80ab-60568d9f4834.png)
![image](https://user-images.githubusercontent.com/1559108/134383225-c6cb227f-8830-4bd8-8f30-e25140ba5421.png)
![image](https://user-images.githubusercontent.com/1559108/134383251-8ce61eda-ea86-4b3e-92c4-dfa2f06854bd.png)


## Cause

The `ga` parameter is passed to `url_for()`, and since the game isn't a parameter to the `/mod/` route, it is appended to the end of the URL:

https://github.com/KSP-SpaceDock/SpaceDock/blob/4054e8eb0b09b51289b503256dbe3d0d01321dae/KerbalStuff/blueprints/mods.py#L322

https://github.com/KSP-SpaceDock/SpaceDock/blob/4054e8eb0b09b51289b503256dbe3d0d01321dae/KerbalStuff/blueprints/mods.py#L101-L104

The format of the value comes from `Game.__repr__()`:

https://github.com/KSP-SpaceDock/SpaceDock/blob/4054e8eb0b09b51289b503256dbe3d0d01321dae/KerbalStuff/objects.py#L194-L195

## Changes

Now this `ga` parameter is removed from:

- Saving an edit to a mod
- Deleting a mod version
- Saving an edit to a mod version
- Automatically updating the compatibility of the latest mod version

This will make the resulting URLs in those cases the same as the normal URLs without a `ga` parameter that we already use elsewhere.

### Also

- Our `Blueprints` were being created with [the `template_folder` parameter](https://flask.palletsprojects.com/en/2.0.x/blueprints/#templates) set to paths that don't exist, which would have no effect, and the main template folder would be used. Now this is removed.
- These links are switched from HTTP to HTTPS:
  ![image](https://user-images.githubusercontent.com/1559108/132030139-e58d2aa5-114b-4370-98c3-82e4e8184152.png)
