### PR TITLE
Auto-import KSP2 versions from CKAN

### DIFF
--- a/KerbalStuff/celery.py
+++ b/KerbalStuff/celery.py
@@ -15,7 +15,7 @@ from .common import with_session
 from .config import _cfg, _cfgi, _cfgb, site_logger
 from .objects import Mod
 from .search import get_mod_score
-from .ckan import import_ksp_versions_from_ckan
+from .ckan import import_ksp_versions_from_ckan, import_ksp2_versions_from_ckan
 
 app = Celery("tasks", broker=_cfg("redis-connection"))
 
@@ -131,6 +131,10 @@ def ckan_version_import() -> None:
     game_id = _cfgi('ksp-game-id', -1)
     if game_id > 0:
         import_ksp_versions_from_ckan(game_id)
+    game2_id = _cfgi('ksp2-game-id', -1)
+    if game2_id > 0:
+        import_ksp2_versions_from_ckan(game2_id)
+
 
 # to debug this:
 # * add PTRACE capability to celery container via docker-compose.yaml

--- a/config.ini.example
+++ b/config.ini.example
@@ -30,6 +30,10 @@ registration=True
 # Its GameVersions will automatically sync up with CKAN's KSP builds.json.
 ksp-game-id=
 
+# Set this to the id of the Game that represents KSP2.
+# Its GameVersions will automatically sync up with CKAN's KSP2 builds.json.
+ksp2-game-id=
+
 # Thumbnail size in WxH format. Defaults to 320x195 if not set.
 # The better it matches the aspect ratio as it is displayed in the mod box, the better the quality.
 # It's somewhere between 16:9 and 16:10, but changes a bit based on client screen size.


### PR DESCRIPTION
This extends the work from #294 to cover KSP2.

- <https://github.com/KSP-CKAN/KSP2-CKAN-meta/blob/main/builds.json>

Enable with configuration:

```ini
ksp2-game-id = 12345
```
