### PR TITLE
Use mod version entered by user unaltered

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -203,7 +203,7 @@ def _get_modversion_paths(mod_name: str, friendly_version: str) -> Tuple[str, st
     if not storage:
         return '', ''
     storage_path = os.path.join(storage, base_path)
-    filename = f'{mod_name_sec}-{friendly_version}.zip'
+    filename = secure_filename(f'{mod_name}-{friendly_version}.zip')
     if not os.path.exists(storage_path):
         os.makedirs(storage_path)
     full_path = os.path.join(storage_path, filename)
@@ -649,7 +649,7 @@ def create_mod() -> Tuple[Dict[str, Any], int]:
     mod_name = request.form.get('name')
     short_description = request.form.get('short-description')
     description = request.form.get('description', default_description)
-    mod_friendly_version = secure_filename(request.form.get('version', ''))
+    mod_friendly_version = request.form.get('version', '')
     # 'game' is deprecated, but kept for compatibility
     game_id = request.form.get('game-id') or request.form.get('game')
     game_short = request.form.get('game-short-name')
@@ -735,7 +735,7 @@ def create_mod() -> Tuple[Dict[str, Any], int]:
 def update_mod(mod_id: int) -> Tuple[Dict[str, Any], int]:
     mod = _get_mod(mod_id)
     _check_mod_editable(mod)
-    friendly_version = secure_filename(request.form.get('version', ''))
+    friendly_version = request.form.get('version', '')
     game_friendly_version = request.form.get('game-version')
     if not friendly_version or not game_friendly_version:
         return {'error': True, 'reason': 'All fields are required.'}, 400


### PR DESCRIPTION
## Problem

https://github.com/andrew-vant/dragalt/releases

![image](https://user-images.githubusercontent.com/1559108/178078437-3ffec355-2f0e-4ff4-aaf2-90b4597a05f8.png)

https://spacedock.info/mod/1077/Draggable%20Altimeter#changelog

![image](https://user-images.githubusercontent.com/1559108/178078503-344b874c-63f4-4302-bcb0-aee8e006590d.png)

Apparently @andrew-vant entered `v1.0.1+2` there, and SpaceDock silently dropped the `+`. This is bad; user input should be used as-is whenever possible, and if it can't be, there should be a good reason for it, and the input should be rejected with a meaningful error message rather than silently altered.

## Cause

The user-entered version number is filtered through `secure_filename` before being committed to the db. The specific code that does this has been through a number of mutations and iterations, but the behavior goes all the way back to the beginning.

The reason for this was probably that the download path had to be constructed on the fly based on the mod name and version number. At some point we migrated to the more sensible solution of generating and storing the download path in `ModVersion.download_path` and using it as needed.

## Changes

Now the mod version entered by the user is committed to the database as-is.
The _filename_ is filtered through `secure_filename` as before, but the mod version can be anything now.