### PR TITLE
Fix mobile hamburger menu and search

### DIFF
--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -1076,7 +1076,7 @@ a.gamename, a.gamename:hover {
     color: #333333;
 }
 
-@media (max-width: 750px) {
+@media (max-width: 767px) {
     ul.nav li.dropdown ul.dropdown-menu {
         display: block;
         clear: both;
@@ -1089,7 +1089,7 @@ a.gamename, a.gamename:hover {
         display: none;
     }
 
-    div.collapse.navbar-collapse {
+    div.in.navbar-collapse {
         bottom: 0;
         max-height: 100%;
         background-color: rgba(25, 25, 25, .9);
@@ -1097,7 +1097,6 @@ a.gamename, a.gamename:hover {
 
     form.navbar-form.navbar-search div.form-group input.form-control.search-box {
         width: 100%;
-        float: left;
     }
 
     .logoimg {

--- a/frontend/styles/navigation.scss
+++ b/frontend/styles/navigation.scss
@@ -1,7 +1,10 @@
-.navbar ::-webkit-input-placeholder {color: #fff;}
-.navbar :-moz-placeholder {color: #fff;}
-.navbar ::-moz-placeholder {color: #fff;}
-.navbar :-ms-input-placeholder {color: #fff;}  
+.navbar ::-webkit-input-placeholder,
+.navbar :-moz-placeholder,
+.navbar ::-moz-placeholder,
+.navbar :-ms-input-placeholder {
+.navbar ::placeholder {
+    color: #ddd;
+}
 
 .navbar {
   margin-bottom: 0;
@@ -92,10 +95,6 @@
     z-index:3
 }
 
-.navbar-form {
-    float:right
-}
-
 .dropdown-menu > li > a {
     color:#fff
 }
@@ -170,7 +169,11 @@
     color:#333
 }
 
-@media (min-width:767px) {
+@media (min-width: 768px) {
+    .navbar-form {
+        float: right;
+    }
+
     .navbar {
         padding:0;
         border-bottom:0;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -83,72 +83,48 @@
                     </a>
                 </div>
                 <div class="collapse navbar-collapse" id="navbar-collapse">
-                    {% if not user %}
                     <ul class="nav navbar-nav navbar-right">
                         <li class="dropdown">
-                            <a class="dropdown-toggle" data-toggle="dropdown" href="#"   ><span class="glyphicon glyphicon-menu-hamburger"></span></a>
-                            <ul class="dropdown-menu" >
-                                <li>
-                                    <a href="#" data-toggle="modal" data-target="#loginModal">Login</a>
-                                </li>
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% if user %}Welcome, {{ user.username }} {% endif %}<span class="glyphicon glyphicon-menu-hamburger"></span></a>
+                            <ul class="dropdown-menu{% if admin %} dropdown-menu-admin{% endif %}" >
+                                {% if not user %}
+                                <li><a href="#" data-toggle="modal" data-target="#loginModal">Login</a></li>
                                 {% if registration %}
                                 <li><a href="{{ url_for("accounts.register") }}">Register</a></li>
                                 {% endif %}
                                 <li class="divider"></li>
+                                {% endif %}
+                                <li><a href="/random">Random Mod</a></li>
+                                <li><a href="/blog">Blog</a></li>
+                                <li class="divider"></li>
                                 <li><a href="{{ donation_link }}" target="_BLANK">Donate</a></li>
+                                {% if user %}
                                 <li class="divider"></li>
-                                <li><a href="/random">Random Mod</a></li>
-                                <li><a href="/blog">Blog</a></li>
-                            </ul>
-                        </li>
-                    </ul>
-                    {% else %}
-                    <ul class="nav navbar-nav navbar-right">
-                        <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Welcome, {{ user.username }} <span class="glyphicon glyphicon-menu-hamburger"></span></a>
-                            <ul class="dropdown-menu{% if user and user.admin %} dropdown-menu-admin{% endif %}" >
-                                <li><a href="/random">Random Mod</a></li>
-                                <li><a href="/blog">Blog</a></li>
-                                <li class="divider"></li>
-                                <li><a href="{{ donation_link }}">Donate</a></li>
-                                <li class="divider"></li>
-                                <li>
-                                    <a href="/create/mod">
-                                        <span class="glyphicon glyphicon-open"></span> Create a New Mod
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="/create/pack">
-                                        <span class="glyphicon glyphicon-list"></span> Create a New Pack
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ url_for("profile.view_profile", username=user.username) }}">
-                                        <span class="glyphicon glyphicon-user"></span> View Your Profile
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ url_for("profile.profile", username=user.username) }}">
-                                        <span class="glyphicon glyphicon-pencil"></span> Edit Your Profile
-                                    </a>
-                                </li>
+                                <li><a href="/create/mod">
+                                    <span class="glyphicon glyphicon-open"></span> Create a New Mod
+                                </a></li>
+                                <li><a href="/create/pack">
+                                    <span class="glyphicon glyphicon-list"></span> Create a New Pack
+                                </a></li>
+                                <li><a href="{{ url_for("profile.view_profile", username=user.username) }}">
+                                    <span class="glyphicon glyphicon-user"></span> View Your Profile
+                                </a></li>
+                                <li><a href="{{ url_for("profile.profile", username=user.username) }}">
+                                    <span class="glyphicon glyphicon-pencil"></span> Edit Your Profile
+                                </a></li>
                                 {% if admin %}
-                                <li>
-                                    <a href="{{ url_for("admin.admin_main") }}">
-                                        <span class="glyphicon glyphicon-fire"></span> Admin Stuff
-                                    </a>
-                                </li>
+                                <li><a href="{{ url_for("admin.admin_main") }}">
+                                    <span class="glyphicon glyphicon-fire"></span> Admin Stuff
+                                </a></li>
                                 {% endif %}
                                 <li class="divider"></li>
-                                <li>
-                                    <a href="{{ url_for("accounts.logout") }}">
-                                        <span class="glyphicon glyphicon-remove"></span> Log Out
-                                    </a>
-                                </li>
+                                <li><a href="{{ url_for("accounts.logout") }}">
+                                    <span class="glyphicon glyphicon-remove"></span> Log Out
+                                </a></li>
+                                {% endif %}
                             </ul>
                         </li>
                     </ul>
-                    {% endif %}
                     {% block search %}
                     <form class="navbar-form navbar-search" role="search" action="{% if ga %}/{{ ga.short }}{% endif %}/search" method="GET">
                         <div class="form-group">


### PR DESCRIPTION
## Problems

- The search box is positioned weirdly for logged out users, floating in space off to the right:
  ![image](https://user-images.githubusercontent.com/1559108/140977990-48ce4546-061a-46df-b780-fa5312028138.png)
  For logged in users it is not visible (and Log Out is missing too):
  ![image](https://user-images.githubusercontent.com/1559108/140977629-a0ca6c36-5b09-466e-9d92-81ec2faa04e1.png)
  ... unless you scroll down, when it is revealed to also be floating in space to the right:
  ![image](https://user-images.githubusercontent.com/1559108/141010899-b8774728-1de1-4399-ba71-fb5dc3739a59.png)
- The menu items are inconsistent for the two groups of users (donate before random vs. donate after blog; donate opens a new window in one case but not the other)
- There are some subtle inconsistencies regarding when various styles switch from desktop to mobile
- The placeholder text in the search box is oddly bright, usually this is a dimmer color than a real text value to de-emphasize it

## Causes

- Bootstrap sets the max height of `.navbar-fixed-top .navbar-collapse` to 340px, which is smaller than our menu
  - `bootstrap-theme.css` was applying styles to `div.collapse.navbar-collapse`, which is an invisible element, so some changes intended to fix this had no effect
- The search form floats right, which takes it out of its container's extent
- The search box floats left, which takes it out of its container's extent
- There are two independent copies of the menu for logged in and logged out users, which has caused the contents of the menus to diverge over time
- Bootstrap treats a 768px or wider window as desktop, but some of our styles use 750px or 767px instead
- The placeholder text color is set to `#fff` in `navigation.scss`

## Changes

- Now `bootstrap-theme.css` applies styles to `div.in.navbar-collapse`, as probably originally intended, to override the menu's default max height and display the whole thing without scrolling
- Now the search form no longer floats right on mobile, to make it full width
- Now the search box no longer floats left on mobile, to make its container expand to fit it
- Now the logged in and logged out hamburger menus are merged and more consistent
- Now all the styles that are for mobile use `max-width: 767px` and all the styles for larger layouts use `min-width: 768px` for consistency
- Now the search placeholder is slightly dimmer (`#ddd` instead of `#fff`)

![image](https://user-images.githubusercontent.com/1559108/141030817-333369db-4efd-4059-813e-fa68d4e00380.png)

Fixes #130.