### PR TITLE
Deferred loading and pre-rendering for mod changelogs

### DIFF
--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -17,13 +17,14 @@ from markupsafe import Markup
 from sqlalchemy import desc
 from werkzeug.exceptions import HTTPException
 from sqlalchemy.orm import Query
+from markdown import markdown
 
 from .config import _cfg
 from .custom_json import CustomJSONEncoder
 from .database import db, Base
 from .objects import Game, Mod, Featured, ModVersion, ReferralEvent, DownloadEvent, FollowEvent
 from .search import search_mods
-from .kerbdown import EmbedInlineProcessor
+from .kerbdown import EmbedInlineProcessor, KerbDown
 
 TRUE_STR = ('true', 'yes', 'on')
 PARAGRAPH_PATTERN = re.compile('\n\n|\r\n\r\n')
@@ -52,6 +53,11 @@ def many_paragraphs(text: str) -> bool:
 
 def sanitize_text(text: str) -> Markup:
     return Markup(cleaner.clean(text))
+
+
+def render_markdown(md: Optional[str]) -> Optional[Markup]:
+    # The Markdown class is not thread-safe, sadly
+    return None if not md else sanitize_text(markdown(md, extensions=[KerbDown(), 'fenced_code']))
 
 
 def dumb_object(model):  # type: ignore

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -366,6 +366,7 @@ class ModVersion(Base):  # type: ignore
     created = Column(DateTime, default=datetime.now)
     download_path = Column(String(512))
     changelog = Column(Unicode(10000))
+    changelog_html = Column(Unicode(20000))
     sort_index = Column(Integer, default=0)
     download_count = Column(Integer, default=0)
     download_size = Column(BigInteger)

--- a/alembic/versions/2021_10_27_20_24_54-1b3f98f3620d.py
+++ b/alembic/versions/2021_10_27_20_24_54-1b3f98f3620d.py
@@ -1,0 +1,22 @@
+"""Add ModVersion.changelog_html
+
+Revision ID: 1b3f98f3620d
+Revises: 3fb8a6e2e0a5
+Create Date: 2021-10-28 01:24:57.435381
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1b3f98f3620d'
+down_revision = '3fb8a6e2e0a5'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.add_column('modversion', sa.Column('changelog_html', sa.Unicode(length=20000), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('modversion', 'changelog_html')

--- a/frontend/coffee/mods.coffee
+++ b/frontend/coffee/mods.coffee
@@ -124,6 +124,46 @@ if reject
         xhr.send()
     , false)
 
+loadChangelog = () ->
+    xhr = new XMLHttpRequest()
+    xhr.open('GET', '/mod_changelog/' + mod_id)
+    xhr.onload = () ->
+        $("#changelog").html(xhr.responseText)
+
+        edit.addEventListener('click', (e) ->
+            e.preventDefault()
+            p = e.target.parentElement.parentElement
+            v = e.target.parentElement.dataset.version
+            c = p.querySelector('.raw-changelog').innerHTML
+            m = document.getElementById('version-edit-modal')
+            m.querySelector('.version-id').value = v
+            m.querySelector('.changelog-text').innerHTML = c
+            $(m).modal()
+        , false) for edit in document.querySelectorAll('.edit-version')
+
+        edit.addEventListener('click', (e) ->
+            e.preventDefault()
+            m = document.getElementById('confirm-delete-version')
+            m.querySelector('form').action = "/mod/#{mod_id}/version/#{e.target.dataset.version}/delete"
+            $(m).modal()
+        , false) for edit in document.querySelectorAll('.delete-version')
+
+        b.addEventListener('click', (e) ->
+            e.preventDefault()
+            target = e.target
+            while target.tagName != 'P'
+                target = target.parentElement
+            version = target.dataset.version
+            mod = window.mod_id
+            xhr = new XMLHttpRequest()
+            xhr.open('POST', "/api/mod/#{mod}/set-default/#{version}")
+            xhr.setRequestHeader('Accept', 'application/json')
+            xhr.onload = () ->
+                window.location = window.location
+            xhr.send()
+        , false) for b in document.querySelectorAll('.set-default-version')
+    xhr.send()
+
 switchTab = () ->
     switch location.hash
         when '#info', ''
@@ -132,6 +172,8 @@ switchTab = () ->
         when '#changelog'
             $(".tab-pane.active").removeClass('active')
             $("#changelog").addClass('active')
+            if $("#changelog").children('.timeline-entry').length == 0
+                loadChangelog()
         when "#stats"
             $(".tab-pane.active").removeClass('active')
             $("#stats").addClass('active')

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -328,48 +328,7 @@
             {{ mod.description | markdown | bleach }}
         </div>
         <div class="tab-pane  space-left-right" id="changelog">
-            <div class="timeline-centered">
-                <a href="{{ url_for("mods.mod_rss", mod_name=mod.name, mod_id=mod.id) }}" class="pull-right"><img src="/static/rss.png" height=38 /></a>
-            {% for v in mod.versions %}
-                <div class="timeline-entry">
-                    <div class="timeline-entry-inner">
-                        <div class="timeline-icon">
-                            <span class="glyphicon glyphicon-asterisk"></span>
-                        </div>
-                        <div class="timeline-label">
-                            <h2>Version {{ v.friendly_version }} <small>for {{ ga.name }} {{ v.gameversion.friendly_version }}</small></h2>
-                            <p><small class="text text-muted">Released on {{ v.created.strftime("%Y-%m-%d") }}</small></p>
-                            {% if not v.changelog %}
-                            <p><em>No changelog provided</em></p>
-                            {% else %}
-                            {{ v.changelog | markdown | bleach }}
-                            {% endif %}
-                            <p data-version="{{ v.id }}" data-friendly_version="{{ v.friendly_version }}">
-                                <a class="btn btn-primary piwik_download" href="{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name, version=v.friendly_version) }}">
-                                    <span class="glyphicon glyphicon-save"></span> Download {% if v.id in size_versions and size_versions[v.id] is not none %} ({{ size_versions[v.id] }}) {% endif %}
-                                </a>
-                                {% if editable %}
-                                <button class="btn btn-danger edit-version" data-version="{{ v.id }}">
-                                    <span class="glyphicon glyphicon-pencil"></span> Edit
-                                </button>
-                                {% if len(mod.versions) != 1 and v.id != latest.id %}
-                                <button class="btn btn-danger delete-version" data-version="{{ v.id }}">
-                                    <span class="glyphicon glyphicon-trash"></span> Delete
-                                </button>
-                                {% endif %}
-                                <span class="hidden raw-changelog">{% if v.changelog %}{{ v.changelog }}{% endif %}</span>
-                                {% if v.id != latest.id %}
-                                <button class="set-default-version btn btn-danger">
-                                    <span class="glyphicon glyphicon-ok"></span> Set as default
-                                </button>
-                                {% endif %}
-                                {% endif %}
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            {% endfor %}
-            </div>
+            <em>Loading changelog...</em>
         </div>
         <div class="tab-pane  space-left-right" id="stats">
             <h2>Stats for {{ mod.name }}</h2>

--- a/templates/mod_changelog.html
+++ b/templates/mod_changelog.html
@@ -1,0 +1,42 @@
+<div class="timeline-centered">
+    <a href="{{ url_for("mods.mod_rss", mod_name=mod.name, mod_id=mod.id) }}" class="pull-right"><img src="/static/rss.png" height=38 /></a>
+    {% for v in mod.versions %}
+        <div class="timeline-entry">
+            <div class="timeline-entry-inner">
+                <div class="timeline-icon">
+                    <span class="glyphicon glyphicon-asterisk"></span>
+                </div>
+                <div class="timeline-label">
+                    <h2>Version {{ v.friendly_version }} <small>for {{ ga.name }} {{ v.gameversion.friendly_version }}</small></h2>
+                    <p><small class="text text-muted">Released on {{ v.created.strftime("%Y-%m-%d") }}</small></p>
+                    {% if not v.changelog %}
+                    <p><em>No changelog provided</em></p>
+                    {% else %}
+                    {{ v.changelog_html | safe }}
+                    {% endif %}
+                    <p data-version="{{ v.id }}" data-friendly_version="{{ v.friendly_version }}">
+                        <a class="btn btn-primary piwik_download" href="{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name, version=v.friendly_version) }}">
+                            <span class="glyphicon glyphicon-save"></span> Download {% if v.id in size_versions and size_versions[v.id] is not none %} ({{ size_versions[v.id] }}) {% endif %}
+                        </a>
+                        {% if editable %}
+                        <button class="btn btn-danger edit-version" data-version="{{ v.id }}">
+                            <span class="glyphicon glyphicon-pencil"></span> Edit
+                        </button>
+                        {% if len(mod.versions) != 1 and v.id != latest.id %}
+                        <button class="btn btn-danger delete-version" data-version="{{ v.id }}">
+                            <span class="glyphicon glyphicon-trash"></span> Delete
+                        </button>
+                        {% endif %}
+                        <span class="hidden raw-changelog">{% if v.changelog %}{{ v.changelog }}{% endif %}</span>
+                        {% if v.id != latest.id %}
+                        <button class="set-default-version btn btn-danger">
+                            <span class="glyphicon glyphicon-ok"></span> Set as default
+                        </button>
+                        {% endif %}
+                        {% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>


### PR DESCRIPTION
## Motivation

See #402, mods with a lot of changelogs load more slowly than other mods, even if the user never looks at them, because we render them all from Markdown to HTML during page load.

## Changes

- The mod changelog is split into a separate `/mod_changelog/<mod_id>` route and template
- The mod page loads without the changelog initially, so all mods should load fast
- If the user clicks the Changelog button (probably rare), we load the full list of changelogs on demand and insert it into the page
- A new `ModVersion.changelog_html` column now holds the rendered content of a version's changelog, stored at creation and edit, and also populated on demand at load if needed (to avoid needing to run a migration that could take a long time)

Fixes #402.