### PR TITLE
Escape user-edited fields in OpenGraph meta tags

### DIFF
--- a/templates/mod.html
+++ b/templates/mod.html
@@ -3,15 +3,15 @@
 <title>{{ mod.name }} on {{ site_name }}</title>
 {% endblock %}
 {% block opengraph %}
-    <meta property="og:title" content="{{ mod.name }} by {{ mod.user.username }}
+    <meta property="og:title" content="{{ mod.name | escape }} by {{ mod.user.username | escape }}
         {%- for author in mod.shared_authors if author.accepted -%}
             {% if loop.last %} and {% else %}, {% endif -%}
-            {{ author.user.username }}
+            {{ author.user.username | escape }}
         {%- endfor -%}
     ">
     <meta property="og:type" content="website">
-    <meta property="og:description" content="{{ latest.friendly_version }} for {{ ga.abbrev }} {{ latest.gameversion.friendly_version }} | Download: {{ size_versions[latest.id] }} | Released on: {{ latest.created.strftime("%Y-%m-%d") }}
-{{ mod.short_description }}">
+    <meta property="og:description" content="{% if latest %}{{ latest.friendly_version | escape }} for {{ ga.abbrev }} {{ latest.gameversion.friendly_version }} | Download: {{ size_versions[latest.id] }} | Released on: {{ latest.created.strftime("%Y-%m-%d") }}
+{% endif %}{{ mod.short_description | escape }}">
     {% set thumbnail = mod.background_thumb() or "/static/background-s.png" -%}
     <meta property="og:image" content="{{ thumbnail }}">
 {% endblock %}

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -3,10 +3,10 @@
 <title>{{ mod_list.name }} on {{ site_name }}</title>
 {% endblock %}
 {% block opengraph %}
-    <meta property="og:title" content="{{ mod_list.name }} by {{ mod_list.user.username }}">
+    <meta property="og:title" content="{{ mod_list.name | escape }} by {{ mod_list.user.username | escape }}">
     <meta property="og:type" content="website">
     {# don't render the Markdown, keep it plain text -#}
-    <meta property="og:description" content="{{ mod_list.description | first_paragraphs | bleach }}">
+    <meta property="og:description" content="{{ mod_list.description | first_paragraphs | escape }}">
     {% set thumbnail = mod_list.background or "/static/background-s.png" -%}
     <meta property="og:image" content="{{ thumbnail }}">
 {% endblock %}

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -6,11 +6,15 @@
 <title>{{ profile.username }} on {{ site_name }}</title>
 {% endblock %}
 {% block opengraph %}
-    <meta property="og:title" content="{{ profile.username }} on {{ site_name }}">
+    <meta property="og:title" content="{{ profile.username | escape }} on {{ site_name }}">
     <meta property="og:type" content="profile">
-    <meta property="og:profile:username" content="{{ profile.username }}">
-    <meta property="og:description" content="See all mods made by {{ profile.username }}">
+    <meta property="og:profile:username" content="{{ profile.username | escape }}">
+    <meta property="og:description" content="See all mods made by {{ profile.username | escape }}">
+    {% if background -%}
+    <meta property="og:image" content="{{ background }}">
+    {%- else -%}
     <meta property="og:image" content="/static/og.png">
+    {%- endif %}
 {% endblock %}
 {% block body %}
 {% if background %}


### PR DESCRIPTION
## Problems

- https://spacedock.info/pack/397/Cuinq
  ![image](https://user-images.githubusercontent.com/1559108/138083448-8b39c3a4-42e4-4444-acaa-13c1bab83997.png)
- https://spacedock.info/mod/1967 still crashes

## Causes

- We need to handle HTML attribute values specially:
  - https://bleach.readthedocs.io/en/latest/clean.html
    > If you need to use the output of bleach.clean() in an HTML attribute, you need to pass it through your template library’s escape function. For example, Jinja2’s escape or django.utils.html.escape or something like that.
  - https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.escape
- Apparently `ChainedUndefined` (see #378) makes properties safe but not methods, and #385 added `latest.created.strftime()`

## Changes

- Now the Jinja2 `escape` filter is applied to each instance of user-edited text in the `og:` meta tags, which will prevent them from terminating the attributes. `bleach` was mangling the text in a way that prevented `escape` from working, so I replaced `bleach` instead of combining them.
- Now if `latest` is `None`, we skip the whole first line of the mod description and just return `Mod.short_description` by itself
- Now if the user has a background set on his or her profile, it will be returned as the `og:image` rather than `/static/og.png`

Fixes #407.