### PR TITLE
 Game thumbnails

### DIFF
--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -32,6 +32,8 @@ def game(gameshort: str) -> str:
                        key=lambda m: m.updated, reverse=True)[:6] if current_user else list()
     return render_template("game.html",
                            ga=ga,
+                           background=ga.background_url(_cfg('protocol'), _cfg('cdn-domain')),
+                           editable=current_user and current_user.admin,
                            featured=featured,
                            new=new,
                            top=top,
@@ -39,6 +41,30 @@ def game(gameshort: str) -> str:
                            user_count=user_count,
                            mod_count=mod_count,
                            yours=following)
+
+
+@anonymous.route("/<gameshort>/background")
+def game_background(gameshort: str) -> werkzeug.wrappers.Response:
+    ga = get_game_info(short=gameshort)
+    if not ga:
+        abort(404)
+    if not ga.background:
+        # This won't happen normally, as background_url() only redirects here if background is set.
+        # However, it's possible that someone calls this manually.
+        abort(404)
+    return sendfile(ga.background, False)
+
+
+@anonymous.route("/<gameshort>/thumb")
+def game_thumbnail(gameshort: str) -> werkzeug.wrappers.Response:
+    ga = get_game_info(short=gameshort)
+    if not ga:
+        abort(404)
+    if not ga.thumbnail:
+        # This won't happen normally, as thumbnail_url() only redirects here if background is set.
+        # However, it's possible that someone calls this manually.
+        abort(404)
+    return sendfile(ga.thumbnail, False)
 
 
 @anonymous.route("/content/<path:path>")

--- a/KerbalStuff/blueprints/lists.py
+++ b/KerbalStuff/blueprints/lists.py
@@ -141,11 +141,6 @@ def list_background(pack_id: int, pack_name: str) -> werkzeug.wrappers.Response:
 
     if not pack:
         abort(404)
-    if not current_user:
-        abort(401)
-    if current_user.id != pack.user_id:
-        if not current_user.admin:
-            abort(403)
 
     if not pack.background:
         # This won't happen for pack pages, as ModList.background_url() only redirects here if ModList.background is set.
@@ -161,11 +156,6 @@ def list_thumbnail(pack_id: int, pack_name: str) -> werkzeug.wrappers.Response:
 
     if not pack:
         abort(404)
-    if not current_user:
-        abort(401)
-    if current_user.id != pack.user_id:
-        if not current_user.admin:
-            abort(403)
 
     if not pack.thumbnail:
         # This won't happen for mod boxes, as Mod.background_thumb() only redirects here if Mod.thumbnail is set.

--- a/KerbalStuff/thumbnail.py
+++ b/KerbalStuff/thumbnail.py
@@ -9,7 +9,7 @@ from KerbalStuff.config import _cfg, _cfgi, site_logger
 from KerbalStuff.database import db
 
 if TYPE_CHECKING:
-    from KerbalStuff.objects import Mod, ModList
+    from KerbalStuff.objects import Mod, ModList, Game
 
 
 def create(background_path: str, thumbnail_path: str) -> None:
@@ -140,6 +140,48 @@ def get_or_create_pack(pack: 'ModList') -> Optional[str]:
         return f'{protocol}://{cdn_domain}/{pack.thumbnail}'
     else:
         return url_for('lists.list_thumbnail', pack_id=pack.id, pack_name=pack.name)
+
+
+# Returns the URL for the thumbnail
+def get_or_create_game(game: 'Game') -> Optional[str]:
+    protocol = _cfg('protocol')
+    cdn_domain = _cfg('cdn-domain')
+
+    if not game.thumbnail:
+        storage = _cfg('storage')
+        if not game.background:
+            return None
+        if not storage:
+            return game.background_url(protocol, cdn_domain)
+
+        thumb_path = thumb_path_from_background_path(game.background)
+
+        thumb_disk_path = os.path.join(storage, thumb_path)
+        background_disk_path = os.path.join(storage, game.background)
+
+        logging.debug("Checking file system for thumbnail")
+        if not os.path.isfile(thumb_disk_path):
+            if not os.path.isfile(background_disk_path):
+                site_logger.warning('Background image does not exist, clearing path from db')
+                game.background = None
+                db.add(game)
+                db.commit()
+                return None
+            try:
+                logging.debug("Creating thumbnail")
+                create(background_disk_path, thumb_disk_path)
+            except Exception as e:
+                site_logger.exception(e)
+                return game.background_url(protocol, cdn_domain)
+        game.thumbnail = thumb_path
+        db.add(game)
+        db.commit()
+
+    # Directly return the CDN path if we have any, so we don't have a redirect that breaks caching.
+    if protocol and cdn_domain:
+        return f'{protocol}://{cdn_domain}/{game.thumbnail}'
+    else:
+        return url_for('anonymous.game_thumbnail', gameshort=game.short)
 
 
 def thumb_path_from_background_path(background_path: str) -> str:

--- a/alembic/versions/2023_03_14_18_49_21-b9e4c97b74c1.py
+++ b/alembic/versions/2023_03_14_18_49_21-b9e4c97b74c1.py
@@ -1,0 +1,22 @@
+"""Create Game.thumbnail
+
+Revision ID: b9e4c97b74c1
+Revises: 3a9de8cf341d
+Create Date: 2023-03-14 18:49:24.632850
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b9e4c97b74c1'
+down_revision = '3a9de8cf341d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.add_column('game', sa.Column('thumbnail', sa.VARCHAR(length=512), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('game', 'thumbnail')

--- a/frontend/coffee/game.coffee
+++ b/frontend/coffee/game.coffee
@@ -1,0 +1,34 @@
+window.upload_bg = (files, box) ->
+    file = files[0]
+    p = document.createElement('p')
+    p.textContent = 'Uploading...'
+    p.className = 'status'
+    box.appendChild(p)
+    box.querySelector('a').classList.add('hidden')
+    progress = box.querySelector('.upload-progress')
+
+    xhr = new XMLHttpRequest()
+    xhr.open('POST', "/api/game/#{window.game_id}/update-bg")
+    xhr.setRequestHeader('Accept', 'application/json')
+    xhr.upload.onprogress = (e) ->
+        if e.lengthComputable
+            progress.style.width = (e.loaded / e.total) * 100 + '%'
+    xhr.onload = (e) ->
+        if xhr.status != 200
+            p.textContent = 'Please upload JPG or PNG only.'
+            setTimeout(() ->
+                box.removeChild(p)
+                box.querySelector('a').classList.remove('hidden')
+            , 3000)
+        else
+            resp = JSON.parse(xhr.responseText)
+            p.textContent = 'Done!'
+            document.getElementById('header-well').style.backgroundImage =
+              'url("' + resp.path + '?nocache=' + new Date().getTime() + '")'
+            setTimeout(() ->
+                box.removeChild(p)
+                box.querySelector('a').classList.remove('hidden')
+            , 3000)
+    formdata = new FormData()
+    formdata.append('image', file)
+    xhr.send(formdata)

--- a/templates/game.html
+++ b/templates/game.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% block styles %}
 <link rel="stylesheet" type="text/css" href="/static/index.css" />
+<link rel="stylesheet" type="text/css" href="/static/mod.css" />
 {% endblock %}
 {% block opengraph %}
     <meta property="og:title" content="Mods for {{ ga.name }} on {{ site_name }}">
@@ -10,6 +11,23 @@
     <meta property="og:image" content="{{ thumbnail }}">
 {% endblock %}
 {% block body %}
+{%- if editable -%}
+<div class="header upload-well scrollable" id="header-well" style="
+    {% if background %}background-image: url({{ background }});{% endif %}
+    background-position: 0 {% if ga.bgOffsetY %}{{ ga.bgOffsetY }}px{% else %}0{% endif %};
+    background-color: #ddd;"
+    data-event="upload_bg"
+    data-scroll-y="bg-offset-y">
+    <a href="#" class="upload-link">Click to upload header</a>
+    <input type="file">
+    <div class="upload-progress"></div>
+    <div class="directions"><span class="glyphicon glyphicon-resize-vertical"></span>Click and drag to move <span class="glyphicon glyphicon-resize-vertical"></span></div>
+</div>
+<input type="hidden" name="bg-offset-y" id="bg-offset-y" value="{% if ga.bgOffsetY %}{{ ga.bgOffsetY }}{% endif %}">
+{%- elif background -%}
+<div class="header" style="background-image: url({{ background }});
+    background-position: 0 {% if ga.bgOffsetY %}{{ ga.bgOffsetY }}px{% else %}0{% endif %};"></div>
+{%- endif -%}
 {% if user and len(yours) >= 1 %}
     <div class="well" style="margin-bottom: 0;">
         <div class="container main-cat">
@@ -104,4 +122,10 @@
         </div>
     </div>
 </div>
+{% endblock %}
+{% block scripts %}
+    <script>
+        window.game_id = {{ga.id}};
+    </script>
+    <script src="/static/game.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Motivation

With the addition of KSP2, SpaceDock now has another game listed with a similar name, so the usability of the list of games has become more important. See #477 for some previous clean-up of that list.

There is some support for game header images in the database, but none in the code. It would be nice to have this to make it easier to spot the game that interests you in the game list.

## Changes

Now the existing support for profile and mod header images is applies to games.

- A `Game.thumbnail` column is created
- Admins can see a "Click to upload header" link when viewing the main page for a game
- If used, the link populates `Game.background` and `Game.thumbnail`
- If populated, `Game.background` appears across the top of a game's page
- If populated, `Game.thumbnail` is used for the game's entry in the list of games
- Fixed a bug noticed in passing: mod pack thumbnails and header images were only visible to the same user or admins, now everyone can see them
