### PR TITLE
Batch retrieval of download counts with /api/download_counts

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -425,6 +425,25 @@ def mod_version(mod_id: int, version: str) -> Union[Dict[str, Any], Tuple[Dict[s
     return info
 
 
+@api.route("/api/download_counts", methods=['POST'])
+@json_output
+def download_counts() -> Tuple[Dict[str, Any], int]:
+    return {
+        'download_counts': [
+            {
+                'id': id_count[0],
+                'downloads': id_count[1]
+            }
+            for id_count
+            in Mod.query.filter(Mod.published,
+                                Mod.id.in_(request.form.getlist('mod_id')))\
+                        .order_by(Mod.id)\
+                        .with_entities(Mod.id, Mod.download_count)\
+                        .all()
+         ]
+    }, 200
+
+
 @api.route("/api/user/<username>")
 @json_output
 def user_info_api(username: str) -> Union[Dict[str, Any], Tuple[Dict[str, Any], int]]:

--- a/api.md
+++ b/api.md
@@ -488,7 +488,7 @@ This will list the available games and their ids.
       }
     ]
 
-**GET /api/<gameid>/versions**
+**GET /api/&lt;gameid&gt;/versions**
 
 This will list the available versions of a game.
 For KSP the response is the same as `/api/kspversions`
@@ -510,3 +510,33 @@ For KSP the response is the same as `/api/kspversions`
       },
       ...continued...
 	]
+
+
+**POST /api/download_counts**
+
+This will return download counts for the specified mods.
+
+*Curl*
+
+    curl -d 'mod_id=1&mod_id=2&mod_id=3' https://spacedock.info/api/download_counts
+
+*Example Response*:
+
+```json
+{
+    "download_counts": [
+        {
+            "id": 1,
+            "downloads": 53
+        },
+        {
+            "id": 2,
+            "downloads": 2
+        },
+        {
+            "id": 3,
+            "downloads": 1
+        }
+    ]
+}
+```


### PR DESCRIPTION
## Motivation

CKAN queries SpaceDock for download counts every day. Currently this happens via the `/api/mod/<mod_id>` route, which means that for each SpaceDock mod that CKAN knows about, we do:

- One HTTPS request with a lot of extra output that isn't needed
- One SQL request with a lot of data sent that isn't needed

This isn't a big problem today, but it is mildly wasteful of resources that could otherwise be available for users.

## Changes

Now a new `/api/download_counts` route is available that takes multiple `mod_id` form parameters as input, then runs one SQL query that returns the download counts for all the mods without extraneous info and returns them as one JSON object.

To test locally:

```
curl -d 'mod_id=1&mod_id=2&mod_id=3' http://localhost:5080/api/download_counts
```

Once this is live, KSP-CKAN/NetKAN-Infra#228 will allow download counts to be queried with just one HTTPS and SQL request per day.