### PR TITLE
Quoted and negated search terms, up front search help

### DIFF
--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -63,6 +63,12 @@ $('#alert-error').on 'close.bs.alert', () ->
     $('#alert-error').addClass 'hidden'
     return false
 
+$('.search-tips-button').on 'click', (e) ->
+    $('.search-tips').addClass 'search-tips-visible'
+
+$('.search-tips').on 'click', (e) ->
+    $('.search-tips').removeClass 'search-tips-visible'
+
 link.addEventListener('click', (e) ->
     e.preventDefault()
     xhr = new XMLHttpRequest()

--- a/frontend/styles/navigation.scss
+++ b/frontend/styles/navigation.scss
@@ -199,3 +199,53 @@
     text-decoration:none;
     background-color:transparent
 }
+
+.search-tips {
+    font: 4mm "glacial_indifferenceregular";
+    text-transform: none;
+    letter-spacing: normal;
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    position: absolute;
+    top: 55px;
+    @media (max-width: 767px) {
+        left: 2px;
+        right: 2px;
+    }
+    @media (min-width: 768px) {
+        left: 15%;
+        right: 30%;
+    }
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0.5s, opacity 0.5s ease;
+    code {
+        white-space: nowrap;
+    }
+}
+
+.search-tips-button {
+    float: left;
+}
+
+.search-tips-visible {
+    visibility: visible;
+    opacity: 1;
+}
+
+@media (max-width: 767px) {
+    form.navbar-form.navbar-search div.form-group input.form-control.search-box {
+        margin-left: 1ex;
+        width: auto;
+    }
+}
+
+@media (min-width: 768px) {
+    /* On mobile you get a button. On desktop you get hover. */
+    .search-tips-button {
+        display: none;
+    }
+    #form-mod-search:focus-within .search-tips {
+        visibility: visible;
+        opacity: 1;
+    }
+}

--- a/templates/browse-list.html
+++ b/templates/browse-list.html
@@ -9,13 +9,6 @@
 <title>{{ name }} on {{ site_name }}</title>
 {% endif %}
 {% endblock %}
-{% block search %}
-<form class="navbar-form navbar-right" role="search" action="{% if ga %}/{{ ga.short }}{% endif %}/search" method="GET" style="margin-right: 2.5mm;">
-    <div class="form-group">
-        <input type="text" class="form-control search-box" name="query" placeholder="Search mods..." value="{{query}}">
-    </div>
-</form>
-{% endblock %}
 {% block body %}
 <div class="well">
     <div class="container main-cat">
@@ -23,7 +16,6 @@
         <a href="{% if ga %}/{{ ga.short }}{% endif %}{{ rss }}" class="pull-right"><img src="/static/rss.png" height=38 /></a>
         {% endif %}
         {% if search %}
-        <a href="#" class="pull-right btn btn-primary" data-toggle="modal" data-target="#advanced-modal">Advanced Search</a>
         <h3>Search results for "{{ query }}"</h3>
         {% else %}
         <h3>{{ name }}</h3>
@@ -63,31 +55,6 @@
             </a>
             {% endif %}
             {% endif %}
-        </div>
-    </div>
-</div>
-<div class="modal fade" id="advanced-modal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
-                <h4 class="modal-title">Advanced Search</h4>
-            </div>
-            <div class="modal-body">
-                <p>By using special search terms, you can narrow your results. Try these:</p>
-                <ul>
-                    <li><code>user:[author]</code> for mods by [author]</li>
-                    <li><code>ver:[version]</code> for mods compatible with [version]</li>
-                    <li><code>game:[game]</code> for mods for [game]</li>
-                    <li><code>downloads:&gt;[count]</code> for mods with at least [count] downloads</li>
-                    <li><code>downloads:&lt;[count]</code> for mods with fewer than [count] downloads</li>
-                    <li><code>followers:&gt;[count]</code> for mods with at least [count] followers</li>
-                    <li><code>followers:&lt;[count]</code> for mods with fewer than [count] followers</li>
-                </ul>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal">Got it</button>
-            </div>
         </div>
     </div>
 </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -150,9 +150,55 @@
                     </ul>
                     {% endif %}
                     {% block search %}
-                    <form class="navbar-form navbar-search" role="search" action="{% if ga %}/{{ ga.short }}{% endif %}/search" method="GET">
-                        <div class="form-group">
-                            <input type="text" class="form-control search-box" name="query" placeholder="Search mods...">
+                    <form id="form-mod-search" class="navbar-form navbar-search" role="search" action="{% if ga %}/{{ ga.short }}{% endif %}/search" method="GET">
+                        <div class="form-group vertical-centered">
+                            <a href="#" class="search-tips-button">
+                                <span class="glyphicon glyphicon-question-sign"></span>
+                            </a>
+                            <input type="text" class="form-control search-box" name="query" placeholder="Search mods..." required{% if query %} value="{{ query | trim | escape }} "{% endif %}>
+                            <div id="search-tips" class="search-tips alert alert-info">
+                                <h3>Advanced search:</h3>
+                                <table class="table table-condensed">
+                                    <tbody>
+                                        <tr>
+                                            <td><code>"term in quotes"</code></td>
+                                            <td>For terms with spaces</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>-term</code></td>
+                                            <td>Exclude mods matching <code>term</code>, which can be a word or another advanced term</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>user:[author]</code></td>
+                                            <td>For mods by [author]</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>ver:[version]</code></td>
+                                            <td>For mods compatible with [version], can be either the full version number or a partial prefix, e.g. <code>ver:1.12</code> matches 1.12.0, 1.12.1, and 1.12.2</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>game:[game]</code></td>
+                                            <td>For mods for [game], by number or part of name</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>downloads:&gt;[count]</code></td>
+                                            <td>For mods with at least [count] downloads</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>downloads:&lt;[count]</code></td>
+                                            <td>For mods with fewer than [count] downloads</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>followers:&gt;[count]</code></td>
+                                            <td>For mods with at least [count] followers</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>followers:&lt;[count]</code></td>
+                                            <td>For mods with fewer than [count] followers</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </form>
                     {% endblock %}


### PR DESCRIPTION
## Problems

- Currently you can't search for a string that contains a space
- Currently you can't exclude a term from a search
- If you want to search by game, you have to know its id number in the db, and attempting to search by a `game:string` value throws a 500 server error
- The `ver:` search term only supports exact matches on the full version string, so you have to type it many times to match larger version ranges
- The advanced search tips are not visible when you start typing your first search, instead you have to submit the search and then notice that there's an "Advanced Search" button, then click that button, and _then_ you can see the tips, but you have to dismiss them again to actually enter your search, so you can't easily double check what you want to search for
- The search box allows you to submit an empty search

## Causes

- The search logic just splits the search string on space to get the separate terms
- There's no negation logic in the search
- The game search forcibly casts its parameter with `int()` regardless of whether it's numeric, so an exception is thrown if it isn't
- The `ver:` search just checks for equality of its argument and game versions
- The advanced tip popup is in `browse-list.html`, which is only loaded if you've already done a search, and it uses a modal popup instead of something that can be visible while the user is editing the search
- Nothing checks whether your search is empty

## Changes

- Now we tokenize the search with a regex that allows `"quotes around terms"` to include spaces
- Now if you take any search term (including with quotes or some other prefix) and add a `-` prefix to it, then mods that match that term will be excluded instead of included
- Now `game:` searches with a numeric argument will search by id as before, but otherwise the argument will be treated as a substring of the game (e.g. `game:kerbal` will now work instead of crashing)
- Now `ver:` will match versions that either exactly match its argument or match its argument followed by a period and optionally more characters, so `ver:1.12` will match all of the 1.12.x releases
- Now the advanced tips display as soon as you click in the search box and remain visible while you edit a search, and they include the new features listed above:
  ![image](https://user-images.githubusercontent.com/1559108/141604262-adc3a203-7c3d-4d1e-b063-50591b815663.png)
- On mobile, nothing happens on focus, but you get a `?` button before the search box that can be clicked to show the tips full-screen, which can be dismissed by clicking inside the tips box
  ![image](https://user-images.githubusercontent.com/1559108/141693322-b8a7b21f-f710-406f-9ac1-3255e82cb61b.png)
  (Note that #427 is making some fixes to how this search box displays, so it may look bad until both pull requests are combined.)
- Now the search box has the `required` attribute and will only submit when it has a value

Fixes #142.