### PR TITLE
Fix curl commands in API doc

### DIFF
--- a/api.md
+++ b/api.md
@@ -385,7 +385,7 @@ Creates a new mod. **Requires authentication**.
 
 *Curl*
 
-    curl -c ./cookies \
+    curl -b ./cookies \
         -F" name=Example Mod" \
         -F "short-description=this is your schort description" \
         -F "version=1.0" \
@@ -423,7 +423,7 @@ Publishes an update to an existing mod. **Requires authentication**.
 
 *Curl*
 
-    curl -c ./cookies \
+    curl -b ./cookies \
         -F "version=1.0" \
         -F "changelog=this is your changelog" \
         -F "game-version=0.24" \


### PR DESCRIPTION
## Background

```
$ curl --help all
[...]
 -b, --cookie <data|filename>  Send cookies from string/file
 -c, --cookie-jar <filename>  Write cookies to <filename> after operation
[...]
```

More simply, `-c` creates a cookie file (as when logging in), and `-b` reads from it (as when using established credentials to do things).

## Problem

All of the `curl` commands in the API doc currently use `-c`, but two of them should be reading the file rather than creating it.

https://forum.kerbalspaceprogram.com/index.php?/topic/170865-spacedockinfo-mod-hosting-site/&do=findComment&comment=4101102

## Changes

Now the login call uses `-c`, and the mod creation/update calls use `-b`.
