### PR TITLE
Send download size, co-authors, and authors' GitHub and forum names to CKAN

### DIFF
--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -17,6 +17,7 @@ def send_to_ckan(mod: Mod) -> None:
     domain = _cfg('domain')
     url = _cfg('create-url')
     site_name = _cfg('site-name')
+    storage = _cfg('storage')
     if mod.ckan and mod.published and url and protocol and domain and site_name:
         site_base_url = protocol + "://" + domain
         _bg_post(url, {
@@ -34,6 +35,9 @@ def send_to_ckan(mod: Mod) -> None:
             'user_url': site_base_url + url_for("profile.view_profile", username=mod.user.username),
             'mod_url': site_base_url + url_for('mods.mod', mod_name=mod.name, mod_id=mod.id),
             'site_name': site_name,
+            'download_size': (mod.default_version.format_size(storage)
+                              if mod.default_version and storage else
+                              None),
         })
 
 


### PR DESCRIPTION
## Motivations

KSP-CKAN/NetKAN#8872 was originally submitted with no homepage or source code links, but both existed. I found them via the links on the author's profile.

Later, KSP-CKAN/NetKAN#8918 was submitted when a new co-author checked the CKAN box, but only the original author was included in the description.

## Changes

Now the new mod notification to CKAN contains the author's GitHub and forum info, as well as all of the same fields for each co-author in a `shared_authors` array. A future PR in NetKAN-Infra can then add them to the pull request body to make it easier to find all the info.

A `download_size` property is added as well, pulled from the default mod version if available. This way a CKAN reviewer with a slow network or full disk can defer reviewing huge mods until he or she is at a computer able to handle it.