### PR TITLE
Allow admins to remove CKAN flag

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -535,6 +535,17 @@ def unlock(mod_id: int) -> werkzeug.wrappers.Response:
     return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))
 
 
+@mods.route('/mod/<int:mod_id>/unckan', methods=['POST'])
+@adminrequired
+@with_session
+def unckan(mod_id: int) -> werkzeug.wrappers.Response:
+    mod, game = _get_mod_game_info(mod_id)
+    if not mod.ckan:
+        abort(400)
+    mod.ckan = False
+    return redirect(url_for("mods.mod", mod_id=mod.id, mod_name=mod.name))
+
+
 def _allow_download(mod: Mod) -> bool:
     # Anyone can download published mods
     if mod.published:

--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -843,7 +843,6 @@ div.col-xs-1, div.col-sm-1, div.col-md-1, div.col-lg-1, div.col-xs-2, div.col-sm
 }
 
 div.header {
-    background: transparent;
     background-color: #FFFFFF;
     text-shadow: none;
     color: #333333;

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -198,6 +198,18 @@
     height: 28em;
 }
 
+span.badge a.btn {
+    margin-bottom: 0;
+    padding: 1px 5px;
+    border-radius: 50%;
+    line-height: normal;
+    color: #000;
+    background-color: #ccc;
+    &:hover {
+        background-color: #ddd;
+    }
+}
+
 .following-mods-list {
     max-height: 15em;
     overflow-y: auto;

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -55,7 +55,11 @@
             <h1 title="{{ mod.name }}">
                 {{ mod.name }}
                 {% if mod.ckan %}
-                <span class="badge" title="This mod is listed in CKAN.">CKAN</span>
+                <span class="badge" title="This mod is listed in CKAN.">CKAN
+                    {%- if admin %}
+                        <a title="Remove CKAN flag" class="btn btn-xs" data-toggle="modal" data-target="#confirm-unckan">&times;</a>
+                    {%- endif -%}
+                </span>
                 {% endif %}
             </h1>
             <small>{{ mod.short_description }}</small>
@@ -502,6 +506,28 @@
         </div>
     </div>
 </div>
+<div class="modal fade" id="confirm-unckan" tabindex="-1" role="dialog" aria-labelledby="confirm-unckan" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Remove CKAN Flag</h4>
+            </div>
+            <form action="{{ url_for("mods.unckan", mod_id=mod.id) }}" method="POST">
+                <div class="modal-body">
+                    <p>
+                    Are you sure you want to remove the CKAN flag from this mod?
+                    The CKAN badge will no longer appear, and the CKAN webhook will no longer be notified when this mod is edited or updated. You can undo this by editing the mod and checking the CKAN checkbox again, which may generate another automated pull request.</p>
+                </div>
+                <div class="modal-footer">
+                    <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+                    <input type="submit" class="btn btn-danger" value="Remove CKAN Flag">
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 {% endif %}
 
 <div class="modal fade" id="register-for-updates" tabindex="-1">


### PR DESCRIPTION
## Motivation

Currently the CKAN badge can't be removed from a mod even if the CKAN team decides not to add it to CKAN. This may confuse users who think it would be there and can't find it, and it also causes some minor unnecessary network traffic from SpaceDock to the CKAN webhooks when the mod is edited or updated.

## Changes

Now admin users will see a new X button within the CKAN badge:

![image](https://user-images.githubusercontent.com/1559108/145755567-5d57c605-5479-4e3a-a672-261e7de8de23.png)

When you click it, a confirmation dialog appears:

![image](https://user-images.githubusercontent.com/1559108/145755581-b8220d96-7247-4948-be70-dca8213197d4.png)

If you click the Remove CKAN Flag button, then a new `/mod/<mod_id>/unckan` route removes the flag and refreshes the page so you can see the badge is gone.

Also the mod page's `div.header` previously had a `background: transparent;` style which was immediately overridden by `background-color: #FFFFFF;`. In practice all this accomplished was to mess up the layout of the header graphic. This is now removed so the header graphic will appear as it was intended to.