### PR TITLE
Clean up login/register layout

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -15,28 +15,30 @@
         {% endif %}
         <form class="form-horizontal col-md-6" role="form" action="/login" method="POST">
             <div class="form-group">
-                <label for="username" class="col-sm-2 control-label">Username</label>
-                <div class="col-sm-10">
+                <label for="username" class="col-sm-2 control-label">Username:</label>
+                <div class="col-sm-8">
                     <input type="text" class="form-control" id="username" placeholder="Username" name="username" value="{{ username }}">
                 </div>
             </div>
             <div class="form-group">
-                <label for="password" class="col-sm-2 control-label">Password</label>
-                <div class="col-sm-10">
+                <label for="password" class="col-sm-2 control-label">Password:</label>
+                <div class="col-sm-8">
                     <input type="password" class="form-control" id="password" placeholder="Password" name="password">
                 </div>
             </div>
             <div class="form-group">
-                <div class="checkbox">
-                    <label class="col-sm-10 col-sm-offset-2">
-                        <input type="checkbox" name="remember-me" id="remember-me">
-                        Remember Me
-                    </label>
+                <div class="col-sm-offset-2 col-sm-8">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="remember-me" id="remember-me">
+                            Remember me
+                        </label>
+                    </div>
                 </div>
             </div>
             <div class="form-group">
-                <div class="col-sm-10 col-sm-offset-2">
-                    <input type="submit" value="Log In" class="btn btn-primary">
+                <div class="col-sm-4 col-sm-offset-2">
+                    <input type="submit" value="Log In" class="btn btn-lg btn-primary btn-block">
                 </div>
             </div>
             {% if return_to %}
@@ -49,17 +51,18 @@
             {% endif %}
             <p>Have you <a href="/forgot-password">forgotten your password</a>?</p>
             <p>Or maybe you want to <a href="/register">create a new account</a>?</p>
+            <p>If you run into any trouble, please <a href="mailto:{{ support_mail }}">get in touch</a>.</p>
             {% for provider in oauth_providers %}
-              {% set provider_icon = oauth_providers[provider].icon %}
-              {% set provider_full_name = oauth_providers[provider].full_name %}
-              <form action="/login-oauth" method="POST">
-                <p>
-                  <input type="hidden" name="provider" value="{{provider}}">
-                  Or <button type="submit" class="btn btn-primary">
-                    <i class="fa fa-{{provider_icon}}"></i> Log In using {{provider_full_name}}
-                  </button>
-                </p>
-              </form>
+                {% set provider_icon = oauth_providers[provider].icon %}
+                {% set provider_full_name = oauth_providers[provider].full_name %}
+                <form action="/login-oauth" method="POST">
+                    <p>
+                        <input type="hidden" name="provider" value="{{provider}}">
+                        Or <button type="submit" class="btn btn-primary">
+                            <i class="fa fa-{{provider_icon}}"></i> Log In using {{provider_full_name}}
+                        </button>
+                    </p>
+                </form>
             {% endfor %}
         </div>
     </div>

--- a/templates/register.html
+++ b/templates/register.html
@@ -22,8 +22,8 @@
         <div class="col-md-6">
             <form class="form-horizontal" role="form" action="/register" method="POST">
                 <div class="form-group{% if emailError %} has-error{% endif %}">
-                    <label for="email" class="col-sm-2 control-label">Email</label>
-                    <div class="col-sm-10">
+                    <label for="email" class="col-sm-2 control-label">Email:</label>
+                    <div class="col-sm-8">
                         <input type="email" class="form-control" id="email" placeholder="Email" name="email" value="{{ email }}">
                         {% if emailError %}
                         <span class="text-danger">{{ emailError }}</span>
@@ -31,8 +31,8 @@
                     </div>
                 </div>
                 <div class="form-group{% if usernameError %} has-error{% endif %}">
-                    <label for="username" class="col-sm-2 control-label">Username</label>
-                    <div class="col-sm-10">
+                    <label for="username" class="col-sm-2 control-label">Username:</label>
+                    <div class="col-sm-8">
                         <input type="text" class="form-control" id="username" placeholder="Username" name="username" value="{{ username }}">
                         {% if usernameError %}
                         <span class="text-danger">{{ usernameError }}</span>
@@ -40,8 +40,8 @@
                     </div>
                 </div>
                 <div class="form-group{% if passwordError %} has-error{% endif %}">
-                    <label for="password" class="col-sm-2 control-label">Password</label>
-                    <div class="col-sm-10">
+                    <label for="password" class="col-sm-2 control-label">Password:</label>
+                    <div class="col-sm-8">
                         <input type="password" class="form-control" id="password" name="password" placeholder="Password">
                         {% if passwordError %}
                         <span class="text-danger">{{ passwordError }}</span>
@@ -49,7 +49,7 @@
                     </div>
                 </div>
                 <div class="form-group{% if repeatPasswordError %} has-error{% endif %}">
-                    <div class="col-sm-10 col-sm-offset-2">
+                    <div class="col-sm-8 col-sm-offset-2">
                         <input type="password" class="form-control" id="password" name="repeatPassword" placeholder="Repeat password">
                         {% if repeatPasswordError %}
                         <span class="text-danger">{{ repeatPasswordError }}</span>
@@ -57,28 +57,32 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <div class="col-sm-10 col-sm-offset-2">
-                        <input type="submit" value="Register" class="btn btn-primary">
+                    <div class="col-sm-4 col-sm-offset-2">
+                        <input type="submit" value="Register" class="btn btn-primary btn-lg btn-block">
+                    </div>
+                    <div class="col-sm-4">
                         <a href="/" class="btn btn-link">Nevermind</a>
                     </div>
                 </div>
             </form>
             <hr>
-            <div style="text-align:center; padding-bottom: 10px">OR</div>
-            {% for provider in oauth_providers %}
-              {% set provider_icon = oauth_providers[provider].icon %}
-              {% set provider_full_name = oauth_providers[provider].full_name %}
-              <div class="col-sm-10 col-sm-offset-2">
-                <p>
-                  <form action="/login-oauth" method="POST">
-                    <input type="hidden" name="provider" value="{{provider}}">
-                    <button type="submit" class="btn btn-primary btn-lg">
-                      <i class="fa fa-{{provider_icon}}"></i> Register using {{provider_full_name}}
-                    </button>
-                  </form>
-                </p>
-              </div>
-            {% endfor %}
+            {%- if oauth_providers -%}
+                <div style="text-align:center; padding-bottom: 10px">OR</div>
+                {% for provider in oauth_providers %}
+                    {% set provider_icon = oauth_providers[provider].icon %}
+                    {% set provider_full_name = oauth_providers[provider].full_name %}
+                    <div class="col-sm-10 col-sm-offset-2">
+                        <p>
+                            <form action="/login-oauth" method="POST">
+                                <input type="hidden" name="provider" value="{{provider}}">
+                                <button type="submit" class="btn btn-primary btn-lg">
+                                    <i class="fa fa-{{provider_icon}}"></i> Register using {{provider_full_name}}
+                                </button>
+                            </form>
+                        </p>
+                  </div>
+                {% endfor %}
+            {%- endif -%}
         </div>
 
         <div class="col-md-6">


### PR DESCRIPTION
## Problems

Complaints about the `/register` template:

![image](https://user-images.githubusercontent.com/1559108/139587808-7a1da1ab-92ac-4462-97cf-df54f58402a8.png)

- The text fields are _huge_, way bigger than any conceivable values that might populate them
- The buttons are tiny
- The labels don't have colons
- There's a stray `OR` at the bottom

Complaints about the `/login` template:

![image](https://user-images.githubusercontent.com/1559108/139587810-ddf8fb79-8720-4287-8763-45a1a378b0f4.png)

- The text fields are _huge_, way bigger than any conceivable values that might populate them
- The buttons are tiny
- The labels don't have colons
- The checkbox isn't aligned with the fields
- There's no link to the support email

## Changes

![image](https://user-images.githubusercontent.com/1559108/139587908-851eab96-caa8-416e-82ae-7e2030f556db.png)

![image](https://user-images.githubusercontent.com/1559108/139587909-c7dbdedb-36ec-41e8-83bd-2cfabb9f9a3e.png)
