### PR TITLE
Co-authorship fixes

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -300,8 +300,7 @@ def search_user() -> Iterable[Dict[str, Any]]:
     results = list()
     for u in search_users(query, page):
         a = user_info(u)
-        mods = Mod.query.filter(Mod.user == u, Mod.published == True).order_by(Mod.created)
-        a['mods'] = [mod_info(m) for m in mods]
+        a['mods'] = [mod_info(m) for m in u.all_mods if m.published]
         results.append(a)
     return results
 
@@ -483,9 +482,8 @@ def user_info_api(username: str) -> Union[Dict[str, Any], Tuple[Dict[str, Any], 
         return {'error': True, 'reason': 'User not found.'}, 404
     if not user.public:
         return {'error': True, 'reason': 'User not public.'}, 403
-    mods = Mod.query.filter(Mod.user == user, Mod.published == True).order_by(Mod.created)
     info = user_info(user)
-    info['mods'] = [mod_info(m) for m in mods]
+    info['mods'] = [mod_info(m) for m in user.all_mods if m.published]
     return info
 
 

--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -151,8 +151,6 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
         for v in mod.versions:
             json_versions.append({'name': v.friendly_version, 'id': v.id})
             size_versions[v.id] = v.format_size(storage)
-    if request.args.get('noedit') is not None:
-        editable = False
     forum_thread = False
     if mod.external_link is not None:
         try:
@@ -177,6 +175,8 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
                 pending_invite = True
             if current_user.id == a.user_id and a.accepted:
                 editable = True
+    if request.args.get('noedit') is not None:
+        editable = False
     latest_game_version = GameVersion.query.filter(
         GameVersion.game_id == mod.game_id).order_by(desc(GameVersion.id)).first()
     outdated = False

--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -42,9 +42,9 @@ def view_profile(username: str) -> str:
     mods_created = list(map(lambda grp: (grp[0], sorted(grp[1],
                                                         key=lambda m: m.created,
                                                         reverse=True)),
-                            groupby(sorted(profile.mods if show_unpublished
+                            groupby(sorted(profile.all_mods if show_unpublished
                                            else filter(lambda m: m.published,
-                                                       profile.mods),
+                                                       profile.all_mods),
                                            key=lambda m: m.game.name),
                                     lambda m: m.game.name)))
     mods_followed = sorted(profile.following, key=lambda mod: mod.created, reverse=True)

--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -47,7 +47,10 @@ def view_profile(username: str) -> str:
                                                        profile.all_mods),
                                            key=lambda m: m.game.name),
                                     lambda m: m.game.name)))
-    mods_followed = sorted(profile.following, key=lambda mod: mod.created, reverse=True)
+    mods_followed = sorted(profile.following if show_unpublished
+                           else filter(lambda m: m.published,
+                                       profile.following),
+                           key=lambda mod: mod.created, reverse=True)
     return render_template("view_profile.html",
                            profile=profile, forum_url=forum_url, forum_url_username=forum_url_username,
                            background=profile.background_url(_cfg('protocol'), _cfg('cdn-domain')),

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -2,7 +2,7 @@ import binascii
 import os.path
 from datetime import datetime
 import re
-from typing import Optional
+from typing import Optional, List
 
 import bcrypt
 from flask import url_for
@@ -88,6 +88,12 @@ class User(Base):  # type: ignore
     # List of mods the user follows
     following = association_proxy('followings', 'mod')
     dark_theme = Column(Boolean, default=False)
+
+    @property
+    def all_mods(self) -> List['Mod']:
+        return list(sorted(self.mods + [sh.mod for sh in self.shared_authors
+                                        if sh.accepted],
+                           key=lambda m: m.created))
 
     def set_password(self, password: str) -> None:
         self.password = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')

--- a/frontend/coffee/edit_mod.coffee
+++ b/frontend/coffee/edit_mod.coffee
@@ -47,12 +47,21 @@ document.getElementById('add-shared-author').addEventListener('click', (e) ->
     xhr.onload = () ->
         response = JSON.parse(this.responseText)
         if response.error
-            m.textContent = response.message
+            m.textContent = response.reason
             m.classList.remove('hidden')
         else
             div = document.createElement('div')
             div.className = 'col-md-6'
-            div.textContent = u.value
+            div.textContent = u.value + ' (pending)'
+            a = document.createElement('a')
+            a.href = '#'
+            a.dataset.user = u.value
+            a.className = 'remove-author'
+            a.addEventListener('click', remove_coauthor, false)
+            span = document.createElement('span')
+            span.className = 'glyphicon glyphicon-remove'
+            a.appendChild(span)
+            div.appendChild(a)
             b = document.getElementById('beforeme')
             b.parentElement.insertBefore(div, b)
             u.value = ''
@@ -67,7 +76,7 @@ document.getElementById('new-shared-author').addEventListener('keypress', (e) ->
         document.getElementById('add-shared-author').click()
 , false)
 
-a.addEventListener('click', (e) ->
+remove_coauthor = (e) ->
     e.preventDefault()
     target = e.target
     if target.tagName != 'A'
@@ -80,4 +89,5 @@ a.addEventListener('click', (e) ->
     form = new FormData()
     form.append('user', target.dataset.user)
     xhr.send(form)
-, false) for a in document.querySelectorAll('.remove-author')
+
+a.addEventListener('click', remove_coauthor, false) for a in document.querySelectorAll('.remove-author')

--- a/templates/edit_mod.html
+++ b/templates/edit_mod.html
@@ -153,9 +153,8 @@
                     {{ author.user.username }}
                     {% if not author.accepted %}
                     (pending)
-                    {% else %}
-                    <a href="#" data-user="{{ author.user.username }}" class="remove-author"><span class="glyphicon glyphicon-remove"></span></a>
                     {% endif %}
+                    <a href="#" data-user="{{ author.user.username }}" class="remove-author"><span class="glyphicon glyphicon-remove"></span></a>
                 </div>
                 {% endfor %}
                 <div class="col-md-6" id="beforeme">


### PR DESCRIPTION
## Problems

While editing a mod's co-authors list:

- If you type a user name that doesn't exist and click Add, a blank red box appears
- If you invite a co-author and then later change your mind, you can only remove them if they've accepted, otherwise you have to wait till they accept
- If you edit a mod with pending co-author invitations, they will say "(pending)", but if you freshly invite a new co-author, it won't say "(pending)" until you reload the page

Co-authored mods (where you're not the primary author but have received and accepted an invitation to co-author) are missing from:

- The user profile
- `/api/user/<username>`
- `/api/search/user?query=<username>`
- Searches for `user:<username>`

Since some co-authors are really the new primary maintainers, this can be misleading.

The "view your mod as if you were not logged in" link did not work for co-authors; the editing controls were still shown.

Note, co-authors are also missing from CKAN notifications, but #435 will address that because it's already editing that code.

## Causes

- The blank red box is because the server is setting `response.reason` and the client is looking at `response.message`
- The template put the remove X button in an `else` clause
- The client code that added the author to the list just added the name
- The profile was using `User.mods`, which omits co-authored mods
- The API was using `Mod.query.filter` calls that omitted co-authored mods
- The search was just checking `Mod.user`, which misses co-authored mods
- The `noedit` flag was applied before the co-authors checks, so editing would be set to `True` for co-authors even if it was present

## Changes

- Now the no-such-user message appears as intended
- Now the remove X button always appears next to co-authors (the server code was already able to delete the invitation)
- Now pending co-authors will say "(pending)" as soon as they are added
- Now a new `User.all_mods` property is created that includes co-authored mods, and this is used to generate mod lists for:
  - The user profile
  - `/api/user/<username>`
  - `/api/search/user?query=<username>`
- Now the search constructs an `or_()` clause that checks `Mod.shared_authors` in addition to `Mod.user`
- Now the `noedit` lag is checked last, so editing will be `False` for co-authors when it is present

Fixes #155.

### Side fix

The profile shows unpublished mods under "Mods X follows":

- https://spacedock.info/profile/Shizihi

Now only admins and the same user can see them, as already done for mods-created.

Discovered after KSP-CKAN/NetKAN#8962.