### PR TITLE
Easier sorting

### DIFF
--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -10,6 +10,7 @@ from ..common import dumb_object, paginate_query, get_paginated_mods, get_game_i
 from ..config import _cfg
 from ..database import db
 from ..objects import Featured, Mod, ModVersion, User
+from ..search import apply_search_to_query
 
 anonymous = Blueprint('anonymous', __name__)
 
@@ -86,9 +87,12 @@ def browse() -> str:
 
 @anonymous.route("/browse/new")
 def browse_new() -> str:
-    mods = Mod.query.filter(Mod.published).order_by(Mod.created.desc())
-    mods, page, total_pages = paginate_query(mods)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
+    query = request.args.get('query', '')
+    mods, page, total_pages = paginate_query(apply_search_to_query(
+        Mod.query.filter(Mod.published).order_by(Mod.created.desc()),
+        query))
+    return render_template("browse-list.html", mods=mods, sort='new', query=query,
+                           page=page, total_pages=total_pages,
                            url="/browse/new", name="Newest Mods", rss="/browse/new.rss")
 
 
@@ -105,9 +109,12 @@ def browse_new_rss() -> Response:
 
 @anonymous.route("/browse/updated")
 def browse_updated() -> str:
-    mods = Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(Mod.updated.desc())
-    mods, page, total_pages = paginate_query(mods)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
+    query = request.args.get('query', '')
+    mods, page, total_pages = paginate_query(apply_search_to_query(
+        Mod.query.filter(Mod.published, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(Mod.updated.desc()),
+        query))
+    return render_template("browse-list.html", mods=mods, sort='updated', query=query,
+                           page=page, total_pages=total_pages,
                            url="/browse/updated", name="Recently Updated Mods", rss="/browse/updated.rss")
 
 
@@ -125,8 +132,11 @@ def browse_updated_rss() -> Response:
 
 @anonymous.route("/browse/top")
 def browse_top() -> str:
-    mods, page, total_pages = get_paginated_mods()
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
+    query = request.args.get('query', '')
+    mods, page, total_pages = get_paginated_mods(query=query)
+    return render_template("browse-list.html",
+                           mods=mods, sort='popularity', query=query,
+                           page=page, total_pages=total_pages,
                            url="/browse/top", name="Popular Mods")
 
 
@@ -158,8 +168,10 @@ def browse_featured_rss() -> Response:
 
 @anonymous.route("/browse/all")
 def browse_all() -> str:
-    mods, page, total_pages = get_paginated_mods()
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
+    query = request.args.get('query', '')
+    mods, page, total_pages = get_paginated_mods(query=query)
+    return render_template("browse-list.html", mods=mods, sort='popularity', query=query,
+                           page=page, total_pages=total_pages,
                            url="/browse/all", name="All Mods")
 
 
@@ -175,9 +187,12 @@ def singlegame_browse(gameshort: str) -> str:
 @anonymous.route("/<gameshort>/browse/new")
 def singlegame_browse_new(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id).order_by(Mod.created.desc())
-    mods, page, total_pages = paginate_query(mods)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
+    query = request.args.get('query', '')
+    mods, page, total_pages = paginate_query(apply_search_to_query(
+        Mod.query.filter(Mod.published, Mod.game_id == ga.id).order_by(Mod.created.desc()),
+        query))
+    return render_template("browse-list.html", mods=mods, sort='new', query=query,
+                           page=page, total_pages=total_pages, ga=ga,
                            url="/browse/new", name="Newest Mods", rss="/browse/new.rss")
 
 
@@ -197,9 +212,12 @@ def singlegame_browse_new_rss(gameshort: str) -> Response:
 @anonymous.route("/<gameshort>/browse/updated")
 def singlegame_browse_updated(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods = Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(Mod.updated.desc())
-    mods, page, total_pages = paginate_query(mods)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
+    query = request.args.get('query', '')
+    mods, page, total_pages = paginate_query(apply_search_to_query(
+        Mod.query.filter(Mod.published, Mod.game_id == ga.id, Mod.versions.any(ModVersion.id != Mod.default_version_id)).order_by(Mod.updated.desc()),
+        query))
+    return render_template("browse-list.html", mods=mods, sort='updated', query=query,
+                           page=page, total_pages=total_pages, ga=ga,
                            url="/browse/updated", name="Recently Updated Mods", rss="/browse/updated.rss")
 
 
@@ -220,8 +238,10 @@ def singlegame_browse_updated_rss(gameshort: str) -> Response:
 @anonymous.route("/<gameshort>/browse/top")
 def singlegame_browse_top(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods, page, total_pages = get_paginated_mods(ga)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
+    query = request.args.get('query', '')
+    mods, page, total_pages = get_paginated_mods(ga, query)
+    return render_template("browse-list.html", mods=mods, sort='popularity', query=query,
+                           page=page, total_pages=total_pages, ga=ga,
                            url="/browse/top", name="Popular Mods")
 
 
@@ -257,8 +277,10 @@ def singlegame_browse_featured_rss(gameshort: str) -> Response:
 @anonymous.route("/<gameshort>/browse/all")
 def singlegame_browse_all(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods, page, total_pages = get_paginated_mods(ga)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
+    query = request.args.get('query', '')
+    mods, page, total_pages = get_paginated_mods(ga, query)
+    return render_template("browse-list.html", mods=mods, sort='popularity', query=query,
+                           page=page, total_pages=total_pages, ga=ga,
                            url="/browse/all", name="All Mods")
 
 
@@ -279,14 +301,16 @@ def privacy() -> str:
 
 @anonymous.route("/search")
 def search() -> str:
-    query = request.args.get('query') or ''
+    query = request.args.get('query', '')
     mods, page, total_pages = get_paginated_mods(query=query)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, search=True, query=query)
+    return render_template("browse-list.html", mods=mods, sort='popularity', query=query,
+                           page=page, total_pages=total_pages, search=True)
 
 
 @anonymous.route("/<gameshort>/search")
 def singlegame_search(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    query = request.args.get('query') or ''
+    query = request.args.get('query', '')
     mods, page, total_pages = get_paginated_mods(ga, query)
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, search=True, query=query, ga=ga)
+    return render_template("browse-list.html", mods=mods, sort='popularity', query=query,
+                           page=page, total_pages=total_pages, search=True, ga=ga)

--- a/templates/browse-list.html
+++ b/templates/browse-list.html
@@ -13,7 +13,7 @@
 <div class="well">
     <div class="container main-cat">
         {% if rss %}
-        <a href="{% if ga %}/{{ ga.short }}{% endif %}{{ rss }}" class="pull-right"><img src="/static/rss.png" height=38 /></a>
+        <h3 class="pull-right"><a href="{% if ga %}/{{ ga.short }}{% endif %}{{ rss }}"><img src="/static/rss.png" style="height: 1em;"/></a></h3>
         {% endif %}
         {% if search %}
         <h3>Search results for "{{ query }}"</h3>
@@ -22,8 +22,28 @@
         {% endif %}
     </div>
 </div>
+{% set qparam = {'query': query} if query else {} %}
 <div class="container">
-    {% if search and not any(mods) %}
+    {% if sort %}
+        <div class="text-right" style="margin-right: 1em;">
+            Sort by
+            <div class="btn-group">
+                <a class="btn btn-default {{"active" if sort == "popularity" else ""}}"
+                   href="{{url_for('anonymous.singlegame_browse_top', gameshort=ga.short, **qparam)
+                           if ga else
+                           url_for('anonymous.browse_top', **qparam)}}">Popularity</a>
+                <a class="btn btn-default {{"active" if sort == "new" else ""}}"
+                   href="{{url_for('anonymous.singlegame_browse_new', gameshort=ga.short, **qparam)
+                           if ga else
+                           url_for('anonymous.browse_new', **qparam)}}">New</a>
+                <a class="btn btn-default {{"active" if sort == "updated" else ""}}"
+                   href="{{url_for('anonymous.singlegame_browse_updated', gameshort=ga.short, **qparam)
+                           if ga else
+                           url_for('anonymous.browse_updated', **qparam)}}">Updated</a>
+            </div>
+        </div>
+    {% endif %}
+    {% if not any(mods) %}
     <p>Nothing to see here. If you're looking for a specific mod, why not ask the modder to upload it here?</p>
     {% endif %}
     <div class="row">
@@ -36,11 +56,13 @@
         <div class="col-md-2">
             {%- if page != 1 -%}
             <a class="btn btn-lg btn-primary btn-block"
-                href="{%- if search -%}
-                {% if ga %}/{{ ga.short }}{% endif %}/search?query={{ query | escape }}&page={{ page - 1 }}
-                {%- else -%}
-                {% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page - 1 }}
-                {%- endif -%}">
+               href="{{(url_for('anonymous.singlegame_search', gameshort=ga.short, page=page-1, **qparam)
+                        if ga else
+                        url_for('anonymous.search', page=page-1, **qparam))
+                       if search else
+                       ('/' ~ ga.short ~ url ~ '?query=' ~ query ~ '&page=' ~ (page-1)
+                        if ga else
+                        url ~ '?query=' ~ query ~ '&page=' ~ (page-1))}}">
                 <span class="glyphicon glyphicon-arrow-left"></span> Previous
             </a>
             {%- endif -%}
@@ -48,12 +70,14 @@
         <div class="col-md-8 centered text-muted">Page {{ page }} / {{ total_pages }}</div>
         <div class="col-md-2">
             {%- if page < total_pages -%}
-            <a href="{%- if search -%}
-                {% if ga %}/{{ ga.short }}{% endif %}/search?query={{ query | escape }}&page={{ page + 1 }}
-                {%- else -%}
-                {% if ga %}/{{ ga.short }}{% endif %}{{ url }}?page={{ page + 1 }}
-                {%- endif -%}"
-                class="btn btn-lg btn-primary btn-block">
+            <a class="btn btn-lg btn-primary btn-block"
+               href="{{(url_for('anonymous.singlegame_search', gameshort=ga.short, page=page+1, **qparam)
+                        if ga else
+                        url_for('anonymous.search', page=page+1, **qparam))
+                       if search else
+                       ('/' ~ ga.short ~ url ~ '?query=' ~ query ~ '&page=' ~ (page+1)
+                        if ga else
+                        url ~ '?query=' ~ query ~ '&page=' ~ (page+1))}}">
                 Next <span class="glyphicon glyphicon-arrow-right"></span>
             </a>
             {%- endif -%}


### PR DESCRIPTION
## Background

SpaceDock has three main ways of sorting mod lists:

- Highest score at top
- Most recently created at top
- Most recently updated at top

When you perform a text search, the sort is only by score.

## Motivation

It's not easy to tell that this is how it works, and it's even less easy to switch between different sorts; you have to go back to the game's main page and click a different link.

It's desirable to be able to tell what the current sort is and change it.

Additional sort methods for searching could be useful.

## Changes

- Now mod lists using one of those three sorts contain a sorting control in the upper right that indicates the current sort and allows the user to switch to the others:
  ![image](https://user-images.githubusercontent.com/1559108/226648814-d8002c8a-4810-4049-acfe-11788478f88e.png)
  - To make this fit nicely on the screen, the RSS icon in the page header is now the same height as the text so the header doesn't change size between New/Updated (which have the icon) and Popularity (which doesn't)
- Now the `&query=` URL parameter for `/search` works for all of the sorts, and is preserved when you click the sort-by buttons, so you can perform a search and then sort it by New/Updated if you wish
