### PR TITLE
Add Locked Mods tab to admin pages

### DIFF
--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -242,6 +242,8 @@ class Mod(Base):  # type: ignore
     # List of users that follow this mods
     followers = association_proxy('followings', 'user')
 
+    Index('ix_mod_locked_updated', locked, updated.desc())
+
     def background_thumb(self) -> Optional[str]:
         return thumbnail.get_or_create(self)
 

--- a/alembic/versions/2023_03_03_22_00_00-76ba7330ce15.py
+++ b/alembic/versions/2023_03_03_22_00_00-76ba7330ce15.py
@@ -1,0 +1,22 @@
+"""Index Mod.locked,Mod.updated
+
+Revision ID: 76ba7330ce15
+Revises: beb0f0da734e
+Create Date: 2023-03-03 22:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '76ba7330ce15'
+down_revision = 'beb0f0da734e'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.create_index('ix_mod_locked_updated', 'mod', ['locked', sa.text('updated DESC')], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_mod_locked_updated', table_name='mod')

--- a/templates/admin-locked-mods.html
+++ b/templates/admin-locked-mods.html
@@ -1,0 +1,24 @@
+{% extends "admin.html" %}
+{% block styles %}
+{{ super() }}
+<link rel="stylesheet" type="text/css" href="/static/index.css" />
+{% endblock %}
+{% block admin_content %}
+<div class="tab-pane active" id="locked_mods">
+    <div class="container admin-container space-left-right">
+        <div class="row">
+            {% set base_url = 'admin.locked_mods' %}
+            {% include 'admin-page-nav.html' %}
+        </div>
+        <br/>
+        <div class="row">
+            {% for mod in locked_mods  %}
+                {% include "mod-box.html" %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    document.getElementById('adm-link-locked-mods').classList.add('active')
+</script>
+{% endblock %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -19,6 +19,7 @@
             <li id="adm-link-publishers"><a href="{{ url_for("admin.publishers", page=1) }}">Publishers</a></li>
             <li id="adm-link-games"><a href="{{ url_for("admin.games", page=1) }}">Games</a></li>
             <li id="adm-link-game-versions"><a href="{{ url_for("admin.game_versions", page=1) }}">Game Versions</a></li>
+            <li id="adm-link-locked-mods"><a href="{{ url_for("admin.locked_mods", page=1) }}">Locked Mods</a></li>
             <li id="adm-link-blog"><a href="{{ url_for("admin.blog") }}">Blog</a></li>
             <li id="adm-link-email"><a href="{{ url_for("admin.email") }}">E-Mail</a></li>
             <li id="adm-link-links"><a href="{{ url_for("admin.links") }}">Links</a></li>


### PR DESCRIPTION
## Motivation

See #403, locked mods are only visible to admins, but admins don't have any easy way to find them if they don't already know about them. This could be a problem if we ever write code that locks mods automatically (e.g., anti-virus scanning), or if we just forget about a mod that we meant to check up on.

## Changes

Now the admin pages have a Locked Mods tab between Game Versions and Blog. It shows the locked mods in the style of the usual "mod box" listings, 30 per page, using a new multi-column index of `(Mod.locked, Mod.updated.desc())` so if a user edits a mod, it will pop to the beginning of the list. The lock reason is not shown in the list on the assumption that admins will click the mods to view it.

![image](https://user-images.githubusercontent.com/1559108/139436002-aeeb7232-be52-4da0-9082-94b967f7a437.png)

Fixes #403.