### PR TITLE
Widescreen layout for mod page

### DIFF
--- a/templates/mod.html
+++ b/templates/mod.html
@@ -75,6 +75,10 @@
     </div>
 </div>
 
+<div class="container">
+<div class="row">
+<div class="col-lg-7">
+
 <div class="info-list">
     <div class="container">
         <div class="row">
@@ -122,7 +126,7 @@
                                 <span class="glyphicon glyphicon-tasks"></span>
                             </div>
                             <div class="timeline-label">
-                                <h2>
+                                <h2 style="white-space: normal;">
                                     <span class="text-muted">
                                         Source code:
                                     </span>
@@ -307,6 +311,9 @@
         {% endif %}
 {% endif %}
 
+</div>
+<div class="col-lg-5">
+
 <div class="tab-container">
     <div class="mod-tabs container">
         <a data-toggle="tab" href="#info" class="btn btn-primary">Information</a>
@@ -394,6 +401,11 @@
         </div>
     </div>
 </div>
+
+</div>
+</div>
+</div>
+
 {% if editable %}
 <div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
     <div class="modal-dialog">


### PR DESCRIPTION
## Problems

- The descriptions on the mod page are very wide on a wide screen, which is not a good use of that space since your eye has to trace very far to read from the end of one line to the beginning of the next:
  ![image](https://user-images.githubusercontent.com/19575360/131613636-53d25420-928b-4575-81e3-65297b6b0e63.png)
- Source code links on the mod page can be "cut off" if they are too long, which does not seem necessary given the available space:
  ![image](https://user-images.githubusercontent.com/1559108/140654579-be025c55-ca92-4c33-b4ab-e8d5cd37d4f3.png)

## Changes

- Now if the browser window is 1200px or wider (which Bootstrap defines as `lg`, the largest scale that it recognizes), the information/changelog/stats tabs and their contents appear at the right instead of the bottom, so we take advantage of wide screens and make the description text easier to read
- Now source code links will wrap beneath their label instead of being cut off

![image](https://user-images.githubusercontent.com/1559108/140654278-afb8bf9e-aa5e-468b-8492-0084aaf3b562.png)

Fixes #390.