### PR TITLE
Send co-authors to CKAN as POST form lists

### DIFF
--- a/KerbalStuff/notification.py
+++ b/KerbalStuff/notification.py
@@ -21,6 +21,7 @@ def send_add_notification(notif: EnabledNotification) -> None:
         protocol = _cfg('protocol')
         domain = _cfg('domain')
         site_name = _cfg('site-name')
+        authors = notif.mod.all_authors()
         if protocol and domain and site_name:
             storage = _cfg('storage')
             site_base_url = protocol + "://" + domain
@@ -28,16 +29,18 @@ def send_add_notification(notif: EnabledNotification) -> None:
                      {'name': notif.mod.name,
                       'id': notif.mod.id,
                       'license': notif.mod.license,
-                      **user_fields(notif.mod.user),
-                      'shared_authors': [user_fields(sh.user)
-                                         for sh in notif.mod.shared_authors
-                                         if sh.accepted],
+                      'username': [user.username for user in authors],
+                      'user_github': [user.githubUsername for user in authors],
+                      'user_forum_id': [user.forumId for user in authors],
+                      'user_forum_username': [user.forumUsername for user in authors],
+                      'email': [user.email for user in authors],
+                      'user_url': [site_base_url + url_for("profile.view_profile",
+                                                           username=user.username)
+                                   for user in authors],
                       'short_description': notif.mod.short_description,
                       'description': notif.mod.description,
                       'external_link': notif.mod.external_link,
                       'source_link': notif.mod.source_link,
-                      'user_url': site_base_url + url_for("profile.view_profile",
-                                                          username=notif.mod.user.username),
                       'mod_url': site_base_url + url_for('mods.mod',
                                                          mod_name=notif.mod.name,
                                                          mod_id=notif.mod.id),
@@ -45,14 +48,6 @@ def send_add_notification(notif: EnabledNotification) -> None:
                       'download_size': (notif.mod.default_version.format_size(storage)
                                         if notif.mod.default_version and storage else
                                         None)})
-
-
-def user_fields(user: User) -> Dict[str, str]:
-    return {'username': user.username,
-            'user_github': user.githubUsername,
-            'user_forum_id': user.forumId,
-            'user_forum_username': user.forumUsername,
-            'email': user.email}
 
 
 def send_change_notifications(mod: Mod, event_type: str, force: bool = False) -> None:

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -279,6 +279,9 @@ class Mod(Base):  # type: ignore
         else:
             return url_for('mods.mod_background', mod_id=self.id, mod_name=self.name)
 
+    def all_authors(self) -> List[User]:
+        return [self.user, *[sh.user for sh in self.shared_authors if sh.accepted]]
+
     def __repr__(self) -> str:
         return '<Mod %r %r>' % (self.id, self.name)
 


### PR DESCRIPTION
## Problem

See KSP-CKAN/NetKAN-Infra#293 and KSP-CKAN/NetKAN-Infra#294, the `shared_authors` property sent to CKAN just says `username`, so we can't use it to add the co-authors to pull requests.

## Cause

#435 was mis-guided; I thought the data sent to CKAN was in JSON format, but it's in POST form input format, which means it can only handle strings and lists of strings, not more complex data structures. That PR tried to send a list of dicts in the `shared_authors` property, which can't work.

## Changes

- Now `shared_authors` is no longer sent
- Now `Mod.all_authors` provides the main author and all the co-authors for convenience
- Now these POST form inputs are lists with one element per (co-)author:
  - `username`
  - `user_github`
  - `user_forum_id`
  - `user_forum_username`
  - `email`
  - `user_url` (which was missed in #435 anyway)

On the CKAN side, `request.form.get` will return just the first element of the list, which ensures backwards compatibility, and `request.form.getlist` will return the entire list, which will allow a future update to get the data for all of the authors.
