### PR TITLE
Make ./start-server.sh work on Windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
-      - ./spacedock-db:/var/lib/postgresql/data
+      - ./spacedock-db:/var/lib/postgresql/data${DISABLE_DB_VOLUME}
     ports:
       - 55432:5432
     networks:

--- a/start-server.sh
+++ b/start-server.sh
@@ -6,11 +6,26 @@ test -f config.ini || cp config.ini.example config.ini
 test -f alembic.ini || cp alembic.ini.example alembic.ini
 test -f logging.ini || cp logging.ini.example logging.ini
 
-# start the docker
-if [[ -z "$(pgrep dockerd)" ]];
-then
-    systemctl start docker.service
-fi
+case "$OSTYPE" in
+    linux*)
+        # Only start docker service on Linux
+        # (pgrep and systemctl may not be available elsewhere)
+        if [[ -z "$(pgrep dockerd)" ]];
+        then
+            systemctl start docker.service
+        fi
+        ;;
+    msys | cygwin)
+        # Turn off db's volume mounting because we can't make the owners match,
+        # by mounting it at /var/lib/postgresql/data_dummy instead.
+        # The db will not persist between restarts, but that's better than
+        # failing to start and can still be used to investigate some issues.
+        echo 'Windows OS detected, disabling db volume mounting.'
+        echo 'NOTE: Database will NOT persist across restarts!'
+        echo
+        export DISABLE_DB_VOLUME=_dummy
+        ;;
+esac
 
 COMPOSE_FILE="docker-compose.yml"
 [ "$1" == "prod" ] && COMPOSE_FILE="docker-compose-prod.yml"


### PR DESCRIPTION
## Motivation

I alternate between Ubuntu and Win7, and previously I could only run a local SpaceDock dev server on Ubuntu. This meant anytime I was in Windows, I had to defer most investigation and testing until after my next reboot into Ubuntu.

## Background

Bash provides environment variable `$OSTYPE` so scripts can tell what OS they're on, for details see dylanaraps/neofetch#433. On my system it is `msys` because I'm using MINGW64.

OS | How to install Docker
:-- | :--
Win10+ | Docker Desktop: <https://docs.docker.com/desktop/windows/install/>
Win7 | Docker Toolbox: <https://github.com/docker-archive/toolbox/releases/latest>

I had to use this URL to access the test server on Windows: <http://192.168.99.100:5080/>

## Problems

The startup script assumes commands that don't exist on Windows:

```
$ ./start-server.sh
./start-server.sh: line 10: pgrep: command not found
./start-server.sh: line 12: systemctl: command not found
```

After you fix that problem, you get lots of these:

```
2022-04-24 16:05:08,399 INFO Spacedock.Info:6 Unable to connect to DB: (psycopg2.OperationalError) could not translate host name "db" to address: Name or service not known

(Background on this error at: https://sqlalche.me/e/14/e3q8)
2022-04-24 16:05:09,429 INFO Spacedock.Info:6 Unable to connect to DB: (psycopg2.OperationalError) could not translate host name "db" to address: Name or service not known

(Background on this error at: https://sqlalche.me/e/14/e3q8)
```

## Causes

`pgrep` is kind of a specialized command, which is fine, but `systemctl` is actually specific to Linux OS internals and probably couldn't be ported even if someone wanted to.

Backend can't connect to db because it's not running; the db fails to start because the owner of the mounted volume is your Windows user rather than `root` (or `postgres`?) as expected by the `postgres` container:

```
$ docker-compose.exe up db
Starting db ... done
Attaching to db
db          | The files belonging to this database system will be owned by user "postgres".
db          | This user must also own the server process.
db          |
db          | The database cluster will be initialized with locale "en_US.utf8".
db          | The default database encoding has accordingly been set to "UTF8".
db          | The default text search configuration will be set to "english".
db          |
db          | Data page checksums are disabled.
db          |
db          | fixing permissions on existing directory /var/lib/postgresql/data/pgdata ... ok
db          | creating subdirectories ... ok
db          | selecting default max_connections ... 20
db          | selecting default shared_buffers ... 400kB
db          | selecting default timezone ... Etc/UTC
db          | selecting dynamic shared memory implementation ... posix
db          | creating configuration files ... ok
db          | running bootstrap script ... 2022-04-24 16:34:37.861 UTC [81] FATAL:  data directory "/var/lib/postgresql/data/pgdata" has wrong ownership
db          | 2022-04-24 16:34:37.861 UTC [81] HINT:  The server must be started by the user that owns the data directory.
db          | child process exited with exit code 1
db          | initdb: removing contents of data directory "/var/lib/postgresql/data/pgdata"
db exited with code 1
```

## Changes

- Now the script only runs the `systemctl` stuff on Linux (on Windows the service initialization is taken care of at installation)
- Now if we are running on Windows, we mount the volume at a dummy location instead of where the container expects it (since `docker-compose` doesn't support conditional logic but does support environment variables). The container will then create the db directory with the correct permissions. This means that any changes to the db will be lost if you restart the server, but I'd rather have that than no server at all.
