### PR TITLE
Fix mobile menu background

### DIFF
--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -1082,7 +1082,6 @@ a.gamename, a.gamename:hover {
         clear: both;
         position: static;
         float: right;
-        background-color: transparent;
         width: 100%;
     }
 


### PR DESCRIPTION
## Problem

The hamburger dropdown menu lacks a background on mobile, making it non-usable:

![image](https://user-images.githubusercontent.com/1559108/133318702-02cd7fcc-ee95-40a6-b31c-60b02f10f94f.png)

## Causes

One of the Bootstrap stylesheets has a directive to make the menu background transparent on mobile:

![image](https://user-images.githubusercontent.com/1559108/133318566-14d4aa33-d87f-457d-b20d-547d704bb909.png)

However, this is not a real part of the Bootstrap project; see 75c918d76f21505c6c9ba47650213376431739d7, it was added by @V1TA5 in an attempt to fix something about the menu on mobile (but I'm not able to find any documentation of _what_ it was trying to fix). The resulting problem was pointed out a few days later in https://github.com/KSP-SpaceDock/SpaceDock/issues/145#issuecomment-208120923, but no one seems to have connected it to that change or investigated it at the time.

## Changes

Now the transparent background directive is removed, so the menu looks right:

![image](https://user-images.githubusercontent.com/1559108/133318768-2e0ecedd-d5a5-429e-b6f6-17829b328117.png)

Fixes #391.