### PR TITLE
Admin users list usability, buttons to delete users

### DIFF
--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -136,6 +136,19 @@ def users(page: int) -> Union[str, werkzeug.wrappers.Response]:
                            query=query, show_non_public=show_non_public)
 
 
+@admin.route("/admin/delete_user/<int:user_id>", methods=['POST'])
+@adminrequired
+def delete_user(user_id: int) -> Union[str, werkzeug.wrappers.Response]:
+    user = User.query.get(user_id)
+    if not user:
+        abort(404)
+    db.delete(user)
+    db.commit()
+    return redirect(url_for('admin.users',
+                            page=request.form.get('page', 1),
+                            show_non_public=(request.form.get('show_non_public', '').lower() in TRUE_STR)))
+
+
 @admin.route("/admin/locked_mods/<int:page>")
 @adminrequired
 def locked_mods(page: int) -> Union[str, werkzeug.wrappers.Response]:

--- a/frontend/coffee/admin-users.coffee
+++ b/frontend/coffee/admin-users.coffee
@@ -1,0 +1,14 @@
+$('.modal-confirm-delete').on 'show.bs.modal', (evt) ->
+    # Disable final Delete button on modal open
+    $(evt.target).find('input[type=submit]').prop('disabled', true)
+    # Clear username confirmation text box on modal open
+    $(evt.target).find('input[type=text]').val('')
+
+$('.modal-confirm-delete').on 'shown.bs.modal', (evt) ->
+    # Focus text box on modal open
+    $(evt.target).find('input[type=text]').focus()
+
+$('.confirm-username').on 'input', (evt) ->
+    # Enable/disable final Delete button on confirmation text box change
+    $("#btn-delete-#{evt.target.dataset.userid}").prop('disabled',
+        evt.target.value != evt.target.dataset.username)

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -3,6 +3,10 @@
 {{ super() }}
 <style>table td { overflow: hidden; }</style>
 {% endblock %}
+{% block scripts %}
+{{ super() }}
+<script src="/static/admin-users.js"></script>
+{% endblock %}
 {% block admin_content %}
 <div class="tab-pane active" id="users">
     <div class="container admin-container space-left-right">
@@ -69,25 +73,33 @@
     </div>
 </div>
 {% for user in users %}
-    <div class="modal fade" id="confirm-delete-{{user.id}}" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
+    <div class="modal fade modal-confirm-delete" id="confirm-delete-{{user.id}}" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Delete User</h4>
+                    <h4 class="modal-title">Delete User</h4>
                 </div>
-                <div class="modal-body">
-                    Are you sure you want to delete {{user.username}}?
-                    This cannot be un-done.
-                </div>
-                <div class="modal-footer">
-                    <form action="/admin/delete_user/{{ user.id }}" method="POST">
+                <form action="/admin/delete_user/{{ user.id }}" method="POST">
+                    <div class="modal-body">
+                        <p>Are you sure you want to delete <b>{{user.username}}</b>?
+                        <br>
+                        This cannot be un-done.</p>
+                        <div class="form-group">
+                            <label for="confirm-username">Username:</label>
+                            <input type="text" name="confirm-username"
+                                class="form-control confirm-username"
+                                placeholder="Enter username to confirm"
+                                data-userid="{{user.id}}" data-username="{{user.username}}">
+                        </div>
+                    </div>
+                    <div class="modal-footer">
                         <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
-                        <input type="submit" class="btn btn-danger" value="Delete">
+                        <input type="submit" id="btn-delete-{{user.id}}" class="btn btn-danger" value="Delete" disabled>
                         <input type="hidden" name="page" value="{{page}}">
                         <input type="hidden" name="show_non_public" value="{{show_non_public}}">
-                    </form>
-                </div>
+                    </div>
+                </form>
             </div>
         </div>
     </div>

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -1,4 +1,8 @@
 {% extends "admin.html" %}
+{% block styles %}
+{{ super() }}
+<style>table td { overflow: hidden; }</style>
+{% endblock %}
 {% block admin_content %}
 <div class="tab-pane active" id="users">
     <div class="container admin-container space-left-right">
@@ -21,37 +25,42 @@
             </div>
         </div>
         <div class="row table-responsive bootstrap-table space-left-right">
-            <table class="table" data-toggle="table" data-pagination="false" data-striped="true">
+            <table class="table table-condensed" style="table-layout: fixed" data-toggle="table" data-pagination="false" data-striped="true">
                 <thead>
                 <tr>
-                    <th>Username</th>
-                    <th>Created</th>
-                    <th>E-Mail</th>
-                    <th>Forums</th>
-                    <th>IRC</th>
-                    <th>Twitter</th>
-                    <th>Reddit</th>
-                    <th>Location</th>
-                    <th>Description</th>
-                    <th>Public</th>
-                    <th>Admin</th>
+                    <th class="col-md-1">Username</th>
+                    <th class="col-md-1">Created</th>
+                    <th class="col-md-1">Public</th>
+                    <th class="col-md-1">Admin</th>
+                    <th class="col-md-1">E-Mail</th>
+                    <th class="col-md-1">Forum</th>
+                    <th class="col-md-2">Socials</th>
+                    <th class="col-md-4">Description</th>
                 </tr>
                 </thead>
 
                 <tbody>
                 {% for user in users %}
                 <tr>
-                    <td><a href="{{ url_for("profile.view_profile", username=user.username) }}">{{ user.username }}</a></td>
-                    <td>{{ user.created }}</td>
-                    <td>{{ user.email }}</td>
-                    <td>{{ user.forumUsername }}</td>
-                    <td>{{ user.ircNick }}</td>
-                    <td>{{ user.twitterUsername }}</td>
-                    <td>{{ user.redditUsername }}</td>
-                    <td>{{ user.location }}</td>
-                    <td>{{ user.description }}</td>
+                    <td>
+                        <a href="{{ url_for("profile.view_profile", username=user.username) }}">{{ user.username }}</a>
+                        <button data-toggle="modal" data-target="#confirm-delete-{{user.id}}" class="btn btn-danger btn-sm">Delete</button>
+                    </td>
+                    <td>{{ user.created.strftime("%Y-%m-%d %H:%M") }}</td>
                     <td>{{ user.public }}</td>
                     <td>{{ user.admin }}</td>
+                    <td title="{{ user.email | escape }}">{{ user.email }}</td>
+                    <td title="{{ user.forumUsername | escape }}">{{ user.forumUsername }}</td>
+                    <td>
+                        {% if user.kerbalxUsername %}<span class="text-muted">KerbalX:</span> {{ user.kerbalxUsername }}<br/>{% endif %}
+                        {% if user.githubUsername %}<span class="text-muted">GitHub:</span> {{ user.githubUsername }}<br/>{% endif %}
+                        {% if user.twitterUsername %}<span class="text-muted">Twitter:</span> {{ user.twitterUsername }}<br/>{% endif %}
+                        {% if user.redditUsername %}<span class="text-muted">Reddit:</span> {{ user.redditUsername }}<br/>{% endif %}
+                        {% if user.ircNick %}<span class="text-muted">IRC:</span> {{ user.ircNick }}<br/>{% endif %}
+                    </td>
+                    <td><div style="max-height: 6em; overflow: auto;">
+                        {{ user.description | markdown | bleach }}
+                    </div></td>
                 </tr>
                 {% endfor %}
                 </tbody>
@@ -59,6 +68,30 @@
         </div>
     </div>
 </div>
+{% for user in users %}
+    <div class="modal fade" id="confirm-delete-{{user.id}}" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Delete User</h4>
+                </div>
+                <div class="modal-body">
+                    Are you sure you want to delete {{user.username}}?
+                    This cannot be un-done.
+                </div>
+                <div class="modal-footer">
+                    <form action="/admin/delete_user/{{ user.id }}" method="POST">
+                        <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                        <input type="submit" class="btn btn-danger" value="Delete">
+                        <input type="hidden" name="page" value="{{page}}">
+                        <input type="hidden" name="show_non_public" value="{{show_non_public}}">
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endfor %}
 <script type="text/javascript">
     document.getElementById('adm-link-users').classList.add('active')
 </script>


### PR DESCRIPTION
## Motivation

See #413; the admin user list has several annoying layout quirks and doesn't allow the main operation I want to do there: deleting spam users.

## Changes

- Each column of the users table is now a static width, the contents do not overflow onto neighboring cells, and the email and forum cells may be hovered to view the full text in a tooltip
- The username cells now have Delete buttons that show a confirmation prompt when clicked, and if you confirm that you really want to delete, the user is deleted and the list is refreshed
  Note that since this is intended for nuisance users who aren't really users of the site, it does not do anything to clean up mods created by the user. It just deletes the user.
- The created column no longer displays seconds or milliseconds
- The public and admin columns are moved towards the left, after created, so the overall logic is basic info, contact info + socials, description
- The Twitter, Reddit, and IRC fields are combined into one "Socials" column, twice as wide as the username column, that shows them all plus KerbalX and GitHub, to make horizontal room for other fields
- The location column is removed completely because it is used nowhere and does nothing
- The description column is now twice the width of the socials column (4x the width of username), renders markdown **with bleach**, and has a vertical scrollbar if the total height is greater than `6em`

![image](https://user-images.githubusercontent.com/1559108/139328134-ba9ea557-faed-430f-bb47-82242c25fdc5.png)

![image](https://user-images.githubusercontent.com/1559108/139328149-719ab604-16ee-4f03-be2a-08d91f408921.png)

Depends on #316
Fixes #413.