### PR TITLE
Preserve admin user search after user deletion

### DIFF
--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -145,9 +145,11 @@ def delete_user(user_id: int) -> Union[str, werkzeug.wrappers.Response]:
         abort(404)
     db.delete(user)
     db.commit()
+    query = request.form.get('query', '')
     return redirect(url_for('admin.users',
                             page=request.form.get('page', 1),
-                            show_non_public=(request.form.get('show_non_public', '').lower() in TRUE_STR)))
+                            show_non_public=(request.form.get('show_non_public', '').lower() in TRUE_STR),
+                            query=query))
 
 
 @admin.route("/admin/locked_mods/<int:page>")

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -98,6 +98,7 @@
                         <input type="submit" id="btn-delete-{{user.id}}" class="btn btn-danger" value="Delete" disabled>
                         <input type="hidden" name="page" value="{{page}}">
                         <input type="hidden" name="show_non_public" value="{{show_non_public}}">
+                        <input type="hidden" name="query" value="{{query}}">
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Problem

1. Go to the admin pages user list
2. Search the users by some keyword such as "escort" or "callgirl"
3. Delete a user
4. The search resets, so you're back to the list of all users. This is inconvenient for deleting many users from the same search; you have to re-enter the search every time.

## Changes

Now after you delete a user from the admin user list, any search query you may have entered remains active, so mass-deleting spammers will be easier.
