### PR TITLE
Downloads: Don't count from bots, send HTML to Discord

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -12,6 +12,7 @@ import threading
 import dns.resolver
 import requests
 import werkzeug.wrappers
+import user_agents
 
 from flask import Blueprint, render_template, send_file, make_response, url_for, abort, session, \
     redirect, request
@@ -564,31 +565,33 @@ def download(mod_id: int, mod_name: Optional[str], version: Optional[str]) -> Op
         else next(filter(lambda v: v.friendly_version == version, mod.versions), None)
     if not mod_version:
         abort(404, 'Unfortunately we couldn\'t find the requested mod version. Maybe it got deleted?')
-    # Events are aggregated hourly
-    an_hour_ago = datetime.now() - timedelta(hours=1)
-    download = DownloadEvent.query\
-        .filter(DownloadEvent.version_id == mod_version.id, DownloadEvent.created > an_hour_ago)\
-        .order_by(desc(DownloadEvent.created))\
-        .first()
-    storage = _cfg('storage')
-    if not storage:
-        abort(404)
-
-    if 'Range' not in request.headers:
-        if not download:
-            download = DownloadEvent()
-            download.mod = mod
-            download.version = mod_version
-            download.downloads = 1
-            db.add(download)
-            db.flush()
-            db.commit()
-            mod.downloads.append(download)
-        else:
-            download.downloads += 1
-        mod.download_count += 1
-        mod_version.download_count += 1
-        mod.score = get_mod_score(mod)
+    ua = user_agents.parse(request.user_agent.string)
+    # Only count download events from non-bots
+    if not ua.is_bot:
+        # Events are aggregated hourly
+        an_hour_ago = datetime.now() - timedelta(hours=1)
+        download = DownloadEvent.query\
+            .filter(DownloadEvent.version_id == mod_version.id, DownloadEvent.created > an_hour_ago)\
+            .order_by(desc(DownloadEvent.created))\
+            .first()
+        if 'Range' not in request.headers:
+            if not download:
+                download = DownloadEvent()
+                download.mod = mod
+                download.version = mod_version
+                download.downloads = 1
+                db.add(download)
+                db.flush()
+                db.commit()
+                mod.downloads.append(download)
+            else:
+                download.downloads += 1
+            mod.download_count += 1
+            mod_version.download_count += 1
+            mod.score = get_mod_score(mod)
+    elif 'discord'.casefold() in ua.browser.family.casefold():
+        # Send HTML to Discord so it can see the OpenGraph tags
+        return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))
 
     protocol = _cfg("protocol")
     cdn_domain = _cfg("cdn-domain")

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -28,4 +28,5 @@ requests-oauthlib
 SQLAlchemy>=1.4,<2 # 1.4 shows deprecation warnings for 2.0, 2.0 would break our backend as of now
 SQLAlchemy-Utils
 urllib3
+user_agents
 Werkzeug


### PR DESCRIPTION
## Background

SpaceDock keeps track of how many times each mod has been downloaded. These numbers are displayed and used to determine the mod's score.

## Problem

The download counts include requests by self-identified bots, software that does not reflect user interest or choice. This distorts the download counts.

(Currently CKAN's bots are not identifying themselves as bots, but we are going to move towards doing that, see KSP-CKAN/CKAN#3490 and KSP-CKAN/xKAN-meta_testing#84.)

## Motivation

If you paste a link into Discord, Discord retrieves the link and parses its HTML to find OpenGraph tags to display in the chat (see #385). For SpaceDock download links, this currently only works if there is a space in the mod name, because Discord excludes the `/download` suffix from the URL and retrieves the mod page instead by coincidence.

## Changes

- Now if a `/download/` request's `User-Agent` header identifies it as a bot, we don't increment the download counts
- Now if a `/download/` request's `User-Agent` header identifies it as Discord, we redirect to the mod page so it can see the OpenGraph tags for that mod
- The `storage` check is removed because `sendfile` does it anyway