### PR TITLE
Scan uploads with pyclamd

### DIFF
--- a/KerbalStuff/antivirus.py
+++ b/KerbalStuff/antivirus.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+from shutil import move
+from typing import Optional
+
+import pyclamd
+
+from .config import _cfg, _cfgi, site_logger
+from .objects import User
+from .email import send_mod_locked
+from .ckan import notify_ckan
+
+clam_daemon = None
+
+
+def file_contains_malware(where: str) -> bool:
+    global clam_daemon
+    try:
+        if not clam_daemon:
+            clam_daemon = pyclamd.ClamdNetworkSocket(host=_cfg('clamav-host'), port=_cfgi('clamav-port', 3310))
+        result = clam_daemon.scan_file(where)
+        if result:
+            site_logger.error(f'ClamAV says {where} contains malware')
+            return True
+    except Exception as exc:
+        # No ClamAV daemon found, log it and let the file through
+        site_logger.error(f'Failed to connect to ClamAV, skipping scan of {where}', exc_info=exc)
+    return False
+
+
+def quarantine_malware(path: str) -> None:
+    quarantine_folder = _cfg('clamav-quarantine-path')
+    if quarantine_folder:
+        move(path, Path(quarantine_folder) / Path(path).name)
+    else:
+        os.remove(path)
+
+
+def punish_malware(user: User) -> None:
+    # Lock all of this author's mods
+    for other_mod in user.mods:
+        if not other_mod.locked:
+            other_mod.locked = True
+            other_mod.published = False
+            other_mod.locked_by = None
+            other_mod.lock_reason = 'Malware detected in upload'
+            send_mod_locked(other_mod, user)
+            notify_ckan(other_mod, 'locked', True)

--- a/config.ini.example
+++ b/config.ini.example
@@ -115,3 +115,12 @@ notify-url=
 profile-dir=
 # If set to an integer, profile approximately 1 out of every this many requests (default 1)
 requests-per-profile=
+
+# Name of host where ClamAV daemon is running
+# Must have storage mounted at same absolute path we use!
+clamav-host=
+# Port where ClamAV daemon is running (default 3310 if host is set)
+clamav-port=
+# Path where uploads determined to have malware will be moved for admin inspection
+# If left empty, they will be deleted instead
+clamav-quarantine-folder=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,13 @@ services:
     networks:
       - spacedock-net
 
+  clamav:
+    image: clamav/clamav:latest
+    volumes:
+      - ./storage:/opt/spacedock/storage
+    networks:
+      - spacedock-net
+
   backend:
     image: spacedock_backend
     build:

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -20,6 +20,7 @@ oauthlib
 packaging
 Pillow
 psycopg2-binary
+pyclamd
 PyGithub
 python-daemon
 redis


### PR DESCRIPTION
## Motivation

See #404, we should scan user-uploaded files for malware. There previously was a nightly storage-wide scan, but it did not detect the EICAR file and so probably wasn't working correctly.

## Changes

Now if you set these settings to the location of a running `clamd` instance that can access the storage in your `config.ini` using the same absolute paths as the backend:

```ini
clamav-host=clamav
clamav-port=3310
clamav-quarantine-folder=/storage/quarantine
```

... then we use it to scan:

- Mod version ZIPs at upload
- Background images (just in case)

If a user is caught attempting to upload malware, the upload will fail, the file will be deleted, and all of that user's mods will be locked automatically with the lock reason "Malware detected in upload." After #419, admins will be able to find these mods in the admin pages to investigate; if it was a scanning error or some other non-malicious incident, the admins can then unlock them as needed.

![image](https://user-images.githubusercontent.com/1559108/141321348-e8151a19-67d2-42d5-862d-334d2d32d15c.png)

The `docker-compose.yml` file is updated so the `./start-server.sh` tool runs the `clamav/clamav:latest` instance at `clamav:3310` with the storage mounted, which will work with the settings shown above.

The backlog of already-uploaded files should be scanned carefully and correctly with `clamdscan` independently from these code changes. Make sure that @DasSkelett's [EICAR test file](https://spacedock.info/mod/2202/test/download/1.16) is caught and removed!

Fixes #404.