### PR TITLE
Option to profile everything, save data only for slow responses

### DIFF
--- a/KerbalStuff/middleware/profiler.py
+++ b/KerbalStuff/middleware/profiler.py
@@ -1,6 +1,11 @@
 from sys import stdout
+import os
 from os import access, W_OK
-from typing import Optional, Iterable, Union, Callable, TextIO, List, TYPE_CHECKING
+from time import time
+from datetime import timedelta, datetime
+from pstats import Stats
+from cProfile import Profile
+from typing import Optional, Iterable, Union, Callable, TextIO, List, TYPE_CHECKING, cast
 
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
@@ -40,3 +45,75 @@ class ConditionalProfilerMiddleware(ProfilerMiddleware):
 
         else:
             return super().__call__(environ, start_response)
+
+
+class CherrypickingProfilerMiddleware(ProfilerMiddleware):
+    def __init__(
+        self,
+        app: "WSGIApplication",
+        stream: Optional[TextIO] = stdout,
+        sort_by: Iterable[str] = ("time", "calls"),
+        restrictions: Iterable[Union[str, int, float]] = (),
+        profile_dir: Optional[str] = None,
+        filename_format: str = "{method}.{path}.{elapsed:.0f}ms.{time:.0f}.prof",
+        log_if_longer: Optional[timedelta] = None,
+    ) -> None:
+        super().__init__(app=app,
+                         stream=stream, sort_by=sort_by, # type: ignore[arg-type]
+                         restrictions=restrictions, profile_dir=profile_dir, filename_format=filename_format)
+        self._app = app
+        self._stream = stream
+        self._sort_by = sort_by
+        self._restrictions = restrictions
+        self._profile_dir = profile_dir
+        self._filename_format = filename_format
+        self._log_if_longer = log_if_longer or timedelta(seconds=1)
+
+    def __call__(self, environ: "WSGIEnvironment", start_response: "StartResponse") -> List[bytes]:
+        response_body: List[bytes] = []
+
+        def catching_start_response(status, headers, exc_info=None):  # type: ignore
+            start_response(status, headers, exc_info)
+            return response_body.append
+
+        def runapp() -> None:
+            app_iter = self._app(environ,
+                                 cast("StartResponse", catching_start_response))
+            response_body.extend(app_iter)
+
+            if hasattr(app_iter, "close"):
+                app_iter.close()  # type: ignore
+
+        profile = Profile()
+        start = time()
+        profile.runcall(runapp)
+        body = b"".join(response_body)
+        end = time()
+        elapsed = end - start
+
+        # Only save profiling data if slow
+        if datetime.fromtimestamp(end) - datetime.fromtimestamp(start) >= self._log_if_longer:
+
+            if self._profile_dir is not None:
+                if callable(self._filename_format):
+                    filename = self._filename_format(environ)
+                else:
+                    filename = self._filename_format.format(
+                        method=environ["REQUEST_METHOD"],
+                        path=environ["PATH_INFO"].strip("/").replace("/", ".") or "root",
+                        elapsed=elapsed * 1000.0,
+                        time=time(),
+                    )
+                filename = os.path.join(self._profile_dir, filename)
+                profile.dump_stats(filename)
+
+            if self._stream is not None:
+                stats = Stats(profile, stream=self._stream)
+                stats.sort_stats(*self._sort_by)
+                print("-" * 80, file=self._stream)
+                path_info = environ.get("PATH_INFO", "")
+                print(f"PATH: {path_info!r}", file=self._stream)
+                stats.print_stats(*self._restrictions)
+                print(f"{'-' * 80}\n", file=self._stream)
+
+        return [body]

--- a/config.ini.example
+++ b/config.ini.example
@@ -113,7 +113,10 @@ notify-url=
 
 # Path to store profiling runs, leave blank to turn off profiling
 profile-dir=
+# If set, profile all requests but only save the data if they take longer than this in milliseconds
+profile-threshold-ms=
 # If set to an integer, profile approximately 1 out of every this many requests (default 1)
+# (ignored if profile-threshold-ms is set)
 requests-per-profile=
 
 # Name of host where ClamAV daemon is running


### PR DESCRIPTION
## Motivation

See #409, with the merging of #414 and #416, all remaining known causes of responses slower than 300ms should be addressed. Once that is the case, it will be very boring and mostly useless to have a long list of randomly sampled responses in the 10–150ms range that do not need attention. If there are any routes left that are still slow, it will be rare for them to be randomly selected for profiling. We would need a different way to collect data to catch such responses.

## Changes

Now if you set this in `config.ini` (recommended!):

```ini
profile-threshold-ms=250
```

... then instead of randomly selecting a small fraction of responses for profiling, we will profile _all_ responses but only save data for the ones that take longer than the configured time. (If you set both `profile-threshold-ms` and `requests-per-profile`, `profile-threshold-ms` takes precedence and `requests-per-profile` is ignored.) This way the profiling list will become a collection of just slow responses that need attention, if any.

Fixes #409.