### PR TITLE
Check user profile field lengths

### DIFF
--- a/KerbalStuff/blueprints/profile.py
+++ b/KerbalStuff/blueprints/profile.py
@@ -107,7 +107,14 @@ def profile(username: str) -> Union[str, werkzeug.wrappers.Response]:
             abort(404)
         if current_user != profile and not current_user.admin:
             abort(403)
-        profile.description = request.form.get('description')
+        descr = request.form.get('description', '')
+        if descr and len(descr) > 10000:
+            abort(400)
+        for key in ['ksp-forum-user', 'kerbalx', 'github', 'twitter', 'reddit', 'irc-nick']:
+            val = request.form.get(key, '')
+            if val and len(val) > 128:
+                abort(400)
+        profile.description = descr
         profile.forumUsername = request.form.get('ksp-forum-user')
         if profile.forumUsername:
             match = FORUM_PROFILE_URL_PATTERN.match(profile.forumUsername)


### PR DESCRIPTION
## Problem

The server recently had to be restarted with lots of this in the log:

```
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(10000)
```

## Cause

The database only allows 10000 characters for user descriptions.

https://github.com/KSP-SpaceDock/SpaceDock/blob/dbd67221961376193983028c8977c51b5296204d/KerbalStuff/objects.py#L69

But the Python code just passes whatever it receives, and some spammer tried to create a user description that was too long. Somehow this seems to have confused gunicorn into repeating the attempt and taking up lots of CPU. Auto retry somehow?

## Changes

Now the profile save code check the lengths of the inputs before using them, and if any exceeds their limits, it aborts. Similar to a side fix in #357 for mod editing.

Fixes #469.
