### PR TITLE
API route for auto-generated remote version files

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -1,6 +1,7 @@
 import math
 import os
 import time
+import re
 import zipfile
 from datetime import datetime
 from functools import wraps
@@ -34,6 +35,9 @@ By the way, you have a lot of flexibility here. You can embed YouTube videos or 
 You can check out the SpaceDock [markdown documentation](/markdown) for tips.
 
 Thanks for hosting your mod on SpaceDock!"""
+
+SOURCE_USER_REPO_PATTERN = re.compile(
+    r'^https://github.com/(?P<user>[^/]+)/(?P<repo>[^/]+)/?')
 
 
 # some helper functions to keep things consistent
@@ -423,6 +427,41 @@ def mod_version(mod_id: int, version: str) -> Union[Dict[str, Any], Tuple[Dict[s
         return {'error': True, 'reason': 'Version not found.'}, 404
     info = version_info(mod, v)
     return info
+
+
+@api.route("/api/ksp-avc/<int:mod_id>")
+@json_output
+def remote_version_file(mod_id: int) -> Dict[str, Any]:
+    mod = _get_mod(mod_id)
+    _check_mod_published(mod)
+    version = mod.default_version
+    gh_match = (None if not mod.source_link
+                else SOURCE_USER_REPO_PATTERN.match(mod.source_link))
+    return {
+        'NAME': mod.name,
+        'URL': url_for("api.remote_version_file",
+                       mod_id=mod.id,
+                       _external=True),
+        'DOWNLOAD': url_for('mods.download',
+                            mod_id=mod.id,
+                            mod_name=mod.name,
+                            version=version.friendly_version,
+                            _external=True),
+        'CHANGE_LOG': version.changelog,
+        'CHANGE_LOG_URL': url_for('mods.mod',
+                                  mod_id=mod.id,
+                                  mod_name=mod.name,
+                                  _anchor='changelog',
+                                  _external=True),
+        **({} if not gh_match else {
+            'GITHUB': {
+                'USERNAME': gh_match.group('user'),
+                'REPOSITORY': gh_match.group('repo')
+            }
+        }),
+        'VERSION': version.friendly_version,
+        'KSP_VERSION': version.gameversion.friendly_version,
+    }
 
 
 @api.route("/api/download_counts", methods=['POST'])


### PR DESCRIPTION
## Background

In the KSP modding ecosystem, you need four things for a truly complete setup:

- Hosting page
- Download link
- Home page
- Remote version file link so KSP-AVC can check for new releases

Currently SpaceDock is great for the first two, and the forum is typical for the third.

Remote version files commonly are hosted on:

- ksp-avc.cybutek.net (the original KSP-AVC host)
- GitHub
- ksp.spacetux.net (for @linuxgurugamer's mods)

It's even more common for SpaceDock mods to lack remote version files entirely. When this is the case, KSP-AVC users will not receive notifications when new versions are available.

## Motivation

If a mod author wants to host a mod on SpaceDock and include a version file with a `URL` property so KSP-AVC can alert users for new versions, they have to create an entry on ksp-avc.cybutek.net, or a repo on GitHub, or figure out their own hosting. But SpaceDock already has all the info such a file would need in its db (with one exception, see future enhancements section below), so adding it somewhere else is duplicative of that storage and an additional hassle for mod authors to maintain (as well as a common source of JSON syntax errors).

## Changes

Now a new `/api/ksp-avc/<mod_id>` route returns JSON representing an auto-generated remote version file based on SpaceDock's data for a mod. A mod author can put a copy of this URL's output in a .version file in their download, and if their users also install KSP-AVC, then they will see alerts when a new version is released.

```
$ curl -fsSL http://192.168.99.100:5080/api/ksp-avc/3 | jq
{
  "NAME": "TestMod",
  "URL": "http://192.168.99.100:5080/api/ksp-avc/3",
  "DOWNLOAD": "http://192.168.99.100:5080/mod/3/TestMod/download/1.0",
  "CHANGE_LOG": "Changes in latest version",
  "CHANGE_LOG_URL": "http://192.168.99.100:5080/mod/3/TestMod#changelog",
  "GITHUB": {
    "USERNAME": "testuser",
    "REPOSITORY": "testrepo"
  },
  "VERSION": "1.0",
  "KSP_VERSION": "1.12.3"
}
```

There is a chicken-and-egg problem where the `VERSION` and `KSP_VERSION` properties will only be correct for a new version _after_ that version is uploaded, so it's hard to add it to the ZIP _before_ uploading it, but #428 will make that easier by allowing authors to replace the download for a version if they wish. Most authors would probably choose to maintain a local copy of the .version file with the `URL` property set to the new API route.

In theory, having access to a remote version file could be an advantage for CKAN as well, but the compatibility info is already available via the existing API calls, so no benefit will accrue there in practice.

### Future enhancements

Right now compatibility is returned using only `KSP_VERSION`, because SpaceDock only tracks a single game version. In the future, if we add support for version ranges, we can return `KSP_VERSION_MIN` and `KSP_VERSION_MAX` at that time.
