### PR TITLE
Lock icon for locked mods

### DIFF
--- a/frontend/styles/listing.scss
+++ b/frontend/styles/listing.scss
@@ -79,14 +79,15 @@
         border-radius: 0;
     }
 
-    .follow-mod-button, .unfollow-mod-button, .download-link, .following-mod-indicator {
+    .follow-mod-button, .unfollow-mod-button, .download-link, .following-mod-indicator, .locked-mod-indicator {
         text-decoration: none;
         font-size: 20px;
         margin-top: -2px;
         color: #07acd2;
     }
-    .follow-mod-button, .unfollow-mod-button, .following-mod-indicator {
+    .follow-mod-button, .unfollow-mod-button, .following-mod-indicator, .locked-mod-indicator {
         float: left;
+        margin-right: 5px;
     }
     .following-mod-indicator,
     .unfollow-mod-button,

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -19,6 +19,9 @@
                     </div>
                 {% endif %}
                 <div class="mod-ftr">
+                    {% if mod.locked %}
+                        <span title="Locked" class="locked-mod-indicator glyphicon glyphicon-lock"></span>
+                    {% endif %}
                     <a class="following-mod-indicator glyphicon glyphicon-star"></a>
                 </div>
                 <div class="caption">
@@ -34,6 +37,9 @@
                     </div>
                 </a>
                 <div class="mod-ftr">
+                    {% if mod.locked %}
+                        <span title="Locked" class="locked-mod-indicator glyphicon glyphicon-lock"></span>
+                    {% endif %}
                     <a href="#" title="Unfollow" class="unfollow-mod-button glyphicon glyphicon-star" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
                     <a href="#" title="Follow" class="follow-mod-button glyphicon glyphicon-star-empty" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
 


### PR DESCRIPTION
Now locked mods have a 🔒 icon in listings (in which they're only visible to admins):

![image](https://user-images.githubusercontent.com/1559108/223858474-2f3998c8-cfa7-44a3-a730-e02bc6486267.png)

Fixes #474.