### PR TITLE
Fix modpack backgrounds and thumbnails

### DIFF
--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -21,7 +21,7 @@ from markdown import markdown
 from .config import _cfg
 from .custom_json import CustomJSONEncoder
 from .database import db, Base
-from .objects import Game, Mod, Featured, ModVersion, ReferralEvent, DownloadEvent, FollowEvent
+from .objects import Game, Mod, ModList, Featured, ModVersion, ReferralEvent, DownloadEvent, FollowEvent
 from .search import search_mods
 from .kerbdown import EmbedInlineProcessor, KerbDown
 
@@ -247,6 +247,15 @@ def check_mod_editable(mod: Mod, abort_response: Optional[Union[int, werkzeug.wr
             return True
     if abort_response is not None:
         abort(abort_response)
+    return False
+
+
+def check_pack_editable(pack: ModList) -> bool:
+    if current_user:
+        if current_user.admin:
+            return True
+        if current_user.id == pack.user_id:
+            return True
     return False
 
 

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -269,11 +269,29 @@ class ModList(Base):  # type: ignore
     user = relationship('User', backref=backref('packs', order_by=created))
     game_id = Column(Integer, ForeignKey('game.id'))
     game = relationship('Game', backref='modlists')
-    background = Column(String(32))
+    # Don't access background directly, use background_url() instead.
+    background = Column(String(512))
+    # Don't access thumbnail directly, use background_thumb() instead.
+    thumbnail = Column(String(512), default='')
     bgOffsetY = Column(Integer)
     description = Column(Unicode(100000))
     short_description = Column(Unicode(1000))
     name = Column(Unicode(1024))
+
+    def background_url(self, protocol: Optional[str], cdn_domain: Optional[str]) -> Optional[str]:
+        if not self.background:
+            return None
+        # Directly return the CDN path if we have any, so we don't have a redirect that breaks caching.
+        if protocol and cdn_domain:
+            return f'{protocol}://{cdn_domain}/{self.background}'
+        else:
+            return url_for('lists.list_background', pack_id=self.id, pack_name=self.name)
+
+    def background_thumb(self) -> Optional[str]:
+        return thumbnail.get_or_create_pack(self)
+
+    def base_path(self) -> str:
+        return os.path.join(self.user.base_path(), secure_filename(self.name))
 
     def __repr__(self) -> str:
         return '<ModList %r %r>' % (self.id, self.name)

--- a/alembic/versions/2021_11_04_12_36_53-beb0f0da734e.py
+++ b/alembic/versions/2021_11_04_12_36_53-beb0f0da734e.py
@@ -1,0 +1,24 @@
+"""Create ModList.thumbnail
+
+Revision ID: beb0f0da734e
+Revises: 44040211d4e7
+Create Date: 2021-11-04 17:36:56.561913
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'beb0f0da734e'
+down_revision = '44040211d4e7'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.alter_column('modlist', 'background', type_=sa.String(length=512))
+    op.add_column('modlist', sa.Column('thumbnail', sa.String(length=512), nullable=True))
+
+
+def downgrade() -> None:
+    # Shortening the ModList.background column breaks if we stored long strings in it and isn't needed for the old code to work
+    op.drop_column('modlist', 'thumbnail')

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -8,7 +8,7 @@
     - https://github.com/miguelgrinberg/Flask-Migrate/issues/155
 """
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import sqlalchemy.sql.type_api
 import sqlalchemy as sa
@@ -37,8 +37,10 @@ class op:
     def alter_column(cls,
                     table_name: str,
                     column_name: str,
+                    nullable: Optional[bool] = None,
                     existing_type: Optional[sa.sql.type_api.TypeEngine] = None,
-                    nullable: Optional[bool] = None) -> None: ...
+                    type_: Optional[Union[sa.sql.type_api.TypeEngine,
+                                    sa.sql.type_api.Type[sa.sql.type_api.TypeEngine]]] = None) -> None: ...
 
     @classmethod
     def create_index(cls,

--- a/frontend/coffee/edit_pack.coffee
+++ b/frontend/coffee/edit_pack.coffee
@@ -10,32 +10,34 @@ window.upload_bg = (files, box) ->
     box.querySelector('a').classList.add('hidden')
     progress = box.querySelector('.upload-progress')
 
-    MediaCrush.upload(file, (media) ->
-        progress.classList.add('fade-out')
-        progress.style.width = '100%'
-        p.textContent = 'Processing...'
-        media.wait(() ->
-            MediaCrush.get(media.hash, (media) ->
-                p.textContent = 'Done'
-                path = null
-                for file in media.files
-                    if file.type == 'image/png' or file.type == 'image/jpeg'
-                        path = file
-                if path == null
-                    p.textContent = 'Please upload images only.'
-                else
-                    document.getElementById('background').value = path.file
-                    document.getElementById('header-well').style.backgroundImage = 'url("https://mediacru.sh/' + path.file + '")'
-                    setTimeout(() ->
-                        box.removeChild(p)
-                        box.querySelector('a').classList.remove('hidden')
-                    , 3000)
-            )
-        )
-    , (e) ->
+    xhr = new XMLHttpRequest()
+    xhr.open('POST', "/api/pack/#{window.pack_id}/update-bg")
+    xhr.setRequestHeader('Accept', 'application/json')
+    xhr.upload.onprogress = (e) ->
         if e.lengthComputable
             progress.style.width = (e.loaded / e.total) * 100 + '%'
-    )
+    xhr.onload = (e) ->
+        if xhr.status != 200
+            p.textContent = 'Please upload JPG or PNG only.'
+            setTimeout(() ->
+                box.removeChild(p)
+                box.querySelector('a').classList.remove('hidden')
+            , 3000)
+        else
+            resp = JSON.parse(xhr.responseText)
+            if resp.error
+                alert resp.reason
+            else
+                p.textContent = 'Done!'
+                document.getElementById('header-well').style.backgroundImage =
+                  'url("' + resp.path + '?nocache=' + new Date().getTime() + '")'
+                setTimeout(() ->
+                    box.removeChild(p)
+                    box.querySelector('a').classList.remove('hidden')
+                , 3000)
+    formdata = new FormData()
+    formdata.append('image', file)
+    xhr.send(formdata)
 
 pack_list = window.pack_list
 new_mod = null

--- a/templates/edit_list.html
+++ b/templates/edit_list.html
@@ -9,11 +9,7 @@
 {% block body %}
 <form class="edit-list" action="{{ url_for("lists.edit_list", list_id=mod_list.id, list_name=mod_list.name) }}" method="POST">
     <div class="header upload-well scrollable" id="header-well" style="
-        {%- if mod_list.background -%}
-            background-image: url({{ mod_list.background }});
-        {%- else -%}
-            background-image: url(/static/background.jpg);
-        {%- endif -%}
+        background-image: url({{ background if background else '/static/background.jpg' }});
         background-position: 0 {% if mod_list.bgOffsetY %}{{ mod_list.bgOffsetY }}px{% else %}0{% endif %};
         background-color: #ddd;"
         data-event="upload_bg"
@@ -104,6 +100,7 @@
 {% endblock %}
 {% block scripts %}
     <script>
+        window.pack_id = {{ mod_list.id }};
         window.pack_list = {{ mod_ids | tojson }};
         window.game_id = {{ mod_list.game.id }};
     </script>

--- a/templates/mod_list.html
+++ b/templates/mod_list.html
@@ -14,8 +14,8 @@
 <link rel="stylesheet" type="text/css" href="/static/mod.css" />
 {% endblock %}
 {% block body %}
-{% if mod_list.background %}
-<div class="header" style="background-image: url({{ mod_list.background }});
+{% if background %}
+<div class="header" style="background-image: url({{ background }});
     background-position: 0 {% if mod_list.bgOffsetY %}{{ mod_list.bgOffsetY }}px{% else %}0{% endif %};"></div>
 {% else %}
 <div class="header" style="background-image: url(/static/background.jpg);"></div>

--- a/templates/pack-box.html
+++ b/templates/pack-box.html
@@ -2,10 +2,11 @@
     <div class="thumbnail">
         <a class="header-img-link" href="{{ url_for("lists.view_list", list_id=list.id, list_name=list.name) }}">
             <div class="header-img" style="
-                {%- if not list.background -%}
-                    background-image: url(/static/background-s.png);
+                {%- set thumbnail = list.background_thumb() -%}
+                {%- if thumbnail -%}
+                    background-image: url({{ thumbnail }});
                 {%- else -%}
-                    background-image: url({{ list.background }});
+                    background-image: url(/static/background-s.png);
                 {%- endif -%}
             "></div>
         </a>


### PR DESCRIPTION
## Problem

If you edit a modpack, there's a link to upload a background, but it doesn't work. Hence no modpacks have backgrounds or thumbnails.

## Cause

The upload link references some very old code based on `MediaCrush`, which SpaceDock doesn't include, so it just crashes.

## Changes

Now the modpack uploading link works, and modpack backgrounds and thumbnails are displayed.

- The `ModList.background` column is increased from 32 to 512 characters to match the other background columns
- The `ModList.thumbnail` column is created
- The recent background/thumbnail handling fixes are copied to `ModList`

If a user gives a modpack the same name as another of his or her own mods or modpacks, the backgrounds and thumbnails may end up in the same `username_userid/packname` folder in storage. This should be fine, though, because the filename of `packname-timestamp.jpg` will be unique thanks to the timestamp.