### PR TITLE
Fix changelog editing for co-authors

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -206,15 +206,9 @@ def mod(mod_id: int, mod_name: str) -> Union[str, werkzeug.wrappers.Response]:
 @mods.route("/mod_changelog/<int:mod_id>")
 def mod_changelog(mod_id: int) -> Union[str, werkzeug.wrappers.Response]:
     mod, ga = _get_mod_game_info(mod_id)
-    editable = False
-    if current_user:
-        if current_user.id == mod.user_id:
-            if request.args.get('new') is not None:
-                return redirect(url_for("mods.edit_mod", mod_id=mod.id, mod_name=mod.name) + '?new=true')
-            else:
-                editable = True
-        elif current_user.admin:
-            editable = True
+    if current_user and current_user.id == mod.user_id and request.args.get('new') is not None:
+        return redirect(url_for("mods.edit_mod", mod_id=mod.id, mod_name=mod.name) + '?new=true')
+    editable = check_mod_editable(mod, None)
     json_versions = list()
     size_versions = dict()
     storage = _cfg('storage')


### PR DESCRIPTION
## Problem

@BrettRyland reported on Discord that he couldn't edit the changelog entries for this mod:

- <https://spacedock.info/mod/2487/BDArmory%20Plus>

This mod was editable for him though:

- <https://spacedock.info/mod/2657/Camera%20Tools%20continued>

## Cause

In one case, the user is the main author, in the other a co-author.

As of #414, the co-author check is missing from the new `/mod_changelog` route:

https://github.com/KSP-SpaceDock/SpaceDock/blob/af016ae8f28e8cf320363741b90cc40cd31e6f86/KerbalStuff/blueprints/mods.py#L209-L217

Previously `editable` would have been set to `True` during the `/mod` route's loop to add the co-authors to the display.

## Changes

Now we use `mod_check_editable` to determine editability, which handles co-authors.
