### PR TITLE
Allow mod authors to replace downloads

### DIFF
--- a/KerbalStuff/purge.py
+++ b/KerbalStuff/purge.py
@@ -1,0 +1,44 @@
+from socket import socket
+from typing import Union, Tuple
+
+import threading
+import dns.resolver
+import requests
+from urllib3.util import connection
+
+from .config import _cfg
+
+_orig_create_connection = connection.create_connection
+_create_connection_mutex = threading.Lock()
+
+
+def purge_download(download_path: str) -> None:
+    protocol = _cfg('protocol')
+    cdn_domain = _cfg('cdn-domain')
+    if protocol and cdn_domain:
+        global _create_connection_mutex
+        # Only one thread is allowed to mess with connection.create_connection at a time
+        with _create_connection_mutex:
+            connection.create_connection = create_connection_cdn_purge  # type: ignore[assignment]
+            try:
+                requests.request('PURGE',
+                                 protocol + '://' + cdn_domain + '/' + download_path)
+            except requests.exceptions.RequestException:
+                pass
+            global _orig_create_connection
+            connection.create_connection = _orig_create_connection
+
+
+def create_connection_cdn_purge(address: Tuple[str, Union[str, int, None]], *args: str, **kwargs: int) -> socket:
+    # Taken from https://stackoverflow.com/a/22614367
+    host, port = address
+
+    cdn_internal = _cfg('cdn-internal')
+    cdn_domain = _cfg('cdn-domain')
+    if cdn_internal and cdn_domain and cdn_domain.startswith(host):
+        result = dns.resolver.resolve(cdn_internal)
+        host = result[0].to_text()
+
+    global _orig_create_connection
+    assert callable(_orig_create_connection)
+    return _orig_create_connection((host, port), *args, **kwargs)

--- a/frontend/coffee/mods.coffee
+++ b/frontend/coffee/mods.coffee
@@ -1,4 +1,37 @@
+dropzone = require('dropzone')
+
+dropzone.options.uploader =
+    chunking: true,
+    forceChunking: true,
+    parallelChunkUploads: false,
+    maxFiles: 1,
+    maxFilesize: 10000,
+    autoProcessQueue: false,
+    addRemoveLinks: true,
+    acceptedFiles: 'application/zip,.zip',
+    paramName: 'zipball',
+    url: '/api/mod/' + window.mod_id + '/edit_version',
+    headers: { 'Accept': 'application/json' },
+
+    params: (files, xhr, chunk) ->
+        return {
+            'dztotalchunkcount': chunk.file.upload.totalChunkCount,
+            'dzchunkindex': chunk.index,
+            'version-id': $('#version-edit-id').val(),
+            'changelog': $('#version-edit-changelog').val(),
+        }
+
+    maxfilesexceeded: (file) ->
+        dropzone.forElement('#uploader').removeFile(file)
+
+    success: (file) ->
+        window.location.reload()
+
+    error: (file, errorMessage, xhr) ->
+        alert errorMessage.reason
+
 window.activateStats()
+
 edit.addEventListener('click', (e) ->
     e.preventDefault()
     p = e.target.parentElement.parentElement
@@ -6,9 +39,33 @@ edit.addEventListener('click', (e) ->
     c = p.querySelector('.raw-changelog').innerHTML
     m = document.getElementById('version-edit-modal')
     m.querySelector('.version-id').value = v
+    m.querySelector('.version-number').innerText = e.target.parentElement.dataset.friendly_version
     m.querySelector('.changelog-text').innerHTML = c
+    dz = dropzone.forElement('#uploader')
+    dz.removeAllFiles(true)
     $(m).modal()
 , false) for edit in document.querySelectorAll('.edit-version')
+
+document.getElementById('submit-version-edit').addEventListener('click', () ->
+    dz = dropzone.forElement('#uploader')
+    if dz.getQueuedFiles().length == 0
+        xhr = new XMLHttpRequest()
+        xhr.open('POST', '/api/mod/' + window.mod_id + '/edit_version')
+        xhr.setRequestHeader('Accept', 'application/json')
+        xhr.onload = () ->
+            response = JSON.parse(this.responseText)
+            if response.error
+                alert response.reason
+            else
+                window.location.reload()
+        data = new FormData()
+        data.append('version-id', $('#version-edit-id').val())
+        data.append('changelog', $('#version-edit-changelog').val())
+        xhr.send(data)
+    else
+        dz.processQueue()
+, false)
+
 
 edit.addEventListener('click', (e) ->
     e.preventDefault()

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -1,6 +1,7 @@
 @import 'stylesheet';
 @import 'timeline';
 @import 'listing';
+@import "~dropzone/dist/dropzone";
 
 .header {
     background-position: center center;
@@ -224,4 +225,15 @@
 .following-mod .unfollow-mod-button,
 .not-following-mod .follow-mod-button {
     display: block;
+}
+
+.upload-mod {
+    border: 5px dotted #ccc;
+    background: inherit;
+    font-size: x-large;
+    a, p {
+        &:hover {
+            text-decoration: none;
+        }
+    }
 }

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -277,7 +277,7 @@
                 {% endif %}
                 {% if admin %}
                 {% if not mod.locked %}
-                <a href="#" data-toggle="modal" data-target="#confirm-lock" class="btn btn-danger btn-block btn-lg">Lock this Mod</a>
+                <button type="button" data-toggle="modal" data-target="#confirm-lock" class="btn btn-danger btn-block btn-lg">Lock this Mod</button>
                 {% else %}
                 <form action="{{ url_for("mods.unlock", mod_id=mod.id) }}" method="POST">
                 <input type="submit" class="btn btn-danger btn-block btn-lg" value="Unlock this Mod (locked by {{ mod.locked_by.username }})">
@@ -344,7 +344,7 @@
                             {% else %}
                             {{ v.changelog | markdown | bleach }}
                             {% endif %}
-                            <p data-version="{{ v.id }}">
+                            <p data-version="{{ v.id }}" data-friendly_version="{{ v.friendly_version }}">
                                 <a class="btn btn-primary piwik_download" href="{{ url_for("mods.download", mod_id=mod.id, mod_name=mod.name, version=v.friendly_version) }}">
                                     <span class="glyphicon glyphicon-save"></span> Download {% if v.id in size_versions and size_versions[v.id] is not none %} ({{ size_versions[v.id] }}) {% endif %}
                                 </a>
@@ -357,7 +357,7 @@
                                     <span class="glyphicon glyphicon-trash"></span> Delete
                                 </button>
                                 {% endif %}
-                                <span class="hidden raw-changelog">{{ v.changelog }}</span>
+                                <span class="hidden raw-changelog">{% if v.changelog %}{{ v.changelog }}{% endif %}</span>
                                 {% if v.id != latest.id %}
                                 <button class="set-default-version btn btn-danger">
                                     <span class="glyphicon glyphicon-ok"></span> Set as default
@@ -420,7 +420,7 @@
             </div>
             <div class="modal-footer">
                 <form action="/mod/{{ mod.id }}/delete" method="POST">
-                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                     <input type="submit" class="btn btn-danger" value="Delete Mod">
                 </form>
             </div>
@@ -430,21 +430,27 @@
 <div class="modal fade" id="version-edit-modal" tabindex="-1" role="dialog" aria-labelledby="version-edit-modal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form action="/mod/{{ mod.id }}/edit_version" method="POST" enctype="multipart/form-data">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Edit Version <span class="version-number"></span></h4>
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="myModalLabel">Edit Version <span class="version-number"></span></h4>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="changelog" class="control-label">You may edit your changelog here:</label>
+                    <textarea id="version-edit-changelog" class="changelog-text form-control input-block-level" rows=8 name="changelog"></textarea>
                 </div>
-                <div class="modal-body">
-                    <p>You may edit your changelog here:</p>
-                    <textarea class="changelog-text form-control input-block-level" rows=8 name="changelog"></textarea>
-                    <input type="hidden" class="version-id" name="version-id">
+                <div class="form-group">
+                    <label class="control-label">You may replace the download here:</label>
+                    <form id="uploader" class="dropzone upload-mod">
+                        <p class="dz-message">Drag and drop or click to browse</p>
+                    </form>
                 </div>
-                <div class="modal-footer">
-                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
-                    <input type="submit" class="btn btn-primary" value="Save Edit">
-                </div>
-            </form>
+                <input type="hidden" id="version-edit-id" class="version-id" name="version-id">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <input type="submit" id="submit-version-edit" class="btn btn-primary" value="Save Edit">
+            </div>
         </div>
     </div>
 </div>
@@ -462,7 +468,7 @@
                     {{ mod.follower_count }} followers to tell them the good news. Sounds good?</p>
                 </div>
                 <div class="modal-footer">
-                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                     <input type="submit" class="btn btn-danger" value="Confirm">
                 </div>
             </form>
@@ -482,7 +488,7 @@
                     Are you sure you wish to continue?</p>
                 </div>
                 <div class="modal-footer">
-                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                     <input type="submit" class="btn btn-danger" value="Confirm">
                 </div>
             </form>
@@ -507,7 +513,7 @@
                     <textarea id="reason" class="form-control input-block-level" style="resize: vertical" rows="8" maxlength="1024" name="reason"></textarea>
                 </div>
                 <div class="modal-footer">
-                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                     <input type="submit" class="btn btn-danger" value="Lock Mod">
                 </div>
             </form>


### PR DESCRIPTION
## Motivation

Sometimes some mod authors build their mods incorrectly and then upload them to SpaceDock without checking them. Currently the remedy for this would be to delete that mod version and then create it again, which is a lot of steps, and I don't think you can do that when there's only one version.

## Changes

Now the version editing popup has a Dropzone control:

![image](https://user-images.githubusercontent.com/1559108/141176674-be639cc5-36f9-4caf-92c8-e2aaf0a4a795.png)

If the user doesn't select a new file, then clicking Save Edit will update the changelog and leave the download as it is.
If the user uses this field to select a new ZIP, then clicking Save Edit will upload it as a replacement for the current file:

1. The old file is deleted from storage
2. A `PURGE` is sent to the CDN to purge the old file from the download cache (see #313)
3. The new file is saved to the path where the old file used to be
4. The mod updated timestamp and mod version created timestamp are set to now (so the CKAN bot will know the file is new)
5. The mod version download size is updated to reflect the new file

Fixes #184.

### Side fixes

- A blank changelog is no longer loaded as "None" when editing a version
- Several of the buttons on the mod page were changing the active tab to info unintentionally, because they use `<a href="#"`, which changes the tab back if it's changelog or stats. These buttons are now `<button type="button"`, which doesn't do that.
- The version editing popup now shows the version number being edited in its title