### PR TITLE
Parse @username links and colon emoji codes in markdown

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -18,6 +18,7 @@ from sqlalchemy import desc
 from werkzeug.exceptions import HTTPException, InternalServerError, NotFound
 from flask.typing import ResponseReturnValue
 from jinja2 import ChainableUndefined
+from pymdownx.emoji import gemoji, to_alt
 
 from .blueprints.accounts import accounts
 from .blueprints.admin import admin
@@ -60,7 +61,13 @@ app.jinja_env.auto_reload = app.debug
 app.secret_key = _cfg("secret-key")
 app.json_encoder = CustomJSONEncoder
 app.session_interface = OnlyLoggedInSessionInterface()
-Markdown(app, extensions=[KerbDown(), 'fenced_code'])
+Markdown(app, extensions=[KerbDown(), 'fenced_code', 'pymdownx.emoji'],
+         extension_configs={'pymdownx.emoji': {
+            # GitHub's emojis
+            'emoji_index': gemoji,
+            # Unicode output
+            'emoji_generator': to_alt
+         }})
 login_manager = LoginManager(app)
 
 prof_dir = _cfg('profile-dir')

--- a/KerbalStuff/kerbdown.py
+++ b/KerbalStuff/kerbdown.py
@@ -2,10 +2,14 @@ import urllib.parse
 from urllib.parse import parse_qs, urlparse
 from typing import Dict, Any, Match, Tuple, Optional
 
+from flask import url_for
 from markdown import Markdown
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
 from xml.etree import ElementTree
+from markdown.util import AtomicString
+
+from .objects import User
 
 
 class EmbedInlineProcessor(InlineProcessor):
@@ -63,6 +67,45 @@ class EmbedInlineProcessor(InlineProcessor):
         return el
 
 
+class AtUsernameProcessor(InlineProcessor):
+    # Don't worry about re.compiling this, markdown.inlinepatterns.Pattern.__init__ does that for us
+    # Same as blueprints.accounts._username_re
+    USER_RE = r'@(?P<username>[A-Za-z0-9_]+)'
+
+    def __init__(self, md: Markdown, configs: Dict[str, Any]) -> None:
+        super().__init__(self.USER_RE, md)
+        self.configs = configs
+
+    def handleMatch(self, match: Match[str], data: str) -> Tuple[Optional[ElementTree.Element], Optional[int], Optional[int]]:  # type: ignore[override]
+        username = match.groupdict().get('username')
+        # Case insensitive lookup
+        user = User.query.filter(User.username.ilike(username)).first()
+        return ((self._profileLink(user), match.start(0), match.end(0))
+                # Keep original text if user not found
+                if user and user.public else (None, None, None))
+
+    @classmethod
+    def _profileLink(cls, user: User) -> ElementTree.Element:
+        # Make a link to the user's profile
+        elt = ElementTree.Element('a', href=url_for('profile.view_profile',
+                                                    username=user.username),
+                                       # Summarize user's profile in tooltip
+                                       title='\n'.join((f'{user.username}\'s profile',
+                                                        f'{cls._profileModCount(user)} mods',
+                                                        f'Joined {user.created.strftime("%Y-%m-%d")}')))
+        # Make it bold
+        strong = ElementTree.SubElement(elt, 'strong')
+        # AtomicString prevents Markdown from entering an infinite loop by processing the subelement's text again
+        strong.text = AtomicString(f'@{user.username}')
+        return elt
+
+    @staticmethod
+    def _profileModCount(user: User) -> int:
+        return len([m for m in user.mods + [sa.mod for sa in user.shared_authors
+                                            if sa.accepted]
+                    if m.published])
+
+
 class KerbDown(Extension):
     def __init__(self, **kwargs: str) -> None:
         super().__init__(**kwargs) # type: ignore[arg-type]
@@ -72,4 +115,5 @@ class KerbDown(Extension):
     def extendMarkdown(self, md: Markdown) -> None:
         # BUG: the base method signature is INVALID, it's a bug in flask-markdown
         md.inlinePatterns.register(EmbedInlineProcessor(md, self.config), 'embed', 200)
+        md.inlinePatterns.register(AtUsernameProcessor(md, self.config), 'atuser', 200)
         md.registerExtension(self)

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -21,6 +21,7 @@ packaging
 Pillow
 psycopg2-binary
 PyGithub
+pymdown-extensions
 python-daemon
 redis
 requests

--- a/templates/markdown.html
+++ b/templates/markdown.html
@@ -52,6 +52,9 @@ This is a very neat mod I wrote that lets you do *super cool things*.
     </blockquote>
     <p>You can use Markdown on your mod descriptions, profile page, and changelogs. The nice thing about using it in
     your changelogs is that it looks nice in plaintext, which is how it shows up in your user's email inboxes.</p>
+    <h2>User profile links</h2>
+    <p>You can create a link to a user's profile like this:</p>
+    <pre>@username</pre>
     <h2>Embedding videos and images</h2>
     <p>You can easily embed a single image like so (this came from the Markdown spec):</p>
     <pre>![](http://example.com/image.png)</pre>


### PR DESCRIPTION
## Motivation

On GitHub, the KSP forum, and most other web sites with users and comments, you can use an @-username sequence to link to a user of that site.

Currently this doesn't do anything on SpaceDock. It could be useful if you want to credit a user for something or if their mods are relevant to your mod's description.

(Thought of while reviewing KSP-CKAN/NetKAN#9007, which accidentally passed such a string through to a pull request and notified the wrong user on GitHub. The link in [that description](https://spacedock.info/mod/2978/YnoT1300) still won't be valid because it references a user that exists on the forum but not SpaceDock, but it would still be a nice feature to have for other cases.)

Similarly, GitHub supports `:emoji_name:` syntax for inserting emojis, as in:

`:thinking:` → :thinking:

... and this also doesn't work on SpaceDock currently.

![image](https://user-images.githubusercontent.com/1559108/158634420-52953a90-305f-4827-b690-cec4d05dc944.png)

## Changes

Now the `KerbDown` processor is updated to handle @-username sequences. If the specified username doesn't exist (case-insensitive lookup) or isn't public, then the original text is preserved unchanged. Otherwise we turn it into a bold link with a tooltip on hover (my screen capture software did not preserve the mouse cursor).

The link tooltip shows the number of mods on the user's profile and the date their account was created. Note that the mod count is the "correct" count of mods that will be visible after #425 is merged (including co-authored mods and excluding non-published mods).

The `/markdown` documentation route is updated to reflect this behavior.

We also now support GitHub's `:emoji_name:` codes.

![image](https://user-images.githubusercontent.com/1559108/158633092-2c7ac372-a542-4892-9027-41c43c89dfc8.png)

### Considered and not done

It would be even nicer to provide editing assistance by autocompleting usernames after the user types @, as GitHub does:

![image](https://user-images.githubusercontent.com/1559108/157745890-d7652d08-9af0-4243-a4a3-ea830c78892e.png)

However, if we tried to add editing assistance now, we would have to re-do it after #420 is merged because it is changing the library that we use for the Markdown editor. So for now this is left as a possible future project.