### PR TITLE
Validate changelog lengths

### DIFF
--- a/KerbalStuff/common.py
+++ b/KerbalStuff/common.py
@@ -47,7 +47,7 @@ cleaner = bleach.Cleaner(tags=list({*bleach_allowlist.markdown_tags,
                              'iframe': allow_iframe_attr
                          },
                          css_sanitizer=CSSSanitizer(),
-                         filters=[bleach.linkifier.LinkifyFilter])
+                         filters=[bleach.linkifier.LinkifyFilter])  # type: ignore[list-item]
 
 
 def first_paragraphs(text: Optional[str]) -> str:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   db:
     image: postgres:11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   db:
     image: postgres:11

--- a/frontend/coffee/update.coffee
+++ b/frontend/coffee/update.coffee
@@ -3,16 +3,20 @@ editor.render()
 
 Dropzone = require('dropzone').Dropzone
 
-error = (name) ->
+error = (name, htmlMsg) ->
     document.getElementById(name).parentElement.classList.add('has-error')
     document.getElementById('error-alert').classList.remove('hidden')
+    alert = $("#error-alert")
+    alert.html if alert.text() == '' then alert.html().concat(htmlMsg) else alert.html().concat("<br/>").concat(htmlMsg)
 
 valid = ->
     a.classList.remove('has-error') for a in document.querySelectorAll('.has-error')
     document.getElementById('error-alert').classList.add('hidden')
+    $("#error-alert").text('')
 
-    error('version') if $("#version").val() == ''
-    error('uploader') if Dropzone.forElement('#uploader').files.length != 1
+    error('version', 'Version is required!') if $("#version").val() == ''
+    error('uploader', 'No file uploaded!') if Dropzone.forElement('#uploader').files.length != 1
+    error('changelog', "Changelog is #{editor.codemirror.getValue().length} bytes, the limit is 10000!") if editor.codemirror.getValue().length > 10000
 
     return document.querySelectorAll('.has-error').length == 0
 


### PR DESCRIPTION
## Problem

1. Click Update for a mod
2. Enter a changelog longer than 10000 characters
3. Click submit
4. You get a 500 Internal Server Error

## Cause

The SQL column has a length limit, but this limit is not checked in the Coffeescript or Python code, so it is only enforced at the very end of updating when we try to create the SQL row.

## Changes

Now the changelog length is checked on the client and on the server, and a user friendly error message is generated if it's too long. I believe this will happen before the upload starts, so the user won't have to wait for their 5-GiB ZIP file to transfer fully.
