### PR TITLE
Upgrade to Flask 2

### DIFF
--- a/KerbalStuff/blueprints/login_oauth.py
+++ b/KerbalStuff/blueprints/login_oauth.py
@@ -66,8 +66,6 @@ def get_github_oath() -> Tuple[str, OAuthRemoteApp]:
     if resp is None:
         raise Exception(
             f"Access denied: reason={request.args['error']} error={request.args['error_description']}")
-    if 'error' in resp:
-        return jsonify(resp)
     session['github_token'] = (resp['access_token'], '')
     gh_info = github.get('user').data
     return gh_info['login'], github

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -127,25 +127,6 @@ def json_output(f: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def cors(f: Callable[..., Any]) -> Callable[..., Any]:
-    @wraps(f)
-    def wrapper(*args: str, **kwargs: int) -> Tuple[str, int]:
-        res = f(*args, **kwargs)
-        if request.headers.get('x-cors-status', False):
-            if isinstance(res, tuple):
-                json_text = res[0].data
-                code = res[1]
-            else:
-                json_text = res.data
-                code = 200
-            o = json.loads(json_text)
-            o['x-status'] = code
-            return jsonify(o)
-        return res
-
-    return wrapper
-
-
 def paginate_query(query: Query, page_size: int = 30) -> Tuple[List[Mod], int, int]:
     total_pages = math.ceil(query.count() / page_size)
     page = get_page()

--- a/KerbalStuff/database.py
+++ b/KerbalStuff/database.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm import scoped_session, sessionmaker, declarative_base
 
 from .config import _cfg
 

--- a/KerbalStuff/kerbdown.py
+++ b/KerbalStuff/kerbdown.py
@@ -1,11 +1,11 @@
 import urllib.parse
 from urllib.parse import parse_qs, urlparse
-from typing import Dict, Any, Match, Tuple
+from typing import Dict, Any, Match, Tuple, Optional
 
 from markdown import Markdown
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
-from markdown.util import etree
+from xml.etree import ElementTree
 
 
 class EmbedInlineProcessor(InlineProcessor):
@@ -23,18 +23,19 @@ class EmbedInlineProcessor(InlineProcessor):
         super().__init__(self.EMBED_RE, md)
         self.config = configs
 
-    def handleMatch(self, m: Match[str], data: str) -> Tuple[etree.Element, int, int]:  # type: ignore[override]
+    def handleMatch(self, m: Match[str], data: str) -> Tuple[ElementTree.Element, int, int]:  # type: ignore[override]
         d = m.groupdict()
         url = d.get('url')
+        el: Optional[ElementTree.Element]
         if not url:
-            el = etree.Element('span')
+            el = ElementTree.Element('span')
             el.text = "[[]]"
             return el, m.start(0), m.end(0)
         try:
             link = urlparse(url)
             host = link.hostname
         except:
-            el = etree.Element('span')
+            el = ElementTree.Element('span')
             el.text = "[[" + url + "]]"
             return el, m.start(0), m.end(0)
         el = None
@@ -44,7 +45,7 @@ class EmbedInlineProcessor(InlineProcessor):
         except:
             pass
         if el is None:
-            el = etree.Element('span')
+            el = ElementTree.Element('span')
             el.text = "[[" + url + "]]"
         return el, m.start(0), m.end(0)
 
@@ -52,8 +53,8 @@ class EmbedInlineProcessor(InlineProcessor):
         return (link.path if link.netloc == 'youtu.be'
                 else parse_qs(link.query)['v'][0])
 
-    def _embed_youtube(self, vid_id: str) -> etree.Element:
-        el = etree.Element('iframe')
+    def _embed_youtube(self, vid_id: str) -> ElementTree.Element:
+        el = ElementTree.Element('iframe')
         el.set('width', '100%')
         el.set('height', '600')
         el.set('frameborder', '0')

--- a/KerbalStuff/stubs/jinja2.pyi
+++ b/KerbalStuff/stubs/jinja2.pyi
@@ -1,8 +1,0 @@
-
-from jinja2.environment import Template as Template
-
-class Undefined:
-    ...
-
-class ChainableUndefined(Undefined):
-    ...

--- a/alembic/versions/2020_06_23_17_49_36-85be165bc5dc.py
+++ b/alembic/versions/2020_06_23_17_49_36-85be165bc5dc.py
@@ -10,8 +10,7 @@ from datetime import datetime
 
 from packaging import version
 from sqlalchemy import orm, Column, Integer, Unicode, DateTime, String, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship, backref, declarative_base
 
 # revision identifiers, used by Alembic.
 revision = '85be165bc5dc'

--- a/alembic/versions/2020_07_20_19_00_00-73c9d707134b.py
+++ b/alembic/versions/2020_07_20_19_00_00-73c9d707134b.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from alembic import op
 import sqlalchemy as sa
 
-Base = sa.ext.declarative.declarative_base()
+Base = sa.orm.declarative_base()
 
 
 class ModVersion(Base):  # type: ignore

--- a/alembic/versions/2021_06_28_19_00_00-17fbd4ff8193.py
+++ b/alembic/versions/2021_06_28_19_00_00-17fbd4ff8193.py
@@ -13,7 +13,7 @@ down_revision = '426e0b848d77'
 from alembic import op
 import sqlalchemy as sa
 
-Base = sa.ext.declarative.declarative_base()
+Base = sa.orm.declarative_base()
 
 
 class User(Base):  # type: ignore

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -6,14 +6,14 @@ celery
 click
 dnspython
 flameprof
-Flask<2 # Needs testing before upgrading
+Flask
 Flask-Login
 Flask-Markdown
 Flask-OAuthlib
 future
 GitPython
 gunicorn
-Jinja2<3 # See Flask
+Jinja2
 Markdown
 MarkupSafe
 oauthlib

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,8 +4,6 @@ flask-api
 flask-testing
 types-Markdown
 types-bleach
-types-Flask
-types-Jinja2
 types-Markdown
 types-MarkupSafe
 types-Werkzeug

--- a/spacedock
+++ b/spacedock
@@ -33,8 +33,8 @@ def wait_database():
     from sqlalchemy.engine.url import URL
     site_logger.info('Waiting for database to come online...')
     u = engine.url
-    pg_engine = create_engine(URL(u.drivername, u.username, u.password, 
-                                  u.host, u.port))
+    pg_engine = create_engine(URL.create(u.drivername, u.username, u.password,
+                                         u.host, u.port))
     while True:
         try:
             connection = pg_engine.connect()

--- a/tests/fixtures/fake_config.py
+++ b/tests/fixtures/fake_config.py
@@ -10,5 +10,7 @@ config[env]['connection-string'] = 'sqlite:///:memory:'
 config[env]['protocol'] = 'https'
 config[env]['domain'] = 'tests.spacedock.info'
 config[env]['ksp-game-id'] = '1'
+if 'profile-dir' in config[env]:
+    del config[env]['profile-dir']
 
 dummy = ''

--- a/tests/test_api_browse.py
+++ b/tests/test_api_browse.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
-from flask_api import status
+from http import HTTPStatus
 
 from .fixtures.client import client
 from KerbalStuff.objects import Publisher, Game, GameVersion, User, Mod, ModVersion
@@ -21,14 +21,14 @@ def test_api_browse(client: 'FlaskClient[Response]') -> None:
     featured_resp = client.get('/api/browse/featured')
 
     # Assert
-    assert browse_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert browse_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     assert browse_resp.data == b'{"total":0,"count":30,"pages":1,"page":1,"result":[]}', 'Should be a simple empty db'
 
-    assert new_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert new_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     assert new_resp.data == b'[]', 'Should return empty list'
 
-    assert top_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert top_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     assert top_resp.data == b'[]', 'Should return empty list'
 
-    assert featured_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert featured_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     assert featured_resp.data == b'[]', 'Should return empty list'

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,7 +1,7 @@
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
-from flask_api import status
+from http import HTTPStatus
 
 from .fixtures.client import client
 
@@ -14,8 +14,8 @@ def test_api_bad_url(client: 'FlaskClient[Response]') -> None:
     bad_url_resp = client.get('/api/something_that_matches_no_routes/69/420')
 
     # Assert
-    assert bad_url_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
-    assert bad_url_resp.json['code'] == status.HTTP_404_NOT_FOUND, 'Code should match'
+    assert bad_url_resp.status_code == HTTPStatus.NOT_FOUND, 'Request should fail'
+    assert bad_url_resp.json['code'] == HTTPStatus.NOT_FOUND, 'Code should match'
     assert bad_url_resp.json['error'] == True, 'Should contain "error" property'
     assert 'not found' in bad_url_resp.json['reason'], 'Reason should be typical 404 lingo'
 
@@ -28,6 +28,6 @@ def test_api_mod_not_found(client: 'FlaskClient[Response]') -> None:
     missing_mod_resp = client.get('/api/mod/20000')
 
     # Assert
-    assert missing_mod_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert missing_mod_resp.status_code == HTTPStatus.NOT_FOUND, 'Request should fail'
     assert missing_mod_resp.json['error'] == True, 'Should contain "error" property'
     assert missing_mod_resp.json['reason'] == 'Mod not found.', 'Reason should match'

--- a/tests/test_api_mod.py
+++ b/tests/test_api_mod.py
@@ -4,7 +4,7 @@ from typing import Dict, Any
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
-from flask_api import status
+from http import HTTPStatus
 
 from .fixtures.client import client
 from KerbalStuff.objects import Publisher, Game, GameVersion, User, Mod, ModVersion
@@ -65,36 +65,36 @@ def test_api_mod(client: 'FlaskClient[Response]') -> None:
     search_user_resp = client.get('/api/search/user?query=Test&page=0')
 
     # Assert
-    assert mod_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert mod_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_mod(mod_resp.json)
     # Not returned by all APIs
     assert mod_resp.json['description'] == 'A mod that we will use to test the API', 'Short description should match'
 
-    assert kspversions_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert kspversions_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_game_version(kspversions_resp.json[0])
 
-    assert gameversions_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert gameversions_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_game_version(gameversions_resp.json[0])
 
-    assert games_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert games_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_game(games_resp.json[0])
 
-    assert publishers_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert publishers_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_publisher(publishers_resp.json[0])
 
-    assert mod_version_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert mod_version_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_mod_version(mod_version_resp.json)
 
-    assert user_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert user_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_user(user_resp.json)
 
-    assert typeahead_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert typeahead_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_mod(typeahead_resp.json[0])
 
-    assert search_mod_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert search_mod_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_mod(search_mod_resp.json[0])
 
-    assert search_user_resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert search_user_resp.status_code == HTTPStatus.OK, 'Request should succeed'
     check_user(search_user_resp.json[0])
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,7 +1,7 @@
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
-from flask_api import status
+from http import HTTPStatus
 
 from .fixtures.client import client
 
@@ -14,7 +14,7 @@ def test_bad_url(client: 'FlaskClient[Response]') -> None:
     bad_url_resp = client.get('/something_that_matches_no_routes/69/420')
 
     # Assert
-    assert bad_url_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert bad_url_resp.status_code == HTTPStatus.NOT_FOUND, 'Request should fail'
     assert bad_url_resp.json is None, 'Should not be JSON'
     assert bad_url_resp.mimetype == 'text/html', 'Should be HTML'
     assert b'Not Found' in bad_url_resp.data, 'Should be a nice web page'
@@ -29,7 +29,7 @@ def test_mod_not_found(client: 'FlaskClient[Response]') -> None:
     missing_mod_resp = client.get('/mod/20000')
 
     # Assert
-    assert missing_mod_resp.status_code == status.HTTP_404_NOT_FOUND, 'Request should fail'
+    assert missing_mod_resp.status_code == HTTPStatus.NOT_FOUND, 'Request should fail'
     assert missing_mod_resp.json is None, 'Should not be JSON'
     assert missing_mod_resp.mimetype == 'text/html', 'Should be HTML'
     assert b'Not Found' in missing_mod_resp.data, 'Should be a nice web page'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,7 @@
 import pytest
 from flask.testing import FlaskClient
 from flask import Response
-from flask_api import status
+from http import HTTPStatus
 
 from .fixtures.client import client
 
@@ -14,7 +14,7 @@ def test_version(client: 'FlaskClient[Response]') -> None:
     resp = client.get('/version')
 
     # Assert
-    assert resp.status_code == status.HTTP_200_OK, 'Request should succeed'
+    assert resp.status_code == HTTPStatus.OK, 'Request should succeed'
     assert resp.data.startswith(b'commit'), 'Response should start with "commit"'
     assert b'\nAuthor: ' in resp.data, 'Response should return a Author header'
     assert b'\nDate: ' in resp.data, 'Response should return a Date header'


### PR DESCRIPTION
## Problem

After #440 was merged, alpha is no longer working (despite working fine in localhost testing).

## Cause

@DasSkelett says this is caused by pallets/markupsafe#282, which says "You are using an unsupported version of Jinja," meaning that we should use the latest version of Jinja.

## Background

In #353 we pinned the Flask and Jinja2 dependency versions because there are API changes that would break parts of the backend and more testing is required.

Backend logs (including deprecation warnings) can be printed with:

```
docker logs spacedock_backend_1 
```

## Motivation

See python/typeshed#5423, the type stubs for Flask and Jinja2 may be removed from typeshed soon because the latest versions of those modules have type hints built-in. I'm not certain, but I think this means we might wake up one day to find that our code using the older versions no longer passes the `mypy` tests.

## Changes

Now we install the latest versions of Flask and Jinja2, and various deprecation warnings are fixed:

- The `sqlalchemy.ext.declarative.declarative_base` imports are changed to `sqlalchemy.orm.declarative_base`
- The `markdown.util.etree` imports are changed to `xml.etree.ElementTree`
- `URL()` is replaced by `URL.create()`
- We delete the `profile-dir` config setting for tests so the test harness doesn't try to create dirs it can't access
- The `flask_api.status` imports are changed to `http.HTTPStatus`
- ~~Since integral type hints for Jinja2 should mean that `ChainableUndefined` is defined properly, the PyType test harness we removed from #378 is back to provide some extra checks on our code (this is currently in flux, the test just failed as I'm typing this but I'm going to try to massage it into working after creating the PR)~~
  PyType still doesn't work, see comments below for details.

As far as I can tell, everything still works.