### PR TITLE
Admin pagination usability fixes

### DIFF
--- a/frontend/styles/stylesheet.scss
+++ b/frontend/styles/stylesheet.scss
@@ -164,5 +164,14 @@ footer {
     height: 150px;
 }
 
+.admin-container .pagination {
+    margin: 10px 0;
+}
+
+.admin-container .pagination > li > a {
+    width: 8ex;
+    text-align: center;
+}
+
 @import "typeahead";
 @import "navigation";

--- a/templates/admin-page-nav.html
+++ b/templates/admin-page-nav.html
@@ -1,18 +1,26 @@
 <div class="col-sm-8">
     <nav aria-label="Page navigation">
         <ul class="pagination" style="padding-left: 0">
+            {% set page_size   = 10 %}
+            {% set left_pages  = [(page_size - 1) // 2, page - 1] | min %}
+            {% set right_pages = [page_size - 1 - left_pages, total_pages - page] | min %}
+            {% set left_pages  = [page_size - 1 - right_pages, left_pages] | max %}
+            {% set left_pages  = [left_pages, page - 1] | min %}
+            {% set start_page  = page - left_pages %}
+            {% set end_page    = page + right_pages %}
+
             <!-- first page -->
-            {% if page != 1 %}
-            <li style="display:inline">
+            <li style="display:inline" {% if left_pages == 0 %}class="disabled"{% endif %}>
                 <a href="{{ url_for(base_url, page=1, query=query, show_non_public=show_non_public, show_none_active=show_none_active, show_inactive=show_inactive) }}" aria-label="First"><span aria-hidden="true">&laquo;</span></a>
             </li>
+
             <!-- previous page -->
-            <li style="display:inline">
+            <li style="display:inline" {% if left_pages == 0 %}class="disabled"{% endif %}>
                 <a href="{{ url_for(base_url, page=page - 1, query=query) }}" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a>
             </li>
-            {% endif %}
-            <!-- all page numbers -->
-            {% for page_num in range([1, page - 3] | max, [total_pages + 1, page + 7] | min) %}
+
+            <!-- page numbers -->
+            {% for page_num in range(start_page, end_page + 1) %}
                 {% if page_num != page %}
                     <li style="display:inline">
                         <a href="{{ url_for(base_url, page=page_num, query=query, show_non_public=show_non_public, show_none_active=show_none_active, show_inactive=show_inactive) }}">{{ page_num }}</a>
@@ -23,15 +31,17 @@
                     </li>
                 {% endif %}
             {% endfor %}
+
             <!-- next page -->
-            {% if page != total_pages %}
-            <li style="display:inline">
+            <li style="display:inline" {% if right_pages == 0 %}class="disabled"{% endif %}>
                 <a href="{{ url_for(base_url, page=page + 1, query=query, show_non_public=show_non_public, show_none_active=show_none_active, show_inactive=show_inactive) }}" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a>
             </li>
-            <li style="display:inline">
+
+            <!-- last page -->
+            <li style="display:inline" {% if right_pages == 0 %}class="disabled"{% endif %}>
                 <a href="{{ url_for(base_url, page=total_pages, query=query, show_non_public=show_non_public, show_none_active=show_none_active, show_inactive=show_inactive) }}" aria-label="Last"><span aria-hidden="true">&raquo;</span></a>
             </li>
-            {% endif %}
+
         </ul>
     </nav>
 </div>


### PR DESCRIPTION
## Background

On the admin pages there are some number and arrow buttons to jump to different pages of the lists:

![image](https://user-images.githubusercontent.com/1559108/140562336-64c281e9-9999-4c5c-9288-f9276e33e90b.png)

![image](https://user-images.githubusercontent.com/1559108/140562388-c5b5594a-8053-4b16-8f9f-31475ccd6491.png)
![image](https://user-images.githubusercontent.com/1559108/140563070-cd1704be-2d38-4a49-a950-bf4bc6a5a6ad.png)

![image](https://user-images.githubusercontent.com/1559108/140562358-f416549b-c97f-4832-bb56-d18c6bbd058b.png)

## Motivation

These buttons have some quirks that make them mildly annoying in practice:

- They're very close to the profilings list and farther from the border above them
- At the start of the list 7 number buttons are shown, in the middle it is 10, at the end it is 4
- The arrow buttons appear and disappear based on whether they're needed, which makes sense in a way, but can be disruptive if you're actively working on the list and don't expect all your numbers to shift back and forth
- They're dynamically sized, so the first page's buttons are smaller than the last page's and in between they vary based on how big the numbers are

## Changes

- Now they're moved up by 10px
- Now for we always show the same number of buttons (10 for a long list), with the active page closer to the center
- Now the arrows are always shown, but disabled when they don't apply (note, they _look_ disabled but you can still click them :sob:)
- Now they're all the same width, with room for 3 digits

This makes the pagination controls more consistent from page to page:

![image](https://user-images.githubusercontent.com/1559108/140562508-e77c689d-4852-4b37-89bb-1107a3263022.png)

![image](https://user-images.githubusercontent.com/1559108/140562657-6c8077fe-ede7-4a81-b9ec-fde9a4ada60c.png)

![image](https://user-images.githubusercontent.com/1559108/140562535-ded33d46-4b20-48cb-a23f-8eb35e5bf33a.png)
