### PR TITLE
Paginated search buttons

### DIFF
--- a/templates/browse-list.html
+++ b/templates/browse-list.html
@@ -39,32 +39,35 @@
         {% include "mod-box.html" %}
     {% endfor %}
     </div>
-    <div style="margin-top: 5mm" class="row" style="margin-bottom:2.5mm;">
+    {%- if total_pages > 1 -%}
+    <div style="margin-top: 5mm" class="row vertical-centered" style="margin-bottom:2.5mm;">
         <div class="col-md-2">
-            {% if page != 1 %}
-            {% if search %}
-            {# TODO #}
-            {% else %}
-            <a href="{% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page - 1 }}"
-                class="btn btn-lg btn-primary btn-block">
+            {%- if page != 1 -%}
+            <a class="btn btn-lg btn-primary btn-block"
+                href="{%- if search -%}
+                {% if ga %}/{{ ga.short }}{% endif %}/search?query={{ query | escape }}&page={{ page - 1 }}
+                {%- else -%}
+                {% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page - 1 }}
+                {%- endif -%}">
                 <span class="glyphicon glyphicon-arrow-left"></span> Previous
             </a>
-            {% endif %}
-            {% endif %}
+            {%- endif -%}
         </div>
-        <div class="col-md-2 col-md-offset-8">
-            {% if page < total_pages %}
-            {% if search %}
-            {# TODO #}
-            {% else %}
-            <a href="{% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page + 1 }}"
+        <div class="col-md-8 centered text-muted">Page {{ page }} / {{ total_pages }}</div>
+        <div class="col-md-2">
+            {%- if page < total_pages -%}
+            <a href="{%- if search -%}
+                {% if ga %}/{{ ga.short }}{% endif %}/search?query={{ query | escape }}&page={{ page + 1 }}
+                {%- else -%}
+                {% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page + 1 }}
+                {%- endif -%}"
                 class="btn btn-lg btn-primary btn-block">
                 Next <span class="glyphicon glyphicon-arrow-right"></span>
             </a>
-            {% endif %}
-            {% endif %}
+            {%- endif -%}
         </div>
     </div>
+    {%- endif -%}
 </div>
 <div class="modal fade" id="advanced-modal" tabindex="-1">
     <div class="modal-dialog">


### PR DESCRIPTION
## Problem

Searches only return one page (30 mods):

- https://spacedock.info/search?query=space
- https://spacedock.info/kerbal-space-program/search?query=space

If you're searching for a common term, the mod you want may not be on the first page, but there's no obvious way to view more pages. If you manually add a `&page=` parameter to a search URL, the backend route supports pagination already:

- https://spacedock.info/kerbal-space-program/search?query=space&page=2
- https://spacedock.info/kerbal-space-program/search?query=space&page=3
- https://spacedock.info/kerbal-space-program/search?query=space&page=4

Since this pull request was submitted, two users on the SpaceDock forum thread have requested it.

## Cause

The `browse-list.html` template has two `{#  TODO #}` blocks where search pagination should be:

https://github.com/KSP-SpaceDock/SpaceDock/blob/0755ae0324d17b02512e9463e31c008e07174f00/templates/browse-list.html#L42-L67

The `/search` routes indeed have code to support pagination already:

https://github.com/KSP-SpaceDock/SpaceDock/blob/4dee33b09072e018cd3f47954f9393a153e55eef/KerbalStuff/blueprints/anonymous.py#L255-L267

https://github.com/KSP-SpaceDock/SpaceDock/blob/4dee33b09072e018cd3f47954f9393a153e55eef/KerbalStuff/common.py#L159-L169

https://github.com/KSP-SpaceDock/SpaceDock/blob/4dee33b09072e018cd3f47954f9393a153e55eef/KerbalStuff/search.py#L107-L112

## Changes

Now the `{# TODO #}` blocks are replaced by previous and next page buttons, which you can click to move between pages of a search.

In addition, all paginated mod lists now have a "Page X / Y" label centered between the pagination buttons, so you can more easily see where you are in the list.

![image](https://user-images.githubusercontent.com/1559108/141519208-cb3da1ff-ccc9-487f-9f20-bd486bac5668.png)
