### PR TITLE
Game list and modpack fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html text eol=lf

--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -27,7 +27,7 @@ def game(gameshort: str) -> str:
     new = get_new_mods(ga.id, 6)
     recent = get_updated_mods(ga.id, 6)
     user_count = User.query.count()
-    mod_count = Mod.query.filter(Mod.game_id == ga.id, Mod.published == True).count()
+    mod_count = ga.mod_count()
     following = sorted(filter(lambda m: m.game_id == ga.id, current_user.following),
                        key=lambda m: m.updated, reverse=True)[:6] if current_user else list()
     return render_template("game.html",

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -216,7 +216,7 @@ def get_follow_events(mod_id: int, timeframe: Optional[timedelta] = None) -> Lis
 
 
 def get_games() -> List[Game]:
-    return Game.query.filter(Game.active).order_by(Game.created.desc()).all()
+    return Game.query.filter(Game.active).order_by(Game.name).all()
 
 
 def get_game_info(**query: str) -> Game:

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -199,6 +199,9 @@ class Game(Base):  # type: ignore
     def get_abbrev(self, gamename: str) -> str:
         return gamename if len(gamename) < 7 else ''.join(self.ABBREV_PATTERN.findall(gamename))
 
+    def mod_count(self) -> int:
+        return Mod.query.filter(Mod.game_id == self.id, Mod.published == True).count()
+
     def __repr__(self) -> str:
         return '<Game %r %r>' % (self.id, self.name)
 

--- a/frontend/coffee/edit_pack.coffee
+++ b/frontend/coffee/edit_pack.coffee
@@ -123,7 +123,7 @@ document.getElementById('add-mod-button').addEventListener('click', (e) ->
 
 move_up = (e) ->
     e.preventDefault()
-    mod_id = e.currentTarget.dataset.mod
+    mod_id = parseInt(e.currentTarget.dataset.mod, 10)
     move_where(mod_id, -1)
 
 move_down = (e) ->

--- a/templates/game-box.html
+++ b/templates/game-box.html
@@ -1,4 +1,4 @@
-<div class="item col-md-2 gamebox">
+<div class="item col-md-4 gamebox">
     <div class="thumbnail">
         <a class="header-img-link" href="/{{ game.short }}">
             <div class="header-img" style="
@@ -13,10 +13,8 @@
         <div class="caption">
             <h2 class="group inner list-group-item-heading">
                 {{ game.name }}
+                <small class="text-muted">({{ game.mod_count() }} mods)</small>
             </h2>
-            <div id="game-{{ game.id }}" class="caption-description">
-                {{ game.short_description }}
-            </div>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,9 +33,11 @@
         </div>
         <div class="container">
             <div class="row">
-                {% for game in games  %}
-                {% include "game-box.html" %}
-                {% endfor %}
+                {%- for game in games  -%}
+                    {%- if game.mod_count() > 0 -%}
+                        {% include "game-box.html" %}
+                    {%- endif -%}
+                {%- endfor -%}
             </div>
         </div>
         {% if not user %}

--- a/templates/packs.html
+++ b/templates/packs.html
@@ -18,6 +18,7 @@
                 {% include "pack-box.html" %}
             {% endfor %}
         </div>
+        {%- if total_pages > 1 -%}
         <div style="margin-top: 5mm" class="row" style="margin-bottom:2.5mm;">
             <div class="col-md-2">
                 {% if page != 1 %}
@@ -37,5 +38,6 @@
                 {% endif %}
             </div>
         </div>
+        {%- endif -%}
     </div>
 {% endblock %}


### PR DESCRIPTION
## Problems

- The top-level games list currently shows games with 0 mods (such as Balsa), even though if you click on it, there's nothing of value to be seen
- The ordering of the games has no apparent sense to it (it's in order of creation, which the user can't possibly figure out or use to find a game of interest)
- The page index and count always appears in the modpack listing, even if there's only one page
- At certain page widths, the boxes for KSP1 and KSP2 look identical
  ![image](https://user-images.githubusercontent.com/1559108/224787368-66cdeb5e-a177-4f32-9c7b-aef0f3b148d5.png)
- When editing a modpack, the up arrow to reorder the mods just swaps the last two mods, regardless of which one you click

## Causes

- The modpack's list of mod ids contains integers, but the up arrow tries to match them against a string version of a mod id (down arrow already converts to int and works), so it gets an index of `-1`, which corresponds to the last element in the list, which is then swapped with the previous element

## Changes

- Now games with 0 mods will be hidden from the mod list (note, Balsa will still be available on the game selection dropdown for mod creation if anyone ever makes a Balsa mod)
- Now the games are sorted alphabetically
- Now the page index and count only appear in the modpack listing if there are multiple pages
- Now the game boxes use double width like the modpack box already does
- Now the mod count is displayed after the game name
- Now the up arrow works in modpack editing

After this the game list looks like this in a somewhat narrow browser window (with the actual mod counts instead of "0 mods" for those games):

![image](https://user-images.githubusercontent.com/1559108/224784725-a4fe70c0-5010-4f5c-82fd-eed853422d2a.png)
