### PR TITLE
Update Dropzone, display upload errors correctly

### DIFF
--- a/frontend/coffee/create.coffee
+++ b/frontend/coffee/create.coffee
@@ -1,6 +1,6 @@
 editor = new Editor()
 editor.render()
-dropzone = require('dropzone')
+Dropzone = require('dropzone').Dropzone
 
 error = (name) ->
     document.getElementById(name).parentElement.classList.add('has-error')
@@ -17,44 +17,44 @@ valid = ->
     error('mod-version') if $("#mod-version").val() == ''
     error('mod-game') if $("#mod-game").val() == null
     error('mod-game-version') if $("#mod-game-version").val() == null
-    error('uploader') if dropzone.forElement('#uploader').files.length != 1
+    error('uploader') if Dropzone.forElement('#uploader').files.length != 1
 
     return document.querySelectorAll('.has-error').length == 0
 
 document.getElementById('submit').addEventListener('click', () ->
     return unless valid()
-    dropzone.forElement('#uploader').processQueue()
+    Dropzone.forElement('#uploader').processQueue()
 , false)
 
-dropzone.options.uploader =
-    chunking: true,
-    forceChunking: true,
-    parallelChunkUploads: false,
-    maxFiles: 1,
-    maxFilesize: 10000,
-    autoProcessQueue: false,
-    addRemoveLinks: true,
-    acceptedFiles: 'application/zip,.zip',
-    paramName: 'zipball',
-    url: '/api/mod/create',
-    headers: { 'Accept': 'application/json' },
+Dropzone.options.uploader =
+    chunking: true
+    forceChunking: true
+    parallelChunkUploads: false
+    maxFiles: 1
+    maxFilesize: 10000
+    autoProcessQueue: false
+    addRemoveLinks: true
+    acceptedFiles: 'application/zip,.zip'
+    paramName: 'zipball'
+    url: '/api/mod/create'
+    headers:
+        Accept: 'application/json'
 
     params: (files, xhr, chunk) ->
-        return {
-            'dztotalchunkcount': chunk.file.upload.totalChunkCount,
-            'dzchunkindex': chunk.index,
-            'name': $("#mod-name").val(),
-            'short-description': $("#mod-short-description").val(),
-            'description': editor.codemirror.getValue(),
-            'version': $("#mod-version").val(),
-            'game-id': $('#mod-game').val(),
-            'game-version': $('#mod-game-version').val(),
-            'license': $("#mod-license").val(),
-            'ckan': $("#ckan").prop('checked'),
-        }
+        return
+            dztotalchunkcount: chunk.file.upload.totalChunkCount
+            dzchunkindex: chunk.index
+            name: $("#mod-name").val()
+            'short-description': $("#mod-short-description").val()
+            description: editor.codemirror.getValue()
+            version: $("#mod-version").val()
+            'game-id': $('#mod-game').val()
+            'game-version': $('#mod-game-version').val()
+            license: $("#mod-license").val()
+            ckan: $("#ckan").prop('checked')
 
     maxfilesexceeded: (file) ->
-        dropzone.forElement('#uploader').removeFile(file)
+        Dropzone.forElement('#uploader').removeFile(file)
 
     success: (file) ->
         response = JSON.parse(file.xhr.response)
@@ -62,7 +62,17 @@ dropzone.options.uploader =
 
     error: (file, errorMessage, xhr) ->
         alert = $("#error-alert")
-        alert.text(errorMessage.reason)
+        alert.text(
+            if typeof errorMessage is 'string'
+                errorMessage
+            else if errorMessage.reason? and typeof errorMessage.reason is 'string'
+                errorMessage.reason
+            else if errorMessage.error? and typeof errorMessage.error is 'string'
+                errorMessage.error
+            else
+                # Give them _something_ to report to us if not in any expected format
+                JSON.stringify(errorMessage)
+        )
         alert.removeClass('hidden')
 
 document.getElementById('mod-license').addEventListener('change', () ->

--- a/frontend/coffee/update.coffee
+++ b/frontend/coffee/update.coffee
@@ -1,4 +1,4 @@
-dropzone = require('dropzone')
+Dropzone = require('dropzone').Dropzone
 
 error = (name) ->
     document.getElementById(name).parentElement.classList.add('has-error')
@@ -9,40 +9,40 @@ valid = ->
     document.getElementById('error-alert').classList.add('hidden')
 
     error('version') if $("#version").val() == ''
-    error('uploader') if dropzone.forElement('#uploader').files.length != 1
+    error('uploader') if Dropzone.forElement('#uploader').files.length != 1
 
     return document.querySelectorAll('.has-error').length == 0
 
 document.getElementById('submit').addEventListener('click', () ->
     return unless valid()
-    dropzone.forElement('#uploader').processQueue()
+    Dropzone.forElement('#uploader').processQueue()
 , false)
 
-dropzone.options.uploader =
-    chunking: true,
-    forceChunking: true,
-    parallelChunkUploads: false,
-    maxFiles: 1,
-    maxFilesize: 10000,
-    autoProcessQueue: false,
-    addRemoveLinks: true,
-    acceptedFiles: 'application/zip,.zip',
-    paramName: 'zipball',
-    url: '/api/mod/' + window.mod_id + '/update',
-    headers: { 'Accept': 'application/json' },
+Dropzone.options.uploader =
+    chunking: true
+    forceChunking: true
+    parallelChunkUploads: false
+    maxFiles: 1
+    maxFilesize: 10000
+    autoProcessQueue: false
+    addRemoveLinks: true
+    acceptedFiles: 'application/zip,.zip'
+    paramName: 'zipball'
+    url: '/api/mod/' + window.mod_id + '/update'
+    headers:
+        Accept: 'application/json'
 
     params: (files, xhr, chunk) ->
-        return {
-            'dztotalchunkcount': chunk.file.upload.totalChunkCount,
-            'dzchunkindex': chunk.index,
-            'game-version': $('#game-version').val(),
-            'version': $('#version').val(),
-            'changelog': $('#changelog').val(),
-            'notify-followers': $('#notify-followers').prop('checked'),
-        }
+        return
+            dztotalchunkcount: chunk.file.upload.totalChunkCount
+            dzchunkindex: chunk.index
+            'game-version': $('#game-version').val()
+            version: $('#version').val()
+            changelog: $('#changelog').val()
+            'notify-followers': $('#notify-followers').prop('checked')
 
     maxfilesexceeded: (file) ->
-        dropzone.forElement('#uploader').removeFile(file)
+        Dropzone.forElement('#uploader').removeFile(file)
 
     success: (file) ->
         response = JSON.parse(file.xhr.response)
@@ -50,7 +50,17 @@ dropzone.options.uploader =
 
     error: (file, errorMessage, xhr) ->
         alert = $("#error-alert")
-        alert.text(errorMessage.reason)
+        alert.text(
+            if typeof errorMessage is 'string'
+                errorMessage
+            else if errorMessage.reason? and typeof errorMessage.reason is 'string'
+                errorMessage.reason
+            else if errorMessage.error? and typeof errorMessage.error is 'string'
+                errorMessage.error
+            else
+                # Give them _something_ to report to us if not in any expected format
+                JSON.stringify(errorMessage)
+        )
         alert.removeClass('hidden')
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chart.js": "^2.9.4",
-        "dropzone": "^5.7.1"
+        "dropzone": "^5.9.3"
       },
       "devDependencies": {
         "@babel/core": "^7.5.5",
@@ -2106,9 +2106,9 @@
       }
     },
     "node_modules/dropzone": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.7.1.tgz",
-      "integrity": "sha512-eqcJafupMKRlVUihZtsLkzLn02WTPUMHeImP5ZtWm3ERObC/dv15te0qqn/X2rEKaSqRC0pNTHUBPgrPWcP52w=="
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.9.3.tgz",
+      "integrity": "sha512-Azk8kD/2/nJIuVPK+zQ9sjKMRIpRvNyqn9XwbBHNq+iNuSccbJS6hwm1Woy0pMST0erSo0u4j+KJaodndDk4vA=="
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -6955,9 +6955,9 @@
       "dev": true
     },
     "dropzone": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.7.1.tgz",
-      "integrity": "sha512-eqcJafupMKRlVUihZtsLkzLn02WTPUMHeImP5ZtWm3ERObC/dv15te0qqn/X2rEKaSqRC0pNTHUBPgrPWcP52w=="
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.9.3.tgz",
+      "integrity": "sha512-Azk8kD/2/nJIuVPK+zQ9sjKMRIpRvNyqn9XwbBHNq+iNuSccbJS6hwm1Woy0pMST0erSo0u4j+KJaodndDk4vA=="
     },
     "duplexer2": {
       "version": "0.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "sass": "^1.22.9"
   },
   "dependencies": {
-    "dropzone": "^5.7.1",
+    "dropzone": "^5.9.3",
     "chart.js": "^2.9.4"
   },
   "coffeelintConfig": {


### PR DESCRIPTION
## Problems

- Uploads are timing out if they take more than 30 seconds to upload a 2 MiB chunk
- Errors from Dropzone (such as a timeout) are being reported as if a field was missing
  ![image](https://user-images.githubusercontent.com/1559108/165124703-7ce66d0b-7290-41e0-9663-b8ab07a6f861.png)


## Causes

- Dropzone implemented a default 30-second timeout per chunk in an older version, which SpaceDock is still using (see dropzone/dropzone#1942), which is ironic because we started using Dropzone in the first place to _avoid_ such timeouts
- Our error handler only looks for `errorMessage.reason` because that's what our JSON-based API calls use, but when Dropzone itself needs to report an error (such as a timeout), it doesn't know about that format, so it just passes a string

## Changes

- Now we are updated to the latest stable Dropzone, which doesn't time out by default
- Now we check whether `errorMessage` is a string, or if it has a `.reason` string property or a `.error` string property (checked by Dropzone's default error handler, so presumably used some of the time), and display whichever of them is available. If none, then we JSONify the thing so we can see what the heck it is if a user reports it.
- Also did a little bit of CoffeeScript-ification of the related code, since it doesn't require braces or commas or some quotes

Fixes #447.