### PR TITLE
HTML emails

### DIFF
--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -147,4 +147,5 @@ def send_bulk_email(users: Iterable[User], subject: str, body: str) -> None:
     targets = list()
     for u in users:
         targets.append(u)
-    send_mail.delay(_cfg('support-mail'), targets, subject, body)
+    send_mail.delay(_cfg('support-mail'), targets, subject, body,
+                    html_message=render_template("email-everyone.html", body=body))

--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -5,6 +5,8 @@ from flask import url_for
 from jinja2 import Template
 from werkzeug.utils import secure_filename
 
+from flask import render_template
+
 from .objects import User, Mod, ModVersion, Following
 from .celery import send_mail
 from .config import _cfg, _cfgd
@@ -102,18 +104,23 @@ def send_update_notification(mod: Mod, version: ModVersion, user: User) -> None:
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
             'changelog': changelog
         }))
+    html_message = render_template(
+        "email-mod-updated.html",
+        mod=mod,
+        user=user,
+        site_name=_cfg('site-name'),
+        domain=_cfg('domain'),
+        latest=version,
+        url=f'/mod/{mod.id}/{secure_filename(mod.name)[:64]}',
+        changelog=version.changelog)
     subject = f'{user.username} has just updated {mod.name}!'
-    send_mail.delay(_cfg('support-mail'), targets, subject, message)
+    send_mail.delay(_cfg('support-mail'), targets, subject, message, html_message=html_message)
 
 
 def send_autoupdate_notification(mod: Mod) -> None:
     followers = (fol.user.email for fol
                  in Following.query.filter(Following.mod_id == mod.id,
                                            Following.send_autoupdate == True))
-    changelog = mod.default_version.changelog
-    if changelog:
-        changelog = '\n'.join(['    ' + line for line in changelog.split('\n')])
-
     targets = list()
     for follower in followers:
         targets.append(follower)
@@ -124,11 +131,16 @@ def send_autoupdate_notification(mod: Mod) -> None:
             'mod': mod,
             'domain': _cfg("domain"),
             'latest': mod.default_version,
-            'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
-            'changelog': changelog
+            'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64]
         }))
+    html_message = render_template(
+        "email-mod-autoupdated.html",
+        mod=mod,
+        domain=_cfg('domain'),
+        latest=mod.default_version,
+        url=f'/mod/{mod.id}/{secure_filename(mod.name)[:64]}')
     subject = f'{mod.name} is compatible with {mod.game.name} {mod.default_version.gameversion.friendly_version}!'
-    send_mail.delay(_cfg('support-mail'), targets, subject, message)
+    send_mail.delay(_cfg('support-mail'), targets, subject, message, html_message=html_message)
 
 
 def send_bulk_email(users: Iterable[User], subject: str, body: str) -> None:

--- a/frontend/coffee/mods.coffee
+++ b/frontend/coffee/mods.coffee
@@ -1,3 +1,6 @@
+editor = new Editor()
+editor.render()
+
 Dropzone = require('dropzone').Dropzone
 
 Dropzone.options.uploader =

--- a/frontend/coffee/update.coffee
+++ b/frontend/coffee/update.coffee
@@ -1,3 +1,6 @@
+editor = new Editor()
+editor.render()
+
 Dropzone = require('dropzone').Dropzone
 
 error = (name) ->

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -65,7 +65,6 @@
                 <a href="{{ url_for("mods.mod", mod_id=mod.id, mod_name=mod.name) }}" class="btn btn-default btn-block">Cancel</a>
             </div>
         </div>
-        <link rel="stylesheet" href="/static/editor.css">
     </div>
 
     <div class="info-list">

--- a/templates/email-everyone.html
+++ b/templates/email-everyone.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+    {{ body | markdown | bleach }}
+</body>
+</html>

--- a/templates/email-mod-autoupdated.html
+++ b/templates/email-mod-autoupdated.html
@@ -1,0 +1,9 @@
+<html>
+<head></head>
+<body>
+    <p>Hi there! Thought you would like to know that {{ mod.user.username }} told us that version {{ latest.friendly_version }} of {{ mod.name }} works great with {{ mod.game.name }} {{ latest.gameversion.friendly_version }}.</p>
+    <p>If you are already up-to-date, you don't need to do anything. Otherwise, you can grab the latest version here:</p>
+    <a href="https://{{ domain }}{{ url }}">{{mod.name}} {{latest.friendly_version}}</a>
+    </p>If you'd prefer us not to email you about this mod, you can hit "Unfollow" on this mod's page and you won't get them any more.</p>
+</body>
+</html>

--- a/templates/email-mod-updated.html
+++ b/templates/email-mod-updated.html
@@ -1,0 +1,12 @@
+<html>
+<head></head>
+<body>
+    <p>Hi there! {{ user.username }} has just published version {{ latest.friendly_version }} of {{ mod.name }} on {{ site_name }}!</p>
+    <p>You can grab the new version here:</p>
+    <a href="https://{{ domain }}{{ url }}">{{mod.name}} {{latest.friendly_version}}</a>
+    <p>This version is compatible with {{ mod.game.name }} {{ latest.gameversion.friendly_version }}.</p>
+    <p>If you'd prefer us not to email you about this mod, you can hit "Unfollow" on this mod's page and you won't get them any more.</p>
+    <p>Here are the changes:</p>
+    {{ changelog | markdown | bleach }}
+</body>
+</html>

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -17,6 +17,7 @@
 {% endblock %}
 {% block styles %}
     <link rel="stylesheet" type="text/css" href="/static/mod.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/editor.css"/>
 {% endblock %}
 {% block body %}
 {% if background %}
@@ -552,4 +553,6 @@
     </script>
     <script src="/static/stats.js"></script>
     <script src="/static/mods.js"></script>
+    <script src="/static/editor.js"></script>
+    <script src="/static/marked.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Motivation

Mod changelogs are in Markdown format and rendered into HTML for the mod page. But when a mod is updated, the email notification to followers is in plain text format only, and the changelog appears in plain text Markdown. Some authors may wish their Markdown to be rendered in a nicer format.

https://docs.python.org/3/library/email-examples.html

Similarly, the Email tab in the admin pages allows a mass email to be composed to all users or all authors, and it has the Markdown rich text editing controls enabled, but the email is sent in plain text.

## Changes

Now update emails are in MIME multipart format, with a `plain` part containing the old plain text message and an `html` part generated by a simple Jinja2 template that puts the changelog through our familiar ` | markdown | bleach` pipeline. The changelog is at the end of the email to reduce difficulties in telling when the different parts of the text begin and end.

Autoupdate emails are also multipart now, though they don't contain the changelog. To reflect this, the backend code that renders them now no longer passes the changelog to the template.

The Email tab in the admin pages now also renders its body into HTML format.

Fixes #399.

### Side fixes

- The changelog editing fields (in `update.html` and `mod.html`) are now proper rich-text editing boxes with ![image](https://user-images.githubusercontent.com/1559108/138564866-5315c48a-497c-4ec0-9bfc-4abde4d39f5b.png)