### PR TITLE
Fix admin user deletion on profile

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -592,7 +592,7 @@ def delete(username: str) -> Tuple[Dict[str, Any], int]:
     if user == current_user:
         logout_user()
 
-    return {"error": False}, 400
+    return {"error": False}, 200
 
 
 @api.route('/api/mod/<int:mod_id>/update-bg', methods=['POST'])

--- a/frontend/coffee/profile.coffee
+++ b/frontend/coffee/profile.coffee
@@ -1,5 +1,6 @@
-editor = new Editor()
-editor.render()
+if $('textarea').length
+    editor = new Editor()
+    editor.render()
 
 # Background Uploading
 window.upload_bg = (files, box) ->
@@ -138,6 +139,21 @@ $('#delete-account-form').submit((e) ->
     xhr.send(form)
 )
 
+$('#confirm-delete-account').on 'show.bs.modal', (evt) ->
+    # Disable final Delete button on modal open
+    $(evt.target).find('input[type=submit]').prop('disabled', true)
+    # Clear username confirmation text box on modal open
+    $(evt.target).find('input[type=text]').val('')
+
+$('#confirm-delete-account').on 'shown.bs.modal', (evt) ->
+    # Focus text box on modal open
+    $(evt.target).find('input[type=text]').focus()
+
+$('#username').on 'input', (evt) ->
+    # Enable/disable final Delete button on confirmation text box change
+    $('#confirm-delete-account').find('input[type=submit]').prop('disabled',
+        evt.target.value != evt.target.dataset.username)
+
 deleteAccountModalDialog = () ->
     $('#delete-account-form').trigger('reset')
     error_message_display = $('#delete-account-error-message')
@@ -150,7 +166,7 @@ deleteAccountModalDialog = () ->
     for button in buttons
         button.removeAttribute('disabled')
 
-$('#delete-account').on('hidden.bs.modal', deleteAccountModalDialog)
+$('#confirm-delete-account').on('hidden.bs.modal', deleteAccountModalDialog)
 
 $('#check-all-updates'      ).on('click', () -> $('[id^=updates-]'    ).prop('checked', true))
 $('#uncheck-all-updates'    ).on('click', () -> $('[id^=updates-]'    ).prop('checked', false))

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -252,7 +252,7 @@
                     <div class="form-group">
                         <label for="username">Username</label>
                         <input type="text" id="username" placeholder="Enter the user's username to confirm" class="form-control"
-                               name="username">
+                               name="username" data-username="{{profile.username}}">
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Problem

As of #316, the user profile page now has a "Delete user" button for admins, which opens a confirmation dialog:

![image](https://user-images.githubusercontent.com/1559108/230791231-06d1073b-2e20-4597-8f99-8b74591d1da5.png)

![image](https://user-images.githubusercontent.com/1559108/230791247-b9d402de-6ced-4796-a4fd-d095d81a9045.png)

However, no matter what you do, the "Delete account" button in the confirmation popup doesn't work. The call to the server never happens.

## Cause

Since the profile editing page has a rich text box, and the `profile.coffee`/`profile.js` client file is shared between the profile editing page and the profile viewing page, the rich text editor tries to initialize on page load and throws an exception because there are no `textarea`s, just like in 1e130afadd510f081db1026070f0d58bc508cf6f.

This exception then stops the client code initialization, so the hooks that make the popup work are not set up.

## Changes

- Now we only try to load the rich text editor if we have a `textarea` for it to use. This will allow the initialization to complete and the "Delete account" button will work.
- The confirmation popup now dynamically enables and disables the "Delete account" button as the user types, to provide a cue as to when the input is valid, just like on the admin user list
- The `/api/user/<username>/delete` now returns 200 on success instead of 400
