### PR TITLE
Remove extra margin-top from h3 styles

### DIFF
--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -24,7 +24,6 @@
     }
 
     h3 {
-        margin-top: 0;
         padding-top: 0;
         font-size: 23pt;
         margin-top: 20px;


### PR DESCRIPTION
This is a completely unused line of code; ```margin-top``` is defined twice, and is overridden, making the top line completely useless.

🤔