### PR TITLE
Handle null text in first_paragraphs()

### DIFF
--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -42,8 +42,8 @@ cleaner = bleach.Cleaner(tags=bleach_allowlist.markdown_tags + ['iframe'],
                          filters=[bleach.linkifier.LinkifyFilter])
 
 
-def first_paragraphs(text: str) -> str:
-    return '\n\n'.join(PARAGRAPH_PATTERN.split(text)[0:3])
+def first_paragraphs(text: Optional[str]) -> str:
+    return '\n\n'.join(PARAGRAPH_PATTERN.split(text)[0:3]) if text else ''
 
 
 def many_paragraphs(text: str) -> bool:


### PR DESCRIPTION
## Problem
This link to a modpack on beta throws a 500: https://beta.spacedock.info/pack/1/some%20stuff

```
   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/../templates/layout.html", line 10, in top-level template code
     {%- block opengraph %}
   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/../templates/mod_list.html", line 9, in block "opengraph"
     <meta property="og:description" content="{{ mod_list.description | first_paragraphs | bleach }}">
   File "/var/www/virtual/spacedock.info/htdocs/SpaceDock/KerbalStuff/common.py", line 46, in first_paragraphs
     return '\n\n'.join(PARAGRAPH_PATTERN.split(text)[0:3])
 TypeError: expected string or bytes-like object
```

#385 made use of our `first_paragraphs()` function to get a short-ish text that can be put into tne `og:description` tag for mod packs.
However, the description column is nullable, and while it appears that new mod packs will always be initialized with an empty string, there can be old ones with NULL/None.

`Pattern.split` can only take strings as argument, and thus throws for None.

It would have been nice if mypy caught that, because `first_paragraphs(test: str)` explicitly asks for an argument that is not `None`, however as we already found out, it can't check Jinja templates. Additionally it seems to assume that `ModList.description` cannot be `None`.

## Changes
`first_paragraphs` now accepts `Optional[str]` and returns an empty string if `text` is `None`.

This solution should be more future-proof than e.g. checking for `None` within the template before calling `first_paragraph`, as it catches all occurrences.