### PR TITLE
Show similar mods on mod page

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -22,6 +22,7 @@ from ..objects import GameVersion, Game, Publisher, Mod, Featured, User, ModVers
     ModList
 from ..search import search_mods, search_users, typeahead_mods, get_mod_score
 from ..thumbnail import thumb_path_from_background_path
+from ..celery import update_mod_similarities
 
 api = Blueprint('api', __name__)
 
@@ -545,6 +546,8 @@ def accept_grant_mod(mod_id: int) -> Tuple[Dict[str, Any], int]:
     mod = _get_mod(mod_id)
     author = _get_mod_pending_author(mod)
     author.accepted = True
+    db.commit()
+    update_mod_similarities.delay([mod.id])
     notify_ckan(mod, 'co-author-added')
     return {'error': False}, 200
 
@@ -581,6 +584,8 @@ def revoke_mod(mod_id: int) -> Tuple[Dict[str, Any], int]:
     author = [a for a in mod.shared_authors if a.user == new_user][0]
     mod.shared_authors = [a for a in mod.shared_authors if a.user != current_user]
     db.delete(author)
+    db.commit()
+    update_mod_similarities.delay([mod.id])
     notify_ckan(mod, 'co-author-removed')
     return {'error': False}, 200
 
@@ -698,6 +703,7 @@ def create_mod() -> Tuple[Dict[str, Any], int]:
         db.commit()
         mod.score = get_mod_score(mod)
         db.commit()
+        update_mod_similarities.delay([mod.id])
         set_game_info(game)
         send_to_ckan(mod)
         return {

--- a/KerbalStuff/celery.py
+++ b/KerbalStuff/celery.py
@@ -11,6 +11,7 @@ from .config import _cfg, _cfgi, _cfgb, site_logger
 from .objects import Mod
 from .search import get_mod_score
 from .ckan import import_ksp_versions_from_ckan
+from .similarity import update_similar_mods
 
 app = Celery("tasks", broker=_cfg("redis-connection"))
 
@@ -117,6 +118,14 @@ def ckan_version_import() -> None:
     game_id = _cfgi('ksp-game-id', -1)
     if game_id > 0:
         import_ksp_versions_from_ckan(game_id)
+
+
+@app.task
+@with_session
+def update_mod_similarities(mod_ids: List[int]) -> None:
+    for mod_id in mod_ids:
+        update_similar_mods(Mod.query.get(mod_id))
+
 
 # to debug this:
 # * add PTRACE capability to celery container via docker-compose.yaml

--- a/KerbalStuff/similarity.py
+++ b/KerbalStuff/similarity.py
@@ -1,0 +1,47 @@
+from heapq import nlargest
+from typing import List
+
+from .objects import Mod, ModSimilarity
+
+
+def find_most_similar(mod: Mod, how_many: int = 6) -> List[ModSimilarity]:
+    get_sim = lambda mod_sim: mod_sim.similarity
+    return sorted(nlargest(how_many,
+                           # Zero similarity means nothing at all in common, so skip those
+                           filter(lambda mod_sim: mod_sim.similarity > 0,
+                                  (ModSimilarity(mod, other_mod)
+                                   for other_mod in
+                                   Mod.query.filter(Mod.published,
+                                                    Mod.game_id == mod.game_id,
+                                                    Mod.id != mod.id))),
+                           key=get_sim),
+                  key=get_sim,
+                  reverse=True)
+
+
+def update_similar_mods(mod: Mod, how_many: int = 6) -> None:
+    if not mod.published:
+        mod.similarities = []
+    else:
+        most_similar = find_most_similar(mod, how_many)
+        # Remove rows for mods that are no longer among the most similar
+        for mod_sim in mod.similarities:
+            if not any(mod_sim.other_mod_id == other_sim.other_mod_id
+                       for other_sim in most_similar):
+               ModSimilarity.query\
+                   .filter(ModSimilarity.main_mod_id == mod_sim.main_mod_id,
+                           ModSimilarity.other_mod_id == mod_sim.other_mod_id)\
+                   .delete()
+        for mod_sim in most_similar:
+            match = [other_sim for other_sim in mod.similarities
+                     if mod_sim.other_mod_id == other_sim.other_mod_id]
+            if match:
+                # Update existing rows for mods that are still similar
+                match[0].similarity = mod_sim.similarity
+                # Update the row with swapped IDs, if any
+                for other_sim in match[0].other_mod.similarities:
+                    if other_sim.other_mod_id == mod_sim.main_mod_id:
+                        other_sim.similarity = mod_sim.similarity
+            else:
+                # Add new rows for newly similar mods
+                mod.similarities.append(mod_sim)

--- a/KerbalStuff/str_similarity.py
+++ b/KerbalStuff/str_similarity.py
@@ -1,0 +1,55 @@
+import re
+from typing import Set, Iterable
+
+
+# Split words on one or more non-alphanumerics
+WORD_SPLIT = re.compile(r'[^a-zA-Z0-9]+')
+
+# Split up pieces of StudlyCapsStrings
+STUDLY_SPLIT = re.compile(r'(?=[A-Z])')
+
+# English words that do not convey meaning about the context
+# We care about things like "rocket" and "propellant" and "deltaV"
+MEANINGLESS = {
+    'the', 'an', 'this', 'these', 'that', 'those',
+    'and', 'or', 'but', 'however',
+    'as', 'such', 'than', 'there',
+    'me', 'my', 'we', 'us', 'our',
+    'you', 'your', 'he', 'him', 'she', 'her', 'it',
+    'they', 'them',
+    'to', 'from', 'in', 'on', 'for', 'with', 'of', 'into', 'at', 'by',
+    'what', 'because', 'then',
+    'is', 'be', 'been', 'are', 'get', 'getting', 'has', 'have', 'come',
+    'do', 'does',
+    'will', 'make', 'work', 'also', 'more',
+    'should', 'so', 'some', 'like', 'likely', 'can', 'seems',
+    'really', 'very', 'each', 'yup', 'which',
+    've', 're',
+    'accommodate', 'manner', 'therefore', 'ever', 'probably', 'almost',
+    'something',
+    'mod', 'pack', 'contains', 'ksp',
+    'http', 'https', 'www', 'youtube', 'imgur', 'com',
+    'github', 'githubusercontent',
+    'forum', 'kerbalspaceprogram', 'index', 'thread', 'topic', 'php',
+    'kerbal', 'space', 'continued', 'revived', 'updated', 'redux',
+    'inc', 'plus',
+}
+
+
+def split_with_acronyms(s: str) -> Iterable[str]:
+    words = WORD_SPLIT.split(s)
+    yield from words
+    for w in words:
+        yield from STUDLY_SPLIT.split(w)
+
+
+def meaningful_words(s: str) -> Set[str]:
+    return set(map(lambda w: w.lower(),
+                   filter(lambda w: len(w) > 1 and not w.isnumeric(),
+                          split_with_acronyms(s)))) - MEANINGLESS
+
+
+def words_similarity(words1: Set[str], words2: Set[str]) -> float:
+    in_both = words1.intersection(words2)
+    all_words = words1 | words2
+    return len(in_both) / len(all_words) if all_words else 0

--- a/alembic/versions/2021_12_15_23_06_02-bbcce95b6e79.py
+++ b/alembic/versions/2021_12_15_23_06_02-bbcce95b6e79.py
@@ -1,0 +1,47 @@
+"""Create mod_similarity table
+
+Revision ID: bbcce95b6e79
+Revises: 3fb8a6e2e0a5
+Create Date: 2021-12-16 05:06:06.312797
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bbcce95b6e79'
+down_revision = '3fb8a6e2e0a5'
+
+from alembic import op
+from alembic.op import create_table, drop_table
+import sqlalchemy as sa
+
+from KerbalStuff.celery import update_mod_similarities
+
+Base = sa.ext.declarative.declarative_base()
+
+class Mod(Base):  # type: ignore
+    __tablename__ = 'mod'
+    id = sa.Column(sa.Integer, primary_key=True)
+    published = sa.Column(sa.Boolean, default=False)
+
+
+def upgrade() -> None:
+    create_table('mod_similarity',
+                 sa.Column('main_mod_id', sa.Integer(), nullable=False),
+                 sa.Column('other_mod_id', sa.Integer(), nullable=False),
+                 sa.Column('similarity', sa.Float(precision=5), nullable=False),
+                 sa.ForeignKeyConstraint(['main_mod_id'], ['mod.id'], ondelete='CASCADE'),
+                 sa.ForeignKeyConstraint(['other_mod_id'], ['mod.id'], ondelete='CASCADE'),
+                 sa.PrimaryKeyConstraint('main_mod_id', 'other_mod_id', name='pk_mods'))
+    op.create_index('ix_mod_similarity_main_mod_similarity',
+                    'mod_similarity', ['main_mod_id', sa.text('similarity DESC')], unique=False)
+
+    # Ask Celery to build the similarity rows for existing published mods
+    update_mod_similarities.delay([mod_id for mod_id, in
+                                   sa.orm.Session(bind=op.get_bind())
+                                         .query(Mod)
+                                         .filter(Mod.published)
+                                         .with_entities(Mod.id)])
+
+def downgrade() -> None:
+    op.drop_index('ix_mod_similarity_main_mod_similarity', table_name='mod_similarity')
+    drop_table('mod_similarity')

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -394,6 +394,21 @@
         </div>
     </div>
 </div>
+{% if mod.similar_mods %}
+<div class="well">
+    <div class="container main-cat">
+        <h3>Similar-ish Mods</h3>
+    </div>
+</div>
+<div class="container">
+    <div class="row">
+        {% set similar_mods = mod.similar_mods[:6] -%}
+        {%- for mod in similar_mods -%}
+        {%- include "mod-box.html" -%}
+        {%- endfor %}
+    </div>
+</div>
+{% endif %}
 {% if editable %}
 <div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-labelledby="confirm-delete" aria-hidden="true">
     <div class="modal-dialog">

--- a/tests/test_mod_similarity.py
+++ b/tests/test_mod_similarity.py
@@ -1,0 +1,84 @@
+from typing import Dict, Optional
+from heapq import nlargest
+import random
+import requests
+
+from KerbalStuff.str_similarity import meaningful_words, words_similarity
+
+
+class ComparableMod:
+    r"""
+    NOTE: This is not a real test to be run during builds!
+          Rather it is a script/utility intended to be run by a developer
+          to exercise the string similarity algorithm with production data
+          instead of a local database.
+
+    USAGE: C:\Users\Me\github\SpaceDock> python3
+           >>> from tests.test_mod_similarity import ComparableMod
+           >>> ComparableMod.similar_mods_test()
+
+           Mods will be retrieved one at a time via the SD API and compared
+           to all previously retrieved mods.
+           For each mod, the 6 most similar mods seen so far will be printed.
+           As more mods are retrieved, the likelihood of a good match increases.
+           If all mods have been retreived, then the mods printed will be the
+           same as the ones shown on the mod page.
+           To quit on Windows: Ctrl-Break
+           To quit on Linux: pkill python3
+    """
+
+    STRING_PROPS = ['name', 'short_description', 'description']
+    MOD_CACHE: Dict[int, Optional['ComparableMod']] = {}
+    # Increase this to the current highest mod id to see mods created
+    # after this script was written
+    MAX_ID = 2927
+
+    @classmethod
+    def get(cls, mod_id: int) -> Optional['ComparableMod']:
+        if mod_id not in cls.MOD_CACHE:
+            try:
+                cls.MOD_CACHE[mod_id] = ComparableMod(mod_id)
+            except:
+                cls.MOD_CACHE[mod_id] = None
+        return cls.MOD_CACHE[mod_id]
+
+    def __init__(self, mod_id: int) -> None:
+        self.mod_id = mod_id
+        api_data = requests.get(
+            f'https://spacedock.info/api/mod/{mod_id}').json()
+        self.name = api_data['name']
+        self.authors = {
+            api_data['author'],
+            *(a['username'] for a in api_data['shared_authors'])}
+        self.prop_words = {
+            prop: meaningful_words(api_data[prop])
+            for prop in self.STRING_PROPS}
+
+    def similarity(self, other: 'ComparableMod') -> float:
+        return (0.1 * words_similarity(self.authors, other.authors)
+                + sum(words_similarity(words, other.prop_words[prop])
+                      for prop, words in self.prop_words.items()))
+
+    def __repr__(self) -> str:
+        return f'{self.mod_id:4}  {self.name}'
+
+    @classmethod
+    def similar_mods_test(cls) -> None:
+        while True:
+            id1 = random.randint(1, cls.MAX_ID)
+            mod1 = cls.get(id1)
+            if mod1:
+                print(f'{mod1}:')
+                to_display = dict(sorted(
+                    nlargest(6, ((mod1.similarity(mod2), mod2)
+                                 for id2, mod2 in cls.MOD_CACHE.items()
+                                 if id1 != id2 and mod2),
+                             key=lambda rating_id: rating_id[0]),
+                    key=lambda pair: pair[0],
+                    reverse=True))
+                rows = 0
+                for rating, mod2 in to_display.items():
+                    if rating == 0.0:
+                        break
+                    rows = rows + 1
+                    print(f"\t {rows}. {rating:.2f}  {mod2}")


### PR DESCRIPTION
## Motivation

See #424, a user who lands on a mod page from off-site has minimal connectivity to other SpaceDock pages. We might have several more mods they'd enjoy, but to find them the user would have to click the header to view an overall list or perform a text search that's currently hard to use. Many web sites famously have "related" links that try to show the user items similar to the current item to help them explore.

## Changes

Now the bottom of the mod page hosts a modestly named "Similar-ish Mods" list containing up to 6 mods that are similar to the current mod:

![image](https://user-images.githubusercontent.com/1559108/146471068-87b1b446-ceca-41b0-84bc-cb4ea220d188.png)

(I decided against using the term "related" because to me, "related" mods would be from the same family of mods like Near Future, or would be designed specifically to extend or work with one another. Rather than such a close relationship, we are just talking about mods that might be about some of the same things, like planet packs or parts.)

To get this list, the mod page template inspects `Mod.similar_mods`, which is an association proxy based on `Mod.similarities`, which is a one-to-many relationship to a new `ModSimilarity` (`mod_similarity`) table:

Column | Purpose
:-- | :--
`main_mod_id` | Stores `Mod.id` of one of the mods being compared
`other_mod_id` | Stores `Mod.id` of the other mod being compared
`similarity` | A number that is larger for more similar mods and smaller for less similar mods

An index of `(main_mod_id, other_mod_id)` allows quick access to known pairs of mods, and an index of `(main_mod_id, similarity.desc())` ensures that `Mod.similarities` can be generated quickly.

`ModSimilarity.similarity` (a single precision float because the values will all be between 0 and 4) is calculated in `ModSimilarity`'s constructor by summing the similarities of the authors (divided by 10 to prevent wildly different mods by the same author from dominating mods that share meaningful keywords, call it "the @linuxgurugamer factor"), name, short description, and description of the two mods, which in turn are calculated as:

$$ \frac{|A\cap B|}{|A\cup B|} $$

... where A and B are the words from each string. For authors, each author name is treated as a word, but for the other strings:

- Blocks of non-alphanumeric characters are treated as word delimiters
- Numbers and single letters are ignored
- StudlyCapsWords are considered both in whole ("StudlyCapsWords") and split ("Studly Caps Words")
- "Meaningless" words are ignored (e.g., "the", "an", "this", and so on for a long list based on currently available texts)
- Letters are converted to lowercase to facilitate case insensitive matching

All routes that modify these inputs are updated to trigger a recalculation of the affected mod's similar mods in the background via a new Celery task. For this to work, we now also `db.commit()` before those calls. The same Celery task also populates the initial values in the `mod_similarity` table for all existing mods in the migration.

The Celery task works by iterating over all mods other than the given one published for the same game and comparing them to the given mod, keeping only the 6 pairs with the highest similarity. Pairs with 0 similarity are never included. Once the most similar pairs are known, the list in `Mod.similarities` is updated to match. According to <https://spacedock.info/api/browse> there are 2252 mods on SpaceDock right now, so if each has 6 rows in `mod_similarities`, that would be 13512 new rows.

To reduce redundant work during repeated similarity calculations for the same mod, `Mod._author_names` and `Mod._words` now cache the words in the input properties on-demand via `Mod.get_author_names()` and `Mod.get_words()`.

To make it easier to experiment with production's large, authentic data set, I have included a utility in `tests/test_mod_similarity.py` that displays the results of the same algorithm applied to data from the production server's API. It's not a test, but I found it very useful for development, and putting it with the tests seemed better than putting it with production code or on a wiki.

I have tried to isolate the similarity logic to the `similarity.py` and `str_similiarity.py` modules in case we find a machine learning package that we want to use later; switching over should be possible as long as we can write replacements for `ModSimiliarity.__init__`, `words_similarity` and `meaningful_words`.

Fixes #424.