### PR TITLE
Non-public draft blog posts

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -23,7 +23,7 @@ from .blueprints.accounts import accounts
 from .blueprints.admin import admin
 from .blueprints.anonymous import anonymous
 from .blueprints.api import api
-from .blueprints.blog import blog
+from .blueprints.blog import blog, get_all_announcement_posts, get_non_member_announcement_posts
 from .blueprints.lists import lists
 from .blueprints.login_oauth import list_defined_oauths, login_oauth
 from .blueprints.mods import mods
@@ -327,13 +327,3 @@ def inject() -> Dict[str, Any]:
         'donation_header_link': _cfgb('donation-header-link') if not dismissed_donation else False,
         'registration': _cfgb('registration')
     }
-
-
-def get_all_announcement_posts() -> List[BlogPost]:
-    return BlogPost.query.filter(BlogPost.announcement).order_by(BlogPost.created.desc()).all()
-
-
-def get_non_member_announcement_posts() -> List[BlogPost]:
-    return BlogPost.query.filter(
-        BlogPost.announcement, BlogPost.members_only != True
-    ).order_by(BlogPost.created.desc()).all()

--- a/KerbalStuff/blueprints/blog.py
+++ b/KerbalStuff/blueprints/blog.py
@@ -1,36 +1,63 @@
 from flask import Blueprint, render_template, request, redirect, abort
 import werkzeug.wrappers
-from typing import Union
+from typing import Union, List
 from flask_login import current_user
 
 from ..common import adminrequired, with_session, json_output, TRUE_STR
 from ..database import db
 from ..objects import BlogPost
 
+
+def get_all_announcement_posts() -> List[BlogPost]:
+    return BlogPost.query.filter(
+        BlogPost.announcement, BlogPost.draft != True
+    ).order_by(BlogPost.created.desc()).all()
+
+
+def get_non_member_announcement_posts() -> List[BlogPost]:
+    return BlogPost.query.filter(
+        BlogPost.announcement, BlogPost.draft != True, BlogPost.members_only != True
+    ).order_by(BlogPost.created.desc()).all()
+
+
 blog = Blueprint('blog', __name__)
 
 
 @blog.route("/blog")
 def index() -> str:
-    posts = (BlogPost.query.order_by(BlogPost.created.desc()).all()
-             if current_user
-             else BlogPost.query.filter(BlogPost.members_only != True).order_by(BlogPost.created.desc()).all())
-    return render_template("blog_index.html", posts=posts)
+    return render_template("blog_index.html", posts=(
+        BlogPost.query.filter(BlogPost.members_only != True, BlogPost.draft != True)
+        if not current_user
+        else BlogPost.query.filter(BlogPost.draft != True)
+        if not current_user.admin
+        else BlogPost.query
+    ).order_by(BlogPost.created.desc()).all())
+
+
+@blog.route("/blog/<id>")
+def view_blog(id: str) -> str:
+    post = BlogPost.query.get(id)
+    if not post:
+        abort(404)
+    if post.draft:
+        if not current_user or not current_user.admin:
+            abort(401)
+    if post.members_only:
+        if not current_user:
+            abort(401)
+    return render_template("blog.html", post=post)
 
 
 @blog.route("/blog/post", methods=['POST'])
 @adminrequired
 @with_session
 def post_blog() -> werkzeug.wrappers.Response:
-    title = request.form.get('post-title')
-    body = request.form.get('post-body')
-    announcement = (request.form.get('announcement', '') in TRUE_STR)
-    members_only = (request.form.get('members_only', '') in TRUE_STR)
     post = BlogPost()
-    post.title = title
-    post.text = body
-    post.announcement = announcement
-    post.members_only = members_only
+    post.title = request.form.get('post-title')
+    post.text = request.form.get('post-body')
+    post.announcement = (request.form.get('announcement', '') in TRUE_STR)
+    post.members_only = (request.form.get('members_only', '') in TRUE_STR)
+    post.draft = (request.form.get('draft', '') in TRUE_STR)
     db.add(post)
     db.commit()
     return redirect("/blog/" + str(post.id))
@@ -50,6 +77,7 @@ def edit_blog(id: str) -> Union[str, werkzeug.wrappers.Response]:
         post.text = request.form.get('post-body')
         post.announcement = (request.form.get('announcement', '') in TRUE_STR)
         post.members_only = (request.form.get('members_only', '') in TRUE_STR)
+        post.draft = (request.form.get('draft', '') in TRUE_STR)
         return redirect("/blog/" + str(post.id))
 
 
@@ -63,11 +91,3 @@ def delete_blog(id: str) -> werkzeug.wrappers.Response:
         abort(404)
     db.delete(post)
     return redirect("/blog")
-
-
-@blog.route("/blog/<id>")
-def view_blog(id: str) -> str:
-    post = BlogPost.query.get(id)
-    if not post:
-        abort(404)
-    return render_template("blog.html", post=post)

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -52,6 +52,7 @@ class BlogPost(Base):  # type: ignore
     text = Column(Unicode(65535))
     announcement = Column(Boolean(), index=True, nullable=False, default=False)
     members_only = Column(Boolean(), index=True, nullable=False, default=False)
+    draft = Column(Boolean(), index=True, nullable=False, default=False)
     created = Column(DateTime, default=datetime.now, index=True)
 
     def __repr__(self) -> str:

--- a/alembic/versions/2023_03_03_22_10_00-3a9de8cf341d.py
+++ b/alembic/versions/2023_03_03_22_10_00-3a9de8cf341d.py
@@ -1,0 +1,26 @@
+"""Add BlogPost.draft
+
+Revision ID: 3a9de8cf341d
+Revises: 76ba7330ce15
+Create Date: 2023-03-03 22:10:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3a9de8cf341d'
+down_revision = '76ba7330ce15'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.add_column('blog', sa.Column('draft', sa.Boolean(), nullable=True, default=False))
+    op.create_index(op.f('ix_blog_draft'), 'blog', ['draft'], unique=False)
+    op.execute("UPDATE blog SET draft = false")
+    op.alter_column('blog', 'draft', nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_blog_draft'), table_name='blog')
+    op.drop_column('blog', 'draft')

--- a/templates/admin-blog.html
+++ b/templates/admin-blog.html
@@ -20,11 +20,17 @@
             </div>
             <div class="checkbox">
                 <label>
+                    <input id="draft" name="draft" type="checkbox">
+                    Draft (only visible to admins)
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
                     <input id="members_only" name="members_only" type="checkbox">
                     Only show this to logged in users
                 </label>
             </div>
-            <input type="submit" class="btn btn-primary btn-block" value="Publish">
+            <input type="submit" class="btn btn-primary btn-block" value="Save">
         </form>
     </div>
 </div>

--- a/templates/edit_blog.html
+++ b/templates/edit_blog.html
@@ -30,6 +30,13 @@
         </div>
         <div class="checkbox">
             <label>
+                <input id="draft" name="draft" type="checkbox"
+                    {%- if post.draft %} checked{% endif -%} >
+                Draft (only visible to admins)
+            </label>
+        </div>
+        <div class="checkbox">
+            <label>
                 <input id="members_only" name="members_only" type="checkbox"
                     {%- if post.members_only %} checked{% endif -%} >
                 Only show this to logged in users


### PR DESCRIPTION
## Motivation

See #406, sometimes we want to prepare an announcement but are not ready to publish it yet. It would be nice to be able to save our work and publish it later.

## Changes

- A new `BlogPost.draft` column is created and set to false for all existing rows
- A Draft checkbox is added to blog post creation and editing corresponding to the new column
- Only admins see drafts in the blog listing
- Drafts are never shown as announcements
- Users attempting to bypass the blog listing filters by guessing id numbers in the URL to see members only posts will no longer succeed

Fixes #406.