### PR TITLE
Fix downloads performance

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -14,7 +14,6 @@ import werkzeug.wrappers
 from flask import Flask, render_template, g, url_for, Response, request
 from flask_login import LoginManager, current_user
 from flaskext.markdown import Markdown
-from sqlalchemy import desc
 from werkzeug.exceptions import HTTPException, InternalServerError, NotFound
 from flask.typing import ResponseReturnValue
 from jinja2 import ChainableUndefined
@@ -331,10 +330,10 @@ def inject() -> Dict[str, Any]:
 
 
 def get_all_announcement_posts() -> List[BlogPost]:
-    return BlogPost.query.filter(BlogPost.announcement).order_by(desc(BlogPost.created)).all()
+    return BlogPost.query.filter(BlogPost.announcement).order_by(BlogPost.created.desc()).all()
 
 
 def get_non_member_announcement_posts() -> List[BlogPost]:
     return BlogPost.query.filter(
         BlogPost.announcement, BlogPost.members_only != True
-    ).order_by(desc(BlogPost.created)).all()
+    ).order_by(BlogPost.created.desc()).all()

--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -7,7 +7,7 @@ from subprocess import run, PIPE
 
 from flask import Blueprint, render_template, redirect, request, abort, url_for
 from flask_login import login_user, current_user
-from sqlalchemy import desc, or_, func
+from sqlalchemy import or_, func
 from sqlalchemy.orm import Query
 import werkzeug.wrappers
 
@@ -121,7 +121,7 @@ def users(page: int) -> Union[str, werkzeug.wrappers.Response]:
     users = search_users(query.lower()) if query else User.query
     if not show_non_public:
         users = users.filter(User.public)
-    users = users.order_by(desc(User.created))
+    users = users.order_by(User.created.desc())
     user_count = users.count()
     # We can limit here because SqlAlchemy executes queries lazily.
     users = users.offset((page - 1) * ITEMS_PER_PAGE).limit(ITEMS_PER_PAGE)
@@ -151,7 +151,7 @@ def publishers(page: int, error: Optional[str] = None) -> Union[str, werkzeug.wr
     publishers = search_publishers(query.lower()) if query else Publisher.query
     if not show_none_active:
         publishers = publishers.join(Publisher.games).filter(Game.active).distinct(Publisher.id)
-    publishers = publishers.order_by(desc(Publisher.id))
+    publishers = publishers.order_by(Publisher.id.desc())
     publisher_count = publishers.count()
     publishers = publishers.offset((page - 1) * ITEMS_PER_PAGE).limit(ITEMS_PER_PAGE)
 
@@ -175,7 +175,7 @@ def games(page: int, error: Optional[str] = None) -> Union[str, werkzeug.wrapper
     games = search_games(query.lower()) if query else Game.query
     if not show_inactive:
         games = games.filter(Game.active)
-    games = games.order_by(desc(Game.id))
+    games = games.order_by(Game.id.desc())
     game_count = games.count()
     games = games.offset((page - 1) * ITEMS_PER_PAGE).limit(ITEMS_PER_PAGE)
 
@@ -183,7 +183,7 @@ def games(page: int, error: Optional[str] = None) -> Union[str, werkzeug.wrapper
     if page > total_pages:
         return redirect(url_for('admin.games', page=total_pages, **request.args))
 
-    publishers = Publisher.query.order_by(desc(Publisher.id))
+    publishers = Publisher.query.order_by(Publisher.id.desc())
 
     return render_template('admin-games.html',
                            games=games, publishers=publishers, game_count=game_count,
@@ -202,7 +202,7 @@ def game_versions(page: int, error: Optional[str] = None) -> Union[str, werkzeug
     game_versions = search_game_versions(query.lower()) if query else GameVersion.query
     if not show_inactive:
         game_versions = game_versions.join(GameVersion.game).filter(Game.active)
-    game_versions = game_versions.order_by(desc(GameVersion.id))
+    game_versions = game_versions.order_by(GameVersion.id.desc())
     game_version_count = game_versions.count()
     game_versions = game_versions.offset((page - 1) * ITEMS_PER_PAGE).limit(ITEMS_PER_PAGE)
 
@@ -210,7 +210,7 @@ def game_versions(page: int, error: Optional[str] = None) -> Union[str, werkzeug
     if page > total_pages:
         return redirect(url_for('admin.game_versions', page=total_pages, **request.args))
 
-    games = Game.query.order_by(desc(Game.id))
+    games = Game.query.order_by(Game.id.desc())
 
     return render_template('admin-game-versions.html',
                            game_versions=game_versions, games=games,

--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -3,7 +3,6 @@ import os.path
 import werkzeug.wrappers
 from flask import Blueprint, render_template, abort, request, Response, make_response, send_file
 from flask_login import current_user
-from sqlalchemy import desc
 from datetime import timezone
 
 from ..common import dumb_object, paginate_query, get_paginated_mods, get_game_info, get_games, \
@@ -61,7 +60,7 @@ def browse() -> str:
 
 @anonymous.route("/browse/new")
 def browse_new() -> str:
-    mods = Mod.query.filter(Mod.published).order_by(desc(Mod.created))
+    mods = Mod.query.filter(Mod.published).order_by(Mod.created.desc())
     mods, page, total_pages = paginate_query(mods)
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
                            url="/browse/new", name="Newest Mods", rss="/browse/new.rss")
@@ -80,7 +79,7 @@ def browse_new_rss() -> Response:
 
 @anonymous.route("/browse/updated")
 def browse_updated() -> str:
-    mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated))
+    mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(Mod.updated.desc())
     mods, page, total_pages = paginate_query(mods)
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
                            url="/browse/updated", name="Recently Updated Mods", rss="/browse/updated.rss")
@@ -107,7 +106,7 @@ def browse_top() -> str:
 
 @anonymous.route("/browse/featured")
 def browse_featured() -> str:
-    mods = Featured.query.order_by(desc(Featured.created))
+    mods = Featured.query.order_by(Featured.created.desc())
     mods, page, total_pages = paginate_query(mods)
     mods = [f.mod for f in mods]
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
@@ -150,7 +149,7 @@ def singlegame_browse(gameshort: str) -> str:
 @anonymous.route("/<gameshort>/browse/new")
 def singlegame_browse_new(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id).order_by(desc(Mod.created))
+    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id).order_by(Mod.created.desc())
     mods, page, total_pages = paginate_query(mods)
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
                            url="/browse/new", name="Newest Mods", rss="/browse/new.rss")
@@ -172,7 +171,7 @@ def singlegame_browse_new_rss(gameshort: str) -> Response:
 @anonymous.route("/<gameshort>/browse/updated")
 def singlegame_browse_updated(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(desc(Mod.updated))
+    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(Mod.updated.desc())
     mods, page, total_pages = paginate_query(mods)
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
                            url="/browse/updated", name="Recently Updated Mods", rss="/browse/updated.rss")
@@ -204,7 +203,7 @@ def singlegame_browse_top(gameshort: str) -> str:
 def singlegame_browse_featured(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
     mods = Featured.query.outerjoin(Mod).filter(
-        Mod.game_id == ga.id).order_by(desc(Featured.created))
+        Mod.game_id == ga.id).order_by(Featured.created.desc())
     mods, page, total_pages = paginate_query(mods)
     mods = [f.mod for f in mods]
     return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -254,7 +254,7 @@ def gameversions_list(gameid: str) -> Union[List[Dict[str, Any]], Tuple[List[Dic
 
     for v in GameVersion.query \
             .filter(GameVersion.game_id == gameid) \
-            .order_by(desc(GameVersion.id)):
+            .order_by(GameVersion.id.desc()):
         results.append(game_version_info(v))
 
     return results
@@ -264,7 +264,7 @@ def gameversions_list(gameid: str) -> Union[List[Dict[str, Any]], Tuple[List[Dic
 @json_output
 def games_list() -> List[Dict[str, Any]]:
     results = list()
-    for v in Game.query.filter(Game.active == True).order_by(desc(Game.name)):
+    for v in Game.query.filter(Game.active == True).order_by(Game.name.desc()):
         results.append(game_info(v))
     return results
 
@@ -273,7 +273,7 @@ def games_list() -> List[Dict[str, Any]]:
 @json_output
 def publishers_list() -> List[Dict[str, Any]]:
     results = list()
-    for v in Publisher.query.order_by(desc(Publisher.id)):
+    for v in Publisher.query.order_by(Publisher.id.desc()):
         results.append(publisher_info(v))
     return results
 
@@ -380,7 +380,7 @@ def browse_new() -> Iterable[Dict[str, Any]]:
     game_id = request.args.get('game_id')
     game_version = request.args.get('game_version')
     game_version_id = request.args.get('game_version_id')
-    mods = Mod.query.filter(Mod.published).order_by(desc(Mod.created))
+    mods = Mod.query.filter(Mod.published).order_by(Mod.created.desc())
     mods = game_filters(mods, game_id, game_version_id, game_version)
     mods, page, total_pages = paginate_query(mods)
     return serialize_mod_list(mods)
@@ -396,7 +396,7 @@ def browse_top() -> Iterable[Dict[str, Any]]:
 @api.route("/api/browse/featured")
 @json_output
 def browse_featured() -> Iterable[Dict[str, Any]]:
-    mods = Featured.query.order_by(desc(Featured.created))
+    mods = Featured.query.order_by(Featured.created.desc())
     mods, page, total_pages = paginate_query(mods)
     return serialize_mod_list((f.mod for f in mods))
 

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -3,7 +3,7 @@ from typing import Tuple, List, Union, Optional
 
 from flask import Blueprint, render_template, url_for, abort, redirect, request
 from flask_login import current_user
-from sqlalchemy import desc, or_
+from sqlalchemy import or_
 import werkzeug.wrappers
 
 from ..common import loginrequired, with_session, get_game_info, paginate_query
@@ -33,7 +33,7 @@ def packs(gameshort: Optional[str]) -> str:
     game = None if not gameshort else get_game_info(short=gameshort)
     query = ModList.query \
         .filter(ModList.mods.any()) \
-        .order_by(desc(ModList.created))
+        .order_by(ModList.created.desc())
     if game:
         query = query.filter(ModList.game_id == game.id)
     packs, page, total_pages = paginate_query(query, 9)
@@ -42,8 +42,8 @@ def packs(gameshort: Optional[str]) -> str:
 
 @lists.route("/create/pack")
 def create_list() -> str:
-    games = Game.query.filter(Game.active == True).order_by(desc(Game.id)).all()
-    ga = Game.query.order_by(desc(Game.id)).first()
+    games = Game.query.filter(Game.active == True).order_by(Game.id.desc()).all()
+    ga = Game.query.order_by(Game.id.desc()).first()
     return render_template("create_list.html", games=games, ga=ga)
 
 

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -14,7 +14,6 @@ from bleach_allowlist import bleach_allowlist
 from flask import jsonify, redirect, request, Response, abort, session, send_file, make_response, current_app
 from flask_login import current_user
 from markupsafe import Markup
-from sqlalchemy import desc
 from werkzeug.exceptions import HTTPException
 from sqlalchemy.orm import Query
 from markdown import markdown
@@ -157,21 +156,21 @@ def get_paginated_mods(ga: Optional[Game] = None, query: str = '', page_size: in
 
 
 def get_featured_mods(game_id: Optional[int], limit: int) -> List[Mod]:
-    mods = Featured.query.outerjoin(Mod).filter(Mod.published).order_by(desc(Featured.created))
+    mods = Featured.query.outerjoin(Mod).filter(Mod.published).order_by(Featured.created.desc())
     if game_id:
         mods = mods.filter(Mod.game_id == game_id)
     return mods.limit(limit).all()
 
 
 def get_top_mods(game_id: Optional[int], limit: int) -> List[Mod]:
-    mods = Mod.query.filter(Mod.published).order_by(desc(Mod.score))
+    mods = Mod.query.filter(Mod.published).order_by(Mod.score.desc())
     if game_id:
         mods = mods.filter(Mod.game_id == game_id)
     return mods.limit(limit).all()
 
 
 def get_new_mods(game_id: Optional[int], limit: int) -> List[Mod]:
-    mods = Mod.query.filter(Mod.published).order_by(desc(Mod.created))
+    mods = Mod.query.filter(Mod.published).order_by(Mod.created.desc())
     if game_id:
         mods = mods.filter(Mod.game_id == game_id)
     return mods.limit(limit).all()
@@ -179,7 +178,7 @@ def get_new_mods(game_id: Optional[int], limit: int) -> List[Mod]:
 
 def get_updated_mods(game_id: Optional[int], limit: int) -> List[Mod]:
     mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id))\
-        .order_by(desc(Mod.updated))
+        .order_by(Mod.updated.desc())
     if game_id:
         mods = mods.filter(Mod.game_id == game_id)
     return mods.limit(limit).all()
@@ -188,7 +187,7 @@ def get_updated_mods(game_id: Optional[int], limit: int) -> List[Mod]:
 def get_referral_events(mod_id: int, limit: Optional[int] = None) -> List[ReferralEvent]:
     events = ReferralEvent.query\
         .filter(ReferralEvent.mod_id == mod_id)\
-        .order_by(desc(ReferralEvent.events))
+        .order_by(ReferralEvent.events.desc())
     if limit:
         events = events.limit(limit)
     return events.all()
@@ -198,7 +197,7 @@ def get_referral_events(mod_id: int, limit: Optional[int] = None) -> List[Referr
 def get_download_events(mod_id: int, timeframe: Optional[timedelta] = None) -> List[DownloadEvent]:
     events = DownloadEvent.query\
         .filter(DownloadEvent.mod_id == mod_id)\
-        .order_by(DownloadEvent.created)
+        .order_by(DownloadEvent.created.desc())
     if timeframe:
         thirty_days_ago = datetime.now() - timeframe
         events = events.filter(DownloadEvent.created > thirty_days_ago)
@@ -217,7 +216,7 @@ def get_follow_events(mod_id: int, timeframe: Optional[timedelta] = None) -> Lis
 
 
 def get_games() -> List[Game]:
-    return Game.query.filter(Game.active).order_by(desc(Game.created)).all()
+    return Game.query.filter(Game.active).order_by(Game.created.desc()).all()
 
 
 def get_game_info(**query: str) -> Game:

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -318,8 +318,8 @@ class DownloadEvent(Base):  # type: ignore
     downloads = Column(Integer, default=0)
     created = Column(DateTime, default=datetime.now, index=True)
 
-    Index('ix_downloadevent_mod_id_created', mod_id, created)
-    Index('ix_downloadevent_version_id_created', version_id, created)
+    Index('ix_downloadevent_mod_id_created', mod_id, created.desc())
+    Index('ix_downloadevent_version_id_created', version_id, created.desc())
 
     def __repr__(self) -> str:
         return '<Download Event %r>' % self.id

--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, Iterable, Tuple, Optional
 
 from packaging import version
-from sqlalchemy import and_, or_, not_, desc
+from sqlalchemy import and_, or_, not_
 from sqlalchemy.orm import Query
 
 from .database import db
@@ -83,7 +83,7 @@ def search_mods(game_id: Optional[int], text: str, page: int, limit: int) -> Tup
     # All of the terms must match
     query = query.filter(*(term_to_filter(term) for term in terms))
 
-    query = query.order_by(desc(Mod.score))
+    query = query.order_by(Mod.score.desc())
 
     total_pages = math.ceil(query.count() / limit)
     if page > total_pages:
@@ -153,6 +153,6 @@ def typeahead_mods(game_id: str, text: str) -> Iterable[Mod]:
     filters.append(Mod.name.ilike('%' + text + '%'))
     query = query.filter(or_(*filters))
     query = query.filter(Mod.game_id == game_id, Mod.published == True)
-    query = query.order_by(desc(Mod.score))
+    query = query.order_by(Mod.score.desc())
     results = query.all()
     return results

--- a/alembic/versions/2021_10_28_10_32_09-44040211d4e7.py
+++ b/alembic/versions/2021_10_28_10_32_09-44040211d4e7.py
@@ -1,0 +1,30 @@
+"""Make DownloadEvent index descending order
+
+Revision ID: 44040211d4e7
+Revises: 1b3f98f3620d
+Create Date: 2021-10-28 15:32:13.077268
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '44040211d4e7'
+down_revision = '1b3f98f3620d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.drop_index(op.f('ix_downloadevent_mod_id_created'), table_name='downloadevent')
+    op.drop_index(op.f('ix_downloadevent_version_id_created'), table_name='downloadevent')
+
+    op.create_index(op.f('ix_downloadevent_mod_id_created'), 'downloadevent', ['mod_id', sa.text('created desc')], unique=False)
+    op.create_index(op.f('ix_downloadevent_version_id_created'), 'downloadevent', ['version_id', sa.text('created desc')], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_downloadevent_mod_id_created'), table_name='downloadevent')
+    op.drop_index(op.f('ix_downloadevent_version_id_created'), table_name='downloadevent')
+
+    op.create_index(op.f('ix_downloadevent_mod_id_created'), 'downloadevent', ['mod_id', 'created'], unique=False)
+    op.create_index(op.f('ix_downloadevent_version_id_created'), 'downloadevent', ['version_id', 'created'], unique=False)


### PR DESCRIPTION
## Problem

Despite #370, some `/download/` routes are still taking up to 3 seconds, and most of it seems to be spent in the `DownloadEvent` SQL query:

![image](https://user-images.githubusercontent.com/1559108/139294957-dc295ada-4f83-4e1b-b3d5-e4887a065810.png)

## Cause

https://use-the-index-luke.com/sql/sorting-grouping/indexed-order-by

> SQL queries with an order by clause do not need to sort the result explicitly if the relevant index already delivers the rows in the required order.

The `(version_id, created)` index was supposed to speed up this query, but it does not deliver the rows in the required order! The query is descending order, while the index is ascending. (I was familiar with bidirectional indexes only and so did not realize this was a consideration.)

https://github.com/KSP-SpaceDock/SpaceDock/blob/4dee33b09072e018cd3f47954f9393a153e55eef/KerbalStuff/blueprints/mods.py#L569-L572

![image](https://user-images.githubusercontent.com/1559108/139295206-c51667d2-fab5-4958-a134-ecd8e003c251.png)

I think this means that in order to execute the `ORDER BY` part of our query, the db has to load all the rows and then re-sort them. This will be slow for versions with lots of `DownloadEvent`s. It was supposed to just use the index to find the most recent.

Notably, `get_download_events` _is_ running as quickly as we hoped (since it's not showing up in profiling of mod pages), and it uses the index in ascending order:

https://github.com/KSP-SpaceDock/SpaceDock/blob/4dee33b09072e018cd3f47954f9393a153e55eef/KerbalStuff/common.py#L210-L218

## Changes

- The `DownloadEvent.created` part of these indexes is changed to descending order by a migration (see sqlalchemy/alembic#772 for where I found the syntax), which should allow these queries to execute quickly as intended
  ![image](https://user-images.githubusercontent.com/1559108/139296115-bd425e24-6168-4446-b90f-956fb8e93dfe.png)
  - `get_download_events` now queries in descending order (to make sure it stays fast), and the one place that uses it reverses the result afterwards
- If the `Range` header is sent to a `/download/` route, we were performing that `DownloadEvent` query but not using it for anything. Now we skip the query in this case.
- Usages of `desc(column)` are replaced by `column.desc()` where possible, since it seems like a cleaner approach to call a function on an object we already have rather than passing that object to something we have to import separately
