### PR TITLE
Make sure JNO versions aren't empty

### DIFF
--- a/KerbalStuff/notification.py
+++ b/KerbalStuff/notification.py
@@ -83,7 +83,11 @@ def import_game_versions(notif: Notification) -> None:
 def game_versions_from_notif(url: str, fmt: str, argument: str) -> Iterable[str]:
     resp = requests.get(url)
     if fmt == 'plain_current':
-        yield resp.text
+        # Prune leading and trailing spaces
+        val = resp.text.strip()
+        # Make sure it's not empty
+        if val:
+            yield val
     elif fmt == 'json_list':
         yield from resp.json()
     elif fmt == 'json_nested_dict_values':


### PR DESCRIPTION
## Problem

A game version with an empty version string has been added, then deleted, then added again a couple of times:

![image](https://user-images.githubusercontent.com/1559108/232087152-95313afb-6bce-4137-8d5b-02d167e56b42.png)

## Cause

We don't know the exact cause of this since there are 2 or 3 different automated sources for this data currently:

- A PHP script by VITAS that accesses the official JNO versions API
- A PHP script by VITAS that parses JNO's blog post titles or something
- The built-in support from #480

However, we can construct a plausible narrative of how it happens: If the API sometimes glitches out and returns an empty string, the built-in support from #480 would add that empty string to the db because it doesn't check it.

However², the alpha and beta servers have both been using this code the same way as production, and neither has had this issue so far, so this explanation is not very likely.

## Changes

- Now the API call won't return empty versions
- Since VITAS mentioned trimming spaces, it now does that as well

If this is the cause, this will fix the problem.
