### PR TITLE
Show add-mod button instead of empty game sections

### DIFF
--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -9,7 +9,7 @@ from ..common import dumb_object, paginate_query, get_paginated_mods, get_game_i
     get_featured_mods, get_top_mods, get_new_mods, get_updated_mods, sendfile
 from ..config import _cfg
 from ..database import db
-from ..objects import Featured, Mod, ModVersion, User
+from ..objects import Featured, Mod, ModVersion, User, ModList
 from ..search import apply_search_to_query
 
 anonymous = Blueprint('anonymous', __name__)
@@ -29,6 +29,7 @@ def game(gameshort: str) -> str:
     recent = get_updated_mods(ga.id, 6)
     user_count = User.query.count()
     mod_count = ga.mod_count()
+    pack_count = ModList.query.filter(ModList.game_id == ga.id, ModList.mods.any()).count()
     following = sorted(filter(lambda m: m.game_id == ga.id, current_user.following),
                        key=lambda m: m.updated, reverse=True)[:6] if current_user else list()
     return render_template("game.html",
@@ -41,6 +42,7 @@ def game(gameshort: str) -> str:
                            recent=recent,
                            user_count=user_count,
                            mod_count=mod_count,
+                           pack_count=pack_count,
                            yours=following)
 
 

--- a/templates/game.html
+++ b/templates/game.html
@@ -28,6 +28,7 @@
 <div class="header" style="background-image: url({{ background }});
     background-position: 0 {% if ga.bgOffsetY %}{{ ga.bgOffsetY }}px{% else %}0{% endif %};"></div>
 {%- endif -%}
+{% if mod_count > 0 %}
 {% if user and len(yours) >= 1 %}
     <div class="well" style="margin-bottom: 0;">
         <div class="container main-cat">
@@ -112,6 +113,7 @@
         {% endfor %}
     </div>
 </div>
+{% if pack_count > 0 %}
 <div class="container">
     <div class="row">
         <div class="col-md-12">
@@ -122,6 +124,23 @@
         </div>
     </div>
 </div>
+{% endif %}
+{% else %}
+<div class="well">
+    <div class="container lead">
+        <div class="row centered">
+            <div class="col-md-4 col-md-offset-4">
+                There are no mods for {{ga.name}} yet.
+            </div>
+        </div>
+        <div class="row centered">
+            <div class="col-md-4 col-md-offset-4">
+                <a class="btn btn-lg btn-block btn-primary" href="/create/mod">Be the first to add one!</a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
 {% endblock %}
 {% block scripts %}
     <script>


### PR DESCRIPTION
## Motivation

Currently Kitbash Model Club's page is empty because there are no mods for it, which looks like an error to any user wandering in there:

- <https://spacedock.info/Kitbash-Model-Club>

## History

Games with no mods were hidden from the front page in #477 and restored in 707f1afc04028a34989402f744e3f2e39bf739b5, because the team did not agree on the solution.

## Changes

Now when a game has no mods, we show an explicit explanation instead and a button inviting the user to upload something:

![image](https://user-images.githubusercontent.com/1559108/230790610-bd11772a-00d4-4af7-b630-dd947d803d8b.png)

This somewhat addresses the concern about a useless empty page while still keeping newly enabled games visible on the front page.

In addition, we no longer show a link to the list of modpacks if there are no modpacks for that game.
