### PR TITLE
Show how many mods use each notification

### DIFF
--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -295,6 +295,10 @@ class Notification(Base):  # type: ignore
     add_url = Column(Unicode(1024))
     change_url = Column(Unicode(1024))
 
+    def mod_count(self) -> int:
+        return EnabledNotification.query.filter(
+            EnabledNotification.notification_id == self.id).count()
+
     def __repr__(self) -> str:
         return f'<Notification {self.id} {self.name}>'
 

--- a/templates/admin-notifications.html
+++ b/templates/admin-notifications.html
@@ -20,7 +20,7 @@
                 {% for notif in notifs %}
                     <div class="row">
                         <div class="col-md-7 col-md-offset-1">
-                            <span class="glyphicon glyphicon-link"></span> {{notif.name}}
+                            <span class="glyphicon glyphicon-link"></span> {{notif.name}} <span class="text-muted">({{notif.mod_count()}} mods)</span>
                             {% if notif.builds_url %}
                                 <div class="text-muted col-md-offset-1">
                                     <span class="glyphicon glyphicon-check"></span>


### PR DESCRIPTION
## Motivation

It would be nice to have a sense of how many mods are CKAN-enabled in the admin pages.

## Changes

Now the mod count appears in parentheses:

![image](https://user-images.githubusercontent.com/1559108/230790509-98289fa2-a489-44a6-a782-fd012be2547f.png)

This is done via an sqlalchemy `count()` call to ensure the db won't send the whole list back.
