### PR TITLE
Support tables in markdown

### DIFF
--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -11,6 +11,7 @@ from typing import Union, List, Any, Optional, Callable, Tuple, Iterable
 import bleach
 import werkzeug.wrappers
 from bleach_allowlist import bleach_allowlist
+from bleach.css_sanitizer import CSSSanitizer
 from flask import jsonify, redirect, request, Response, abort, session, send_file, make_response, current_app
 from flask_login import current_user
 from markupsafe import Markup
@@ -34,11 +35,17 @@ def allow_iframe_attr(tagname: str, attrib: str, val: str) -> bool:
             attrib in EmbedInlineProcessor.IFRAME_ATTRIBS)
 
 
-cleaner = bleach.Cleaner(tags=bleach_allowlist.markdown_tags + ['iframe'],
+cleaner = bleach.Cleaner(tags=list({*bleach_allowlist.markdown_tags,
+                                    *bleach_allowlist.print_tags,
+                                    'iframe'}),
                          attributes={  # type: ignore[arg-type]
                              **bleach_allowlist.markdown_attrs,
+                             **bleach_allowlist.print_attrs,
+                             'th': ['style'],
+                             'td': ['style'],
                              'iframe': allow_iframe_attr
                          },
+                         css_sanitizer=CSSSanitizer(),
                          filters=[bleach.linkifier.LinkifyFilter])
 
 

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -29,6 +29,7 @@ requests
 requests-oauthlib
 SQLAlchemy>=1.4,<2 # 1.4 shows deprecation warnings for 2.0, 2.0 would break our backend as of now
 SQLAlchemy-Utils
+tinycss2
 urllib3
 user_agents
 Werkzeug


### PR DESCRIPTION
## Problem

@TedThompson stopped by the SpaceDock Discord to complain about #426 and also point out that SpaceDock's markdown doesn't support tables, as in:

```
Column 1 | Column 2 | Column 3
:-- | :-- | :--
Cell 4 | Cell 5 | Cell 6
```

## Cause

Apparently tables are considered part of [Markdown's "extended syntax"](https://www.markdownguide.org/extended-syntax/#tables), even though most users probably take for granted that they will always be supported. So the Python `markdown` module doesn't enable them by default; you have to use the `tables` extension.

## Changes

Now if you use Markdown table syntax, it'll render as expected:

![image](https://user-images.githubusercontent.com/1559108/232183411-eee22c91-7529-4f58-8bc0-86a338d1da57.png)

- Our Bleach config is updated to allow table-related elements and `style` attributes on table cells (for alignment)
- We use the `tables` extension, but not as shown in the examples, because by default it just creates a plain `<table>` element, which looks awful:
  ![image](https://user-images.githubusercontent.com/1559108/232183658-745a0919-ee85-46db-8175-3b92ec9a6afa.png)
  Instead, we subclass the table block processor so we can add `class="table-condensed table-bordered"` afterwards to make them look nicer.
