### PR TITLE
Add new version import format for KSA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 as backend-dev
+FROM python:3.10 AS backend-dev
 ENV PYTHONUNBUFFERED=1
 RUN useradd -m -d /opt/spacedock -s /bin/bash spacedock
 RUN pip3 install --upgrade pip setuptools wheel pip-licenses
@@ -8,10 +8,10 @@ RUN pip3 install -r requirements-backend.txt
 ADD . ./
 RUN pip3 install -v ./
 
-FROM backend-dev as celery
+FROM backend-dev AS celery
 ADD requirements-celery.txt ./
 RUN pip3 install -r requirements-celery.txt
 
-FROM backend-dev as backend-prod
+FROM backend-dev AS backend-prod
 ADD requirements-prod.txt ./
 RUN pip3 install -r requirements-prod.txt

--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -12,6 +12,7 @@ from sqlalchemy import or_, func
 from sqlalchemy.orm import Query
 import werkzeug.wrappers
 
+from ..notification import import_game_versions
 from ..common import adminrequired, with_session, TRUE_STR
 from ..config import _cfg
 from ..database import db
@@ -285,13 +286,15 @@ def notification_edit(notif_id: int) -> Union[str, werkzeug.wrappers.Response]:
         notif.change_url = request.form.get('change_url')
     else:
         # Create new row
-        db.add(Notification(name=request.form.get('name'),
-                            game_id=request.form.get('game_id'),
-                            builds_url=request.form.get('builds_url'),
-                            builds_url_format=request.form.get('builds_url_format'),
-                            builds_url_argument=request.form.get('builds_url_argument'),
-                            add_url=request.form.get('add_url'),
-                            change_url=request.form.get('change_url')))
+        notif = Notification(name=request.form.get('name'),
+                             game_id=request.form.get('game_id'),
+                             builds_url=request.form.get('builds_url'),
+                             builds_url_format=request.form.get('builds_url_format'),
+                             builds_url_argument=request.form.get('builds_url_argument'),
+                             add_url=request.form.get('add_url'),
+                             change_url=request.form.get('change_url'))
+        db.add(notif)
+    import_game_versions(notif)
     return redirect(url_for('admin.notifications'))
 
 

--- a/KerbalStuff/notification.py
+++ b/KerbalStuff/notification.py
@@ -90,6 +90,8 @@ def game_versions_from_notif(url: str, fmt: str, argument: str) -> Iterable[str]
             yield val
     elif fmt == 'json_list':
         yield from resp.json()
+    elif fmt == 'json_object':
+        yield resp.json()[argument]
     elif fmt == 'json_nested_dict_values':
         for _, full_version in resp.json()[argument].items():
             m = MAJOR_MINOR_PATCH_PATTERN.match(full_version)

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -299,7 +299,7 @@ class Notification(Base):  # type: ignore
     game_id = Column(Integer, ForeignKey('game.id', ondelete='CASCADE'), nullable=False, index=True)
     game = relationship('Game', backref=backref('notifications', passive_deletes='all'), passive_deletes='all', foreign_keys=game_id)
     builds_url = Column(Unicode(1024))
-    builds_url_format = Column(Enum('plain_current', 'json_nested_dict_values', 'json_list', name='builds_url_format'))
+    builds_url_format = Column(Enum('plain_current', 'json_nested_dict_values', 'json_list', 'json_object', name='builds_url_format'))
     builds_url_argument = Column(Unicode(32))
     add_url = Column(Unicode(1024))
     change_url = Column(Unicode(1024))

--- a/README_DOCKERFILE.md
+++ b/README_DOCKERFILE.md
@@ -38,7 +38,7 @@ This will also forward port 5080 of the nginx container to port 5080 of your hos
 
 The following containers will be started:
 
-| docker-compose service name | container name | function |
+| docker compose service name | container name | function |
 | --------------------------- | -------------- | -------- |
 | backend              | spacedock_backend_1   | Flask development server |
 | db                   | spacedock_db_1        | PostgreSQL database |
@@ -47,7 +47,7 @@ The following containers will be started:
 | adminer              | spacedock_adminer_1   | Database management UI for development and debugging |
 
 To interact with a container using the `docker` command, you need to use the container name.
-To interact using `docker-compose`, you need to use the service name and be in the repository directory or any subdirectory.
+To interact using `docker compose`, you need to use the service name and be in the repository directory or any subdirectory.
 
 ## Connecting
 
@@ -61,11 +61,11 @@ User Credentials: user:development
 
 ## Starting and Stopping
 
-If you want to stop your container without losing any data, you can simply do `docker-compose stop`.
-Then, to start it back up, do `docker-compose up`.
+If you want to stop your container without losing any data, you can simply do `docker compose stop`.
+Then, to start it back up, do `docker compose up`.
 
 ## Odd and Ends
 
 ```sh
-docker-compose exec backend /bin/bash # Start a bash shell in the backend container
+docker compose exec backend /bin/bash # Start a bash shell in the backend container
 ```

--- a/alembic/versions/2025_11_16_14_47_55-fb2881831917.py
+++ b/alembic/versions/2025_11_16_14_47_55-fb2881831917.py
@@ -1,0 +1,21 @@
+"""Add json_object to builds_url_format enum
+
+Revision ID: fb2881831917
+Revises: f5a5d29ec765
+Create Date: 2025-11-16 20:47:58.636952
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fb2881831917'
+down_revision = 'f5a5d29ec765'
+
+from alembic import op
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE builds_url_format ADD VALUE IF NOT EXISTS 'json_object'")
+    pass
+
+def downgrade() -> None:
+    # Can't remove enum values
+    pass

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - the build process
-FROM node:16 as build-deps
+FROM node:16 AS build-deps
 WORKDIR /usr/src/app
 ADD package.json ./
 ADD package-lock.json ./

--- a/generate_revision.sh
+++ b/generate_revision.sh
@@ -16,12 +16,12 @@ case "$OSTYPE" in
         ;;
 esac
 
-docker-compose build backend
+docker compose build backend
 
-docker-compose up -d db
+docker compose up -d db
 
 source .env
-docker-compose run --rm --no-deps -u root \
+docker compose run --rm --no-deps -u root \
   -e CONNECTION_STRING="${CONNECTION_STRING}" \
   backend bash -c """
 set -e

--- a/start-server.sh
+++ b/start-server.sh
@@ -31,17 +31,17 @@ COMPOSE_FILE="docker-compose.yml"
 [ "$1" == "prod" ] && COMPOSE_FILE="docker-compose-prod.yml"
 
 # build containers
-docker-compose -f "${COMPOSE_FILE}" build
+docker compose -f "${COMPOSE_FILE}" build
 
 # start database server
-docker-compose -f "${COMPOSE_FILE}" up -d db
+docker compose -f "${COMPOSE_FILE}" up -d db
 
 # stop existing backend
-docker-compose -f "${COMPOSE_FILE}" stop backend
+docker compose -f "${COMPOSE_FILE}" stop backend
 
 # wait for it to accept connections, then create/migrate db schema
 source .env
-docker-compose -f "${COMPOSE_FILE}" run --rm --no-deps \
+docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
 -e CONNECTION_STRING="${CONNECTION_STRING}" \
 backend bash -c '''
 set -e
@@ -52,4 +52,4 @@ spacedock database populate
 '''
 
 # start other containers
-docker-compose -f "${COMPOSE_FILE}" up -d
+docker compose -f "${COMPOSE_FILE}" up -d


### PR DESCRIPTION
## Motivation

[Kitten Space Agency](https://ahwoo.com/store/KPbAA1Au/kitten-space-agency) started its public pre-alpha a few days ago, and [there are already some mods on its forum](https://forums.ahwoo.com/forums/mod-releases.21/). They're mostly hosted at sites like Google Drive and Mediafire, so @V1TA5 wants to add KSA to SpaceDock. To do that, we'll need a way to query for game version updates, and the KSA devs have helpfully provided this URL for that:

- <http://ksa-master1.rocketwerkz.com:8082/>

```json
{
  "Version": "2025.11.4.2791",
  "Url": "https://ksa.ahwoo.com/"
}
```

We can paste that URL into the notifications settings, but the JSON format can't be parsed by any of the existing format options.

## Changes

- Now a new `json_object` format is supported for builds URLs, with the `Argument` value treated as the property that contains the version. We would set it to `Version` for KSA.
  <img width="980" height="272" alt="image" src="https://github.com/user-attachments/assets/e8471362-5811-41b2-9bfb-5f23d568bd3b" />
- Now if you edit and save a notification in the admin pages, we immediately trigger retrieval of its versions, so we don't have to wait for the Celery job to run.
- While trying to do dev on this, I discovered that `docker-compose` is now deprecated and replaced by `docker compose`. So I did a search-replace for that.
- Docker was complaining about the inconsistent capitalization of `FROM x as y`, which is now changed to `FROM x AS y`.

With these changes, my local test server successfully pulled the current version into its `GameVersion` db.

<img width="507" height="98" alt="image" src="https://github.com/user-attachments/assets/c6923e65-a23d-40bf-90c9-b51970866421" />
