### PR TITLE
Let admins control ordering of featured mods

### DIFF
--- a/KerbalStuff/blueprints/anonymous.py
+++ b/KerbalStuff/blueprints/anonymous.py
@@ -144,10 +144,11 @@ def browse_top() -> str:
 
 @anonymous.route("/browse/featured")
 def browse_featured() -> str:
-    mods = Featured.query.order_by(Featured.created.desc())
-    mods, page, total_pages = paginate_query(mods)
-    mods = [f.mod for f in mods]
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages,
+    featured = Featured.query.order_by(Featured.priority.desc())
+    featured, page, total_pages = paginate_query(featured)
+    mods = [f.mod for f in featured]
+    return render_template("browse-list.html", mods=mods, featured=featured,
+                           page=page, total_pages=total_pages,
                            url="/browse/featured", name="Featured Mods", rss="/browse/featured.rss")
 
 
@@ -250,11 +251,12 @@ def singlegame_browse_top(gameshort: str) -> str:
 @anonymous.route("/<gameshort>/browse/featured")
 def singlegame_browse_featured(gameshort: str) -> str:
     ga = get_game_info(short=gameshort)
-    mods = Featured.query.outerjoin(Mod).filter(
-        Mod.game_id == ga.id).order_by(Featured.created.desc())
-    mods, page, total_pages = paginate_query(mods)
-    mods = [f.mod for f in mods]
-    return render_template("browse-list.html", mods=mods, page=page, total_pages=total_pages, ga=ga,
+    featured = Featured.query.outerjoin(Mod)\
+        .filter(Mod.game_id == ga.id)\
+        .order_by(Featured.priority.desc())
+    featured, page, total_pages = paginate_query(featured)
+    mods = [f.mod for f in featured]
+    return render_template("browse-list.html", mods=mods, featured=featured, page=page, total_pages=total_pages, ga=ga,
                            url="/browse/featured", name="Featured Mods", rss="/browse/featured.rss")
 
 

--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -406,7 +406,7 @@ def browse_top() -> Iterable[Dict[str, Any]]:
 @api.route("/api/browse/featured")
 @json_output
 def browse_featured() -> Iterable[Dict[str, Any]]:
-    mods = Featured.query.order_by(Featured.created.desc())
+    mods = Featured.query.order_by(Featured.priority.desc())
     mods, page, total_pages = paginate_query(mods)
     return serialize_mod_list((f.mod for f in mods))
 

--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -174,7 +174,7 @@ def get_paginated_mods(ga: Optional[Game] = None, query: str = '', page_size: in
 
 
 def get_featured_mods(game_id: Optional[int], limit: int) -> List[Mod]:
-    mods = Featured.query.outerjoin(Mod).filter(Mod.published).order_by(Featured.created.desc())
+    mods = Featured.query.outerjoin(Mod).filter(Mod.published).order_by(Featured.priority.desc())
     if game_id:
         mods = mods.filter(Mod.game_id == game_id)
     return mods.limit(limit).all()

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -27,7 +27,8 @@ class Following(Base):  # type: ignore
     send_autoupdate = Column(Boolean(), default=True, nullable=False)
 
     def __init__(self, mod: Optional['Mod'] = None, user: Optional['User'] = None,
-                 send_update: Optional[bool] = True, send_autoupdate: Optional[bool] = True) -> None:
+                 send_update: Optional[bool] = True,
+                 send_autoupdate: Optional[bool] = True) -> None:
         self.mod = mod
         self.user = user
         self.send_update = send_update
@@ -40,6 +41,7 @@ class Featured(Base):  # type: ignore
     mod_id = Column(Integer, ForeignKey('mod.id', ondelete='CASCADE'))
     mod = relationship('Mod', backref=backref('featured', passive_deletes=True, order_by=id))
     created = Column(DateTime, default=datetime.now, index=True)
+    priority = Column(Integer, nullable=False, index=True)
 
     def __repr__(self) -> str:
         return '<Featured %r>' % self.id

--- a/alembic/versions/2024_01_02_14_56_29-f5a5d29ec765.py
+++ b/alembic/versions/2024_01_02_14_56_29-f5a5d29ec765.py
@@ -1,0 +1,63 @@
+"""Add featured.priority
+
+Revision ID: f5a5d29ec765
+Revises: ba0c9afb6cb0
+Create Date: 2024-01-02 20:57:00.647417
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f5a5d29ec765'
+down_revision = 'ba0c9afb6cb0'
+
+from datetime import datetime
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import relationship, backref
+
+Base = sa.orm.declarative_base()
+
+class Featured(Base):  # type: ignore
+    __tablename__ = 'featured'
+    id = sa.Column(sa.Integer, primary_key=True)
+    mod_id = sa.Column(sa.Integer, sa.ForeignKey('mod.id', ondelete='CASCADE'))
+    mod = relationship('Mod', backref=backref('featured', passive_deletes=True, order_by=id))
+    created = sa.Column(sa.DateTime, default=datetime.now, index=True)
+    priority = sa.Column(sa.Integer, nullable=False, index=True)
+
+
+class Mod(Base):  # type: ignore
+    __tablename__ = 'mod'
+    id = sa.Column(sa.Integer, primary_key=True)
+    game_id = sa.Column(sa.Integer, sa.ForeignKey('game.id', ondelete='CASCADE'))
+    game = relationship('Game', backref=backref('mods', passive_deletes=True))
+
+
+class Game(Base):  # type: ignore
+    __tablename__ = 'game'
+    id = sa.Column(sa.Integer, primary_key=True)
+
+
+def upgrade() -> None:
+    op.add_column('featured', sa.Column('priority', sa.Integer(), nullable=True))
+    op.create_index('ix_featured_priority', 'featured', [sa.text('priority DESC')], unique=False)
+
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+    prio = 0
+    game_id = None
+    for feature in session.query(Featured)\
+                          .outerjoin(Mod)\
+                          .order_by(Mod.game_id, Featured.created)\
+                          .all():
+        prio = prio + 1 if game_id == feature.mod.game_id else 0
+        game_id = feature.mod.game_id
+        feature.priority = prio
+    session.commit()
+
+    op.alter_column('featured', 'priority', nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_featured_priority', table_name='featured')
+    op.drop_column('featured', 'priority')

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -109,18 +109,55 @@ link.addEventListener('click', (e) ->
     xhr = new XMLHttpRequest()
     if e.target.classList.contains('feature-button')
         xhr.open('POST', "/mod/#{e.target.dataset.mod}/feature")
-        xhr.setRequestHeader('Accept', 'application/json')
-        e.target.classList.remove('feature-button')
-        e.target.classList.add('unfeature-button')
-        e.target.textContent = 'Unfeature this mod'
     else
         xhr.open('POST', "/mod/#{e.target.dataset.mod}/unfeature")
-        xhr.setRequestHeader('Accept', 'application/json')
-        e.target.classList.remove('unfeature-button')
-        e.target.classList.add('feature-button')
-        e.target.textContent = 'Feature this mod'
+    xhr.setRequestHeader('Accept', 'application/json')
+    xhr.onload = () ->
+        response = JSON.parse this.responseText
+        if response.success
+            if e.target.classList.contains('feature-button')
+                e.target.classList.remove('feature-button')
+                e.target.classList.add('unfeature-button')
+                e.target.textContent = 'Unfeature this mod'
+            else
+                e.target.classList.remove('unfeature-button')
+                e.target.classList.add('feature-button')
+                e.target.textContent = 'Feature this mod'
+        else
+            $('#alert-error-text').text response.reason
+            $('#alert-error').removeClass 'hidden'
     xhr.send()
 , false) for link in document.querySelectorAll('.feature-button, .unfeature-button')
+
+link.addEventListener('click', (e) ->
+    xhr = new XMLHttpRequest()
+    mod_id = e.target.dataset.mod
+    xhr.open 'POST', "/mod/#{mod_id}/feature-down"
+    xhr.setRequestHeader 'Accept', 'application/json'
+    xhr.onload = () ->
+        response = JSON.parse this.responseText
+        if response.success
+            window.location.reload()
+        else
+            $('#alert-error-text').text response.reason
+            $('#alert-error').removeClass 'hidden'
+    xhr.send()
+, false) for link in document.querySelectorAll('.lower-feature-priority-button')
+
+link.addEventListener('click', (e) ->
+    xhr = new XMLHttpRequest()
+    mod_id = e.target.dataset.mod
+    xhr.open 'POST', "/mod/#{mod_id}/feature-up"
+    xhr.setRequestHeader 'Accept', 'application/json'
+    xhr.onload = () ->
+        response = JSON.parse this.responseText
+        if response.success
+            window.location.reload()
+        else
+            $('#alert-error-text').text response.reason
+            $('#alert-error').removeClass 'hidden'
+    xhr.send()
+, false) for link in document.querySelectorAll('.raise-feature-priority-button')
 
 readCookie = (name) ->
     nameEQ = name + "="

--- a/frontend/styles/listing.scss
+++ b/frontend/styles/listing.scss
@@ -79,7 +79,9 @@
         border-radius: 0;
     }
 
-    .follow-mod-button, .unfollow-mod-button, .download-link, .following-mod-indicator, .locked-mod-indicator {
+    .follow-mod-button, .unfollow-mod-button, .following-mod-indicator,
+    .download-link, .locked-mod-indicator,
+    .lower-feature-priority-button, .raise-feature-priority-button {
         text-decoration: none;
         font-size: 20px;
         margin-top: -2px;

--- a/generate_revision.sh
+++ b/generate_revision.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
+case "$OSTYPE" in
+    linux*)
+        ;;
+    msys | cygwin)
+        # Turn off db's volume mounting because we can't make the owners match,
+        # by mounting it at /var/lib/postgresql/data_dummy instead.
+        # The db will not persist between restarts, but that's better than
+        # failing to start and can still be used to investigate some issues.
+        echo 'Windows OS detected, disabling db volume mounting.'
+        echo 'NOTE: Database will NOT persist across restarts!'
+        echo
+        export DISABLE_DB_VOLUME=_dummy
+        ;;
+esac
+
 docker-compose build backend
 
 docker-compose up -d db
@@ -16,4 +31,10 @@ chmod g+rw alembic/versions/* &&
 alembic history --verbose
 """
 
-sudo chown "${USER}":"${USER}" alembic/versions/*
+case "$OSTYPE" in
+    linux*)
+        sudo chown "${USER}":"${USER}" alembic/versions/*
+        ;;
+    msys | cygwin)
+        ;;
+esac

--- a/templates/browse-list.html
+++ b/templates/browse-list.html
@@ -47,9 +47,16 @@
     <p>Nothing to see here. If you're looking for a specific mod, why not ask the modder to upload it here?</p>
     {% endif %}
     <div class="row">
-    {% for mod in mods %}
-        {% include "mod-box.html" %}
-    {% endfor %}
+    {% if featured %}
+        {% for feature in featured %}
+            {% set mod = feature.mod %}
+            {% include "mod-box.html" %}
+        {% endfor %}
+    {% else %}
+        {% for mod in mods %}
+            {% include "mod-box.html" %}
+        {% endfor %}
+    {% endif %}
     </div>
     {%- if total_pages > 1 -%}
     <div style="margin-top: 5mm" class="row vertical-centered" style="margin-bottom:2.5mm;">

--- a/templates/game.html
+++ b/templates/game.html
@@ -48,6 +48,7 @@
     </div>
 {% endif %}
 
+{% if featured %}
 <div class="well"  style="margin-bottom: 0;">
     <div class="container main-cat">
         <a href="{% if ga %}/{{ ga.short }}{% endif %}/browse/featured" class="btn btn-primary pull-right">
@@ -60,11 +61,12 @@
 <div class="container">
     <div class="row">
         {% for feature in featured[:6]  %}
-        {% set mod = feature.mod %}
-        {% include "mod-box.html" %}
+            {% set mod = feature.mod %}
+            {% include "mod-box.html" %}
         {% endfor %}
     </div>
 </div>
+{% endif %}
 <div class="well"  style="margin-bottom: 0;margin-top: 2.5mm;">
     <div class="container main-cat">
         <a href="{% if ga %}/{{ ga.short }}{% endif %}/browse/new" class="btn btn-primary pull-right">

--- a/templates/mod-box.html
+++ b/templates/mod-box.html
@@ -43,6 +43,14 @@
                     <a href="#" title="Unfollow" class="unfollow-mod-button glyphicon glyphicon-star" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
                     <a href="#" title="Follow" class="follow-mod-button glyphicon glyphicon-star-empty" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
 
+                    {% if admin and feature %}
+
+                        <a href="#" title="Raise feature priority" class="raise-feature-priority-button glyphicon glyphicon-chevron-left" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
+
+                        <a href="#" title="Lower feature priority" class="lower-feature-priority-button glyphicon glyphicon-chevron-right" data-mod="{{ mod.id }}" data-id="{{ mod.id }}"></a>
+
+                    {% endif %}
+
                     <a href='{{url_for("mods.download", mod_id=mod.id, mod_name=mod.name)}}' title="Download" class="download-link glyphicon glyphicon-save-file"></a>
                 </div>
                 <div class="caption">


### PR DESCRIPTION
## Motivation

@cheese3660 has been helping to admin KSP2 and gave some feedback that it would be good to be able to control the ordering of featured mods. Currently the most recently featured mod always sorts to the front of the list, so some reordering could be done by de-featuring and re-featuring mods in the desired order, but that would be extremely cumbersome.

## Changes

Now left and right chevrons (with explanatory tooltips) can be clicked to move a mod around in the featured list:

![image](https://github.com/KSP-SpaceDock/SpaceDock/assets/1559108/76efb8a7-7170-4847-b7a2-2b5cec7abd8c)

On the back end, the `featured` table now has a `priority` column that holds each featured mod's position within the featured list. This is a per-game, non-negative integer that is incremented by the left chevron and decremented by the right chevron. Existing featured mods' priorities will be defaulted based on the current ordering. A newly featured mod is given the highest priority (as it works today) and can then be moved around in the list. De-featuring a mod decrements each higher priority by 1 to close gaps in the list.
