### PR TITLE
Send source link to CKAN

### DIFF
--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -28,6 +28,7 @@ def send_to_ckan(mod: Mod) -> None:
             'short_description': mod.short_description,
             'description': mod.description,
             'external_link': mod.external_link,
+            'source_link': mod.source_link,
             'user_url': site_base_url + url_for("profile.view_profile", username=mod.user.username),
             'mod_url': site_base_url + url_for('mods.mod', mod_name=mod.name, mod_id=mod.id),
             'site_name': site_name,


### PR DESCRIPTION
## Motivation

When adding a new mod to CKAN, the repo link can help us find useful information. Currently it's not included in the PR, so we have to click it from the mod's SpaceDock page.

See KSP-CKAN/NetKAN#8780 for a typical example.

## Changes

Now the payload sent to CKAN to make those PRs includes a new `source_link` value containing the source code URL. KSP-CKAN/NetKAN-Infra#227 will add this to the PR body near the homepage.