### PR TITLE
Add dark mode toggle

### DIFF
--- a/dc-override.yml
+++ b/dc-override.yml
@@ -1,0 +1,4 @@
+services:
+  db:
+    ports: !override
+      - "15432:5432"

--- a/dc-override.yml
+++ b/dc-override.yml
@@ -1,4 +1,0 @@
-services:
-  db:
-    ports: !override
-      - "15432:5432"

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -63,6 +63,25 @@ $('#alert-error').on 'close.bs.alert', () ->
     $('#alert-error').addClass 'hidden'
     return false
 
+# Dark mode toggle. Remembers the choice in localStorage; the initial class is
+# set in layout.html's <head> so there's no flash on load.
+darkModeToggle = document.getElementById('dark-mode-toggle')
+if darkModeToggle?
+    root = document.documentElement
+    updateDarkModeButton = () ->
+        active = root.classList.contains('dark-mode')
+        darkModeToggle.setAttribute('aria-pressed', active.toString())
+    updateDarkModeButton()
+    darkModeToggle.addEventListener('click', (e) ->
+        e.preventDefault()
+        active = root.classList.toggle('dark-mode')
+        try
+            localStorage.setItem('dark-mode', active.toString())
+        catch error
+            # localStorage can be blocked (private mode); just skip saving.
+        updateDarkModeButton()
+    , false)
+
 $('.search-tips-button').on 'click', (e) ->
     $('.search-tips').addClass 'search-tips-visible'
 

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -63,7 +63,7 @@ $('#alert-error').on 'close.bs.alert', () ->
     $('#alert-error').addClass 'hidden'
     return false
 
-# Dark mode toggle; choice saved in localStorage, applied early in layout.html
+# Dark mode toggle choice saved in localStorage, aplied early in layout.html
 darkModeToggle = document.getElementById('dark-mode-toggle')
 if darkModeToggle?
     root = document.documentElement
@@ -77,7 +77,7 @@ if darkModeToggle?
         try
             localStorage.setItem('dark-mode', active.toString())
         catch error
-            # localStorage can be blocked (private mode); just skip saving.
+            # localStorage can be blocked (private mode)
         updateDarkModeButton()
     , false)
 

--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -63,8 +63,7 @@ $('#alert-error').on 'close.bs.alert', () ->
     $('#alert-error').addClass 'hidden'
     return false
 
-# Dark mode toggle. Remembers the choice in localStorage; the initial class is
-# set in layout.html's <head> so there's no flash on load.
+# Dark mode toggle; choice saved in localStorage, applied early in layout.html
 darkModeToggle = document.getElementById('dark-mode-toggle')
 if darkModeToggle?
     root = document.documentElement

--- a/frontend/static/css/bootstrap-theme.css
+++ b/frontend/static/css/bootstrap-theme.css
@@ -879,7 +879,7 @@ div.header .vert-text {
 }
 
 div.tab-container {
-    margin: 2.5mm;
+    margin: 9px 0;
 
 }
 

--- a/frontend/styles/darkmode.scss
+++ b/frontend/styles/darkmode.scss
@@ -2,14 +2,18 @@
 // toggle adds/removes (see navigation.scss and global.coffee). layout.html
 // sets the class before first paint so there's no flash on load.
 
-$dark-bg:           #12161d; // page background
+$dark-bg:           #12161d; // page background (also the black navbar)
 $dark-surface:      #1b212b; // panels, wells, cards, modals
 $dark-surface-alt:  #232a35; // striped rows, inputs, hover states
 $dark-border:       #2c3441;
 $dark-text:         #d3d7de;
 $dark-muted:        #aab1bc;
-$dark-link:         #6f93e6;
-$dark-cyan:         #2bc2ee; // brand cyan, brightened for the dark background
+
+// The only accent blue is the SpaceDock logo's blue; everything else is a
+// lighten()/darken() of it so the blue stays consistent across the site.
+$sd-blue:           #07acd2;               // logo blue
+$dark-link:         lighten($sd-blue, 10%); // links / focus / text accents
+$dark-cyan:         $dark-link;             // alias kept for button text
 
 // The theme draws every coloured button as a white "ghost" (white fill,
 // coloured text and border). On dark, fill them dark and keep the accent.
@@ -24,13 +28,6 @@ $dark-cyan:         #2bc2ee; // brand cyan, brightened for the dark background
         border-color: $accent;
         color: #fff;
     }
-}
-
-// Footer links are #777 from Bootstrap and hard to read on white; darken them.
-// (This file is the one stylesheet loaded on every page, so the light-mode fix
-// lives here too.)
-footer a {
-    color: #333;
 }
 
 html.dark-mode {
@@ -50,22 +47,30 @@ html.dark-mode {
         }
     }
 
-    // The footer links are small and sit on the darkest background, where the
-    // link blue is too dim, so give them a brighter, near-white colour.
-    footer a {
-        color: #c4cdde;
-
-        &:hover, &:focus {
-            color: #fff;
-        }
-    }
-
     hr {
         border-top-color: $dark-border;
     }
 
     h2 small, small, .text-muted {
         color: $dark-muted;
+    }
+
+    // Footer blends into the dark page; keep the links light.
+    footer {
+        background-color: $dark-bg;
+        color: $dark-muted;
+
+        a {
+            color: #c4cdde;
+
+            &:hover, &:focus {
+                color: #fff;
+            }
+        }
+
+        hr {
+            border-top-color: $dark-border;
+        }
     }
 
     .page-header {
@@ -91,7 +96,7 @@ html.dark-mode {
         }
     }
 
-    .btn-primary { @include ghost-btn(#07acd2, $dark-cyan); }
+    .btn-primary { @include ghost-btn($sd-blue, $dark-cyan); }
     .btn-success { @include ghost-btn(#20bb20); }
     .btn-info    { @include ghost-btn(#743af3, #9b7cf6); }
     .btn-danger  { @include ghost-btn(#b3182d, #e35d6a); }
@@ -334,18 +339,25 @@ html.dark-mode {
         background-color: $dark-bg;
     }
 
-    // Navbar stays brand blue but a notch darker so it's calmer on dark pages.
+    // Black navbar (and matching dropdown) so the logo blue stands out on it.
+    // A faint border keeps it separated from the (also dark) page below.
     .navbar-default {
-        background-color: #15294d;
+        background-color: $dark-bg;
+        background-image: none;
+        border-bottom: 1px solid $dark-border;
     }
     .dropdown-menu {
-        background-color: #15294d;
-        border-color: #15294d;
+        background-color: $dark-surface;
+        border-color: $dark-border;
     }
 
-    // Home page bands follow the darker navbar blue.
+    // Home page bands: neutral dark surface instead of big colour blocks, so the
+    // only blue on the page is the logo/accent blue.
     #players, #modders, #register {
-        background: #15294d;
+        background: $dark-surface;
+    }
+    #modders a {
+        color: $dark-link;
     }
 
     // Profile pages: the social-link rows and description sit in .info-list and
@@ -366,6 +378,13 @@ html.dark-mode {
     }
     .timeline-entry-inner[style*="F5F5F5"] {
         background-color: $dark-surface-alt !important;
+    }
+    // Use the one logo blue for the timeline marker/line (teal by default).
+    .timeline-centered:before {
+        background-color: $sd-blue;
+    }
+    .timeline-centered .timeline-entry .timeline-entry-inner .timeline-icon {
+        background-color: $sd-blue;
     }
 
     // Header image upload area (inline background-color: #ddd until an image is set)

--- a/frontend/styles/darkmode.scss
+++ b/frontend/styles/darkmode.scss
@@ -70,6 +70,10 @@ html.dark-mode {
         }
     }
 
+    .home:not(.logged-in) footer {
+        background-color: $dark-surface;
+    }
+
     .page-header {
         border-bottom-color: $dark-border;
     }

--- a/frontend/styles/darkmode.scss
+++ b/frontend/styles/darkmode.scss
@@ -1,0 +1,439 @@
+// Dark theme. Everything is scoped under html.dark-mode, which the navbar
+// toggle adds/removes (see navigation.scss and global.coffee). layout.html
+// sets the class before first paint so there's no flash on load.
+
+$dark-bg:           #12161d; // page background
+$dark-surface:      #1b212b; // panels, wells, cards, modals
+$dark-surface-alt:  #232a35; // striped rows, inputs, hover states
+$dark-border:       #2c3441;
+$dark-text:         #d3d7de;
+$dark-muted:        #aab1bc;
+$dark-link:         #6f93e6;
+$dark-cyan:         #2bc2ee; // brand cyan, brightened for the dark background
+
+// The theme draws every coloured button as a white "ghost" (white fill,
+// coloured text and border). On dark, fill them dark and keep the accent.
+@mixin ghost-btn($accent, $text: $accent) {
+    background-color: $dark-surface-alt;
+    background-image: none;
+    border-color: $accent;
+    color: $text;
+
+    &:hover, &:focus, &:active, &.active {
+        background-color: $accent;
+        border-color: $accent;
+        color: #fff;
+    }
+}
+
+// Footer links are #777 from Bootstrap and hard to read on white; darken them.
+// (This file is the one stylesheet loaded on every page, so the light-mode fix
+// lives here too.)
+footer a {
+    color: #333;
+}
+
+html.dark-mode {
+    // Render native form controls and scrollbars in their dark variants.
+    color-scheme: dark;
+
+    body {
+        background: $dark-bg;
+        color: $dark-text;
+    }
+
+    a {
+        color: $dark-link;
+
+        &:hover, &:focus {
+            color: lighten($dark-link, 12%);
+        }
+    }
+
+    // The footer links are small and sit on the darkest background, where the
+    // link blue is too dim, so give them a brighter, near-white colour.
+    footer a {
+        color: #c4cdde;
+
+        &:hover, &:focus {
+            color: #fff;
+        }
+    }
+
+    hr {
+        border-top-color: $dark-border;
+    }
+
+    h2 small, small, .text-muted {
+        color: $dark-muted;
+    }
+
+    .page-header {
+        border-bottom-color: $dark-border;
+    }
+
+    blockquote {
+        border-left-color: $dark-border;
+        color: $dark-muted;
+    }
+
+    // Default buttons (bootstrap-theme paints a light gradient on these)
+    .btn-default {
+        background-color: $dark-surface-alt;
+        background-image: none;
+        border-color: $dark-border;
+        color: $dark-text;
+
+        &:hover, &:focus, &:active, &.active {
+            background-color: lighten($dark-surface-alt, 6%);
+            border-color: $dark-border;
+            color: #fff;
+        }
+    }
+
+    .btn-primary { @include ghost-btn(#07acd2, $dark-cyan); }
+    .btn-success { @include ghost-btn(#20bb20); }
+    .btn-info    { @include ghost-btn(#743af3, #9b7cf6); }
+    .btn-danger  { @include ghost-btn(#b3182d, #e35d6a); }
+    .btn-warning { @include ghost-btn(#b4a232, #cbb84a); }
+
+    // Panels and wells. bootstrap-theme adds light gradients here, so the
+    // background-image needs resetting too, not just the colour.
+    .panel {
+        background-color: $dark-surface;
+        border-color: $dark-border;
+        box-shadow: none;
+    }
+    .panel-default > .panel-heading {
+        background-color: $dark-surface-alt;
+        background-image: none;
+        border-color: $dark-border;
+        color: $dark-text;
+    }
+    .panel-footer {
+        background-color: $dark-surface-alt;
+        border-color: $dark-border;
+    }
+    .well {
+        background-color: $dark-surface;
+        background-image: none;
+        border-color: $dark-border;
+        color: $dark-text;
+        box-shadow: none;
+    }
+    .jumbotron {
+        background-color: $dark-surface;
+        color: $dark-text;
+    }
+
+    // Mod / game / pack listing boxes (light backgrounds set in listing.scss).
+    // Keep the subtle thumbnail outline light mode has, but no fill (a lighter
+    // fill on the dark page reads as a heavy box).
+    .thumbnail {
+        background-color: transparent;
+        border-color: $dark-border;
+        box-shadow: none;
+    }
+    .item,
+    .item:hover,
+    .item:nth-of-type(odd),
+    .item:nth-of-type(odd):hover {
+        background: transparent;
+        border-color: transparent;
+    }
+    .item .caption {
+        color: $dark-text;
+    }
+
+    // Tables
+    .table {
+        color: $dark-text;
+    }
+    .table > thead > tr > th,
+    .table > tbody > tr > td,
+    .table > tbody > tr > th,
+    .table-bordered,
+    .table-bordered > thead > tr > th,
+    .table-bordered > tbody > tr > td {
+        border-color: $dark-border;
+    }
+    .table-striped > tbody > tr:nth-of-type(odd) {
+        background-color: $dark-surface-alt;
+    }
+    .table-hover > tbody > tr:hover {
+        background-color: lighten($dark-surface-alt, 5%);
+    }
+
+    // Forms
+    .form-control {
+        background-color: $dark-surface-alt;
+        border-color: $dark-border;
+        color: $dark-text;
+        box-shadow: none;
+
+        &:focus {
+            border-color: $dark-link;
+        }
+        &::placeholder {
+            color: $dark-muted;
+        }
+    }
+    .input-group-addon {
+        background-color: $dark-surface-alt;
+        border-color: $dark-border;
+        color: $dark-text;
+    }
+    // The navbar stays blue, so keep its search field light rather than dark.
+    .navbar .search-box,
+    .nav input {
+        background-color: rgba(255, 255, 255, 0.18);
+        color: #fff;
+
+        &::placeholder {
+            color: #cfd6e6;
+        }
+    }
+
+    // List groups
+    .list-group-item {
+        background-color: $dark-surface;
+        border-color: $dark-border;
+        color: $dark-text;
+    }
+    a.list-group-item:hover,
+    a.list-group-item:focus {
+        background-color: $dark-surface-alt;
+        color: $dark-text;
+    }
+
+    // Tabs (kept off .navbar-nav so the navbar's own hover stays intact)
+    .nav-tabs {
+        border-bottom-color: $dark-border;
+    }
+    .nav-tabs > li > a:hover,
+    .nav-tabs > li > a:focus {
+        background-color: $dark-surface-alt;
+        border-color: $dark-border;
+    }
+    .nav-tabs > li.active > a,
+    .nav-tabs > li.active > a:hover,
+    .nav-tabs > li.active > a:focus {
+        background-color: $dark-surface;
+        border-color: $dark-border;
+        border-bottom-color: transparent;
+        color: $dark-text;
+    }
+
+    // Pagination
+    .pagination > li > a,
+    .pagination > li > span {
+        background-color: $dark-surface;
+        border-color: $dark-border;
+        color: $dark-link;
+    }
+    .pagination > li > a:hover,
+    .pagination > li > span:hover {
+        background-color: $dark-surface-alt;
+        border-color: $dark-border;
+    }
+    .pagination > .disabled > a,
+    .pagination > .disabled > span {
+        background-color: $dark-surface;
+        border-color: $dark-border;
+        color: $dark-muted;
+    }
+
+    // Breadcrumb
+    .breadcrumb {
+        background-color: $dark-surface-alt;
+    }
+
+    // Modals (e.g. the login dialog)
+    .modal-content {
+        background-color: $dark-surface;
+        color: $dark-text;
+    }
+    .modal-header,
+    .modal-footer {
+        border-color: $dark-border;
+    }
+    .modal-header .close {
+        color: $dark-text;
+        text-shadow: none;
+        opacity: 0.8;
+    }
+    .modal-body input[type="text"],
+    .modal-body input[type="password"],
+    .modal-body input[type="email"] {
+        background-color: $dark-surface-alt;
+        border: 1px solid $dark-border;
+        color: $dark-text;
+    }
+
+    // Code and Markdown content
+    code {
+        background-color: #2b2f36;
+        color: #e0857b;
+    }
+    pre {
+        background-color: $dark-surface-alt;
+        border-color: $dark-border;
+        color: $dark-text;
+    }
+    .CodeMirror {
+        background-color: $dark-surface-alt;
+        color: $dark-text;
+    }
+    // The cm-s-paper theme colours several tokens near-black, and the cursor
+    // and selection default to dark too, all invisible on a dark editor.
+    .cm-s-paper .cm-variable,
+    .cm-s-paper .cm-operator,
+    .cm-s-paper .cm-property,
+    .cm-s-paper .cm-header,
+    .cm-s-paper .cm-def {
+        color: $dark-text;
+    }
+    .CodeMirror div.CodeMirror-cursor {
+        border-left-color: $dark-text;
+    }
+    .CodeMirror-selected {
+        background: #33415c;
+    }
+    .CodeMirror-focused .CodeMirror-selected {
+        background: #3a4a6b;
+    }
+    .CodeMirror-scrollbar-filler {
+        background-color: $dark-surface-alt;
+    }
+
+    // Search tips popover (rendered as an info alert)
+    .search-tips.alert-info {
+        background-color: $dark-surface;
+        border-color: $dark-border;
+        color: $dark-text;
+
+        code {
+            background-color: #2b2f36;
+        }
+    }
+
+    // Mod page changelog timeline (black text set in mod.scss)
+    #changelog p,
+    #changelog .timeline-label h2 {
+        color: $dark-text;
+    }
+
+    // Followed-mods list striping (profile/edit pages)
+    .row.following-mod:nth-of-type(odd) {
+        background-color: $dark-surface-alt;
+    }
+
+    // Header/banner heroes: fall back to a dark colour so they never flash
+    // white when an image is missing or still loading.
+    .header {
+        background-color: $dark-bg;
+    }
+
+    // Navbar stays brand blue but a notch darker so it's calmer on dark pages.
+    .navbar-default {
+        background-color: #15294d;
+    }
+    .dropdown-menu {
+        background-color: #15294d;
+        border-color: #15294d;
+    }
+
+    // Home page bands follow the darker navbar blue.
+    #players, #modders, #register {
+        background: #15294d;
+    }
+
+    // Profile pages: the social-link rows and description sit in .info-list and
+    // light .timeline-label cards (some with an inline #F5F5F5 background).
+    .info-list {
+        background-color: $dark-surface;
+    }
+    // timeline.scss targets the label with a deep selector, so match it here.
+    .timeline-centered .timeline-entry .timeline-entry-inner .timeline-label {
+        background-color: $dark-surface-alt;
+
+        h2, p { color: $dark-text; }
+        h2 a { color: $dark-link; }
+    }
+    .timeline-end,
+    .timeline-hide-end {
+        background-color: $dark-surface-alt;
+    }
+    .timeline-entry-inner[style*="F5F5F5"] {
+        background-color: $dark-surface-alt !important;
+    }
+
+    // Header image upload area (inline background-color: #ddd until an image is set)
+    .upload-well {
+        background-color: $dark-surface !important;
+
+        a, .directions {
+            color: $dark-text;
+        }
+    }
+
+    // Markdown editor (editor.css uses dark-on-light toolbar icons)
+    .editor-wrapper {
+        color: $dark-text;
+    }
+    .editor-toolbar a {
+        color: $dark-text !important;
+
+        &.active, &:hover {
+            background: $dark-surface-alt;
+            border-color: $dark-border;
+        }
+    }
+    .editor-preview {
+        background: $dark-surface;
+    }
+    .editor-statusbar {
+        color: $dark-muted;
+        border-top-color: $dark-border;
+    }
+
+    // Dropzone file upload previews (white tiles by default)
+    .dropzone .dz-preview .dz-image,
+    .dropzone .dz-preview.dz-file-preview .dz-image {
+        background: $dark-surface-alt;
+    }
+    .dropzone .dz-preview .dz-details {
+        color: $dark-text;
+    }
+    .dropzone .dz-preview .dz-details .dz-filename span,
+    .dropzone .dz-preview .dz-details .dz-size span {
+        background-color: $dark-surface !important;
+        color: $dark-text;
+    }
+    .dropzone .dz-preview .dz-details .dz-filename:not(:hover) span {
+        border-color: transparent;
+    }
+
+    // chosen select boxes (create/edit pages). chosen styles the open/active
+    // states with higher-specificity selectors, so !important is needed.
+    .chosen-single,
+    .chosen-choices,
+    .chosen-container-active .chosen-single,
+    .chosen-container-active.chosen-with-drop .chosen-single {
+        background: $dark-surface-alt !important;
+        background-image: none !important;
+        border-color: $dark-border;
+        color: $dark-text;
+    }
+    .chosen-drop {
+        background: $dark-surface !important;
+        border-color: $dark-border;
+    }
+    .chosen-results > li {
+        color: $dark-text;
+
+        &.highlighted {
+            background: $dark-surface-alt;
+        }
+    }
+}

--- a/frontend/styles/darkmode.scss
+++ b/frontend/styles/darkmode.scss
@@ -1,22 +1,19 @@
-// Dark theme. Everything is scoped under html.dark-mode, which the navbar
-// toggle adds/removes (see navigation.scss and global.coffee). layout.html
-// sets the class before first paint so there's no flash on load.
+// Dark theme, all under html.dark-mode (toggled in global.coffee, set early in
+// layout.html to avoid a flash).
 
-$dark-bg:           #12161d; // page background (also the black navbar)
-$dark-surface:      #1b212b; // panels, wells, cards, modals
-$dark-surface-alt:  #232a35; // striped rows, inputs, hover states
+$dark-bg:           #12161d; // page + navbar
+$dark-surface:      #1b212b; // panels, cards, modals
+$dark-surface-alt:  #232a35; // rows, inputs, hover
 $dark-border:       #2c3441;
 $dark-text:         #d3d7de;
 $dark-muted:        #aab1bc;
 
-// The only accent blue is the SpaceDock logo's blue; everything else is a
-// lighten()/darken() of it so the blue stays consistent across the site.
-$sd-blue:           #07acd2;               // logo blue
-$dark-link:         lighten($sd-blue, 10%); // links / focus / text accents
-$dark-cyan:         $dark-link;             // alias kept for button text
+// One blue everywhere: the logo's, plus lighten/darken of it.
+$sd-blue:           #07acd2;
+$dark-link:         lighten($sd-blue, 10%);
+$dark-cyan:         $dark-link;
 
-// The theme draws every coloured button as a white "ghost" (white fill,
-// coloured text and border). On dark, fill them dark and keep the accent.
+// Coloured buttons are white "ghosts" by default; fill them dark instead.
 @mixin ghost-btn($accent, $text: $accent) {
     background-color: $dark-surface-alt;
     background-image: none;
@@ -55,7 +52,7 @@ html.dark-mode {
         color: $dark-muted;
     }
 
-    // Footer blends into the dark page; keep the links light.
+    // footer: dark page, light links
     footer {
         background-color: $dark-bg;
         color: $dark-muted;
@@ -82,7 +79,7 @@ html.dark-mode {
         color: $dark-muted;
     }
 
-    // Default buttons (bootstrap-theme paints a light gradient on these)
+    // bootstrap-theme gradients need background-image: none, not just a colour
     .btn-default {
         background-color: $dark-surface-alt;
         background-image: none;
@@ -102,8 +99,7 @@ html.dark-mode {
     .btn-danger  { @include ghost-btn(#b3182d, #e35d6a); }
     .btn-warning { @include ghost-btn(#b4a232, #cbb84a); }
 
-    // Panels and wells. bootstrap-theme adds light gradients here, so the
-    // background-image needs resetting too, not just the colour.
+    // panels + wells
     .panel {
         background-color: $dark-surface;
         border-color: $dark-border;
@@ -131,9 +127,7 @@ html.dark-mode {
         color: $dark-text;
     }
 
-    // Mod / game / pack listing boxes (light backgrounds set in listing.scss).
-    // Keep the subtle thumbnail outline light mode has, but no fill (a lighter
-    // fill on the dark page reads as a heavy box).
+    // listing boxes: outline only, no fill (a fill reads as a heavy box here)
     .thumbnail {
         background-color: transparent;
         border-color: $dark-border;
@@ -188,7 +182,7 @@ html.dark-mode {
         border-color: $dark-border;
         color: $dark-text;
     }
-    // The navbar stays blue, so keep its search field light rather than dark.
+    // search field rides on the navbar, so a translucent-white fill, not dark
     .navbar .search-box,
     .nav input {
         background-color: rgba(255, 255, 255, 0.18);
@@ -289,8 +283,7 @@ html.dark-mode {
         background-color: $dark-surface-alt;
         color: $dark-text;
     }
-    // The cm-s-paper theme colours several tokens near-black, and the cursor
-    // and selection default to dark too, all invisible on a dark editor.
+    // cm-s-paper paints tokens/cursor/selection near-black, invisible here
     .cm-s-paper .cm-variable,
     .cm-s-paper .cm-operator,
     .cm-s-paper .cm-property,
@@ -328,19 +321,22 @@ html.dark-mode {
         color: $dark-text;
     }
 
+    // match the description/changelog panel to the info cards' grey
+    .tab-content {
+        background-color: $dark-surface-alt;
+    }
+
     // Followed-mods list striping (profile/edit pages)
     .row.following-mod:nth-of-type(odd) {
         background-color: $dark-surface-alt;
     }
 
-    // Header/banner heroes: fall back to a dark colour so they never flash
-    // white when an image is missing or still loading.
+    // dark fallback so heroes don't flash white before the image loads
     .header {
         background-color: $dark-bg;
     }
 
-    // Black navbar (and matching dropdown) so the logo blue stands out on it.
-    // A faint border keeps it separated from the (also dark) page below.
+    // black navbar + dropdown, faint border to split it from the page
     .navbar-default {
         background-color: $dark-bg;
         background-image: none;
@@ -351,8 +347,7 @@ html.dark-mode {
         border-color: $dark-border;
     }
 
-    // Home page bands: neutral dark surface instead of big colour blocks, so the
-    // only blue on the page is the logo/accent blue.
+    // flatten the home page colour bands to plain surface
     #players, #modders, #register {
         background: $dark-surface;
     }
@@ -360,12 +355,13 @@ html.dark-mode {
         color: $dark-link;
     }
 
-    // Profile pages: the social-link rows and description sit in .info-list and
-    // light .timeline-label cards (some with an inline #F5F5F5 background).
+    // .info-list defaults to light text + a pale #dcdcdc border; tone both down
     .info-list {
         background-color: $dark-surface;
+        border-color: $dark-border;
+        color: $dark-text;
     }
-    // timeline.scss targets the label with a deep selector, so match it here.
+    // deep selector to match timeline.scss's specificity on the label
     .timeline-centered .timeline-entry .timeline-entry-inner .timeline-label {
         background-color: $dark-surface-alt;
 
@@ -379,7 +375,7 @@ html.dark-mode {
     .timeline-entry-inner[style*="F5F5F5"] {
         background-color: $dark-surface-alt !important;
     }
-    // Use the one logo blue for the timeline marker/line (teal by default).
+    // logo blue for the timeline marker + line
     .timeline-centered:before {
         background-color: $sd-blue;
     }
@@ -433,8 +429,7 @@ html.dark-mode {
         border-color: transparent;
     }
 
-    // chosen select boxes (create/edit pages). chosen styles the open/active
-    // states with higher-specificity selectors, so !important is needed.
+    // chosen selects; !important to beat its open/active state selectors
     .chosen-single,
     .chosen-choices,
     .chosen-container-active .chosen-single,

--- a/frontend/styles/darkmode.scss
+++ b/frontend/styles/darkmode.scss
@@ -287,6 +287,10 @@ html.dark-mode {
         background-color: $dark-surface-alt;
         color: $dark-text;
     }
+
+    .CodeMirror pre {
+        background-color: transparent;
+    }
     // cm-s-paper paints tokens/cursor/selection near-black, invisible here
     .cm-s-paper .cm-variable,
     .cm-s-paper .cm-operator,
@@ -378,6 +382,14 @@ html.dark-mode {
     }
     .timeline-entry-inner[style*="F5F5F5"] {
         background-color: $dark-surface-alt !important;
+    }
+  
+    .timeline-centered .timeline-entry .timeline-entry-inner:has(input) .timeline-label {
+        background-color: $dark-surface;
+    }
+    .timeline-entry-inner:has(input).timeline-end,
+    .timeline-entry-inner:has(input).timeline-hide-end {
+        background-color: $dark-surface;
     }
     // logo blue for the timeline marker + line
     .timeline-centered:before {

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -67,7 +67,7 @@
     }
 }
 
-/* These bands share the navbar's brand blue so the home page reads as one piece. */
+/* brand-blue bands down the home page */
 #players {
     background: #1d3c8e;
     color: #fff;
@@ -123,4 +123,23 @@
 
 h2 small {
     color: #333;
+}
+
+/* bands only show logged-out, so only there does the footer continue them
+   (#register's #057893). index.css is site-wide, hence the .home guard. */
+.home:not(.logged-in) footer {
+    background-color: #057893;
+    color: #fff;
+
+    a {
+        color: #fff;
+
+        &:hover, &:focus {
+            color: #cdeaf2;
+        }
+    }
+
+    hr {
+        border-top-color: rgba(255, 255, 255, 0.25);
+    }
 }

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -125,9 +125,7 @@ h2 small {
     color: #333;
 }
 
-/* bands only show logged-out, so only there does the footer continue them
-   (#register's #057893). index.css is site-wide, hence the .home guard. */
-.home:not(.logged-in) footer {
+html:not(.dark-mode) .home:not(.logged-in) footer {
     background-color: #057893;
     color: #fff;
 

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -67,24 +67,26 @@
     }
 }
 
+/* These bands share the navbar's brand blue so the home page reads as one piece. */
 #players {
-    background: #55B5DA;
+    background: #1d3c8e;
     color: #fff;
     padding-bottom: 10px;
 }
 
 #modders {
-    background: #409ABD;
+    background: #1d3c8e;
     color: #fff;
     padding-bottom: 10px;
 
     a {
-        color: #333;
+        color: #fff;
+        text-decoration: underline;
     }
 }
 
 #register {
-    background: #3789A8;
+    background: #1d3c8e;
     color: #fff;
     padding-bottom: 10px;
 }

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -31,21 +31,22 @@
     color: #fff;
     padding-top: 10px;
 
-    .timeline-centered .timeline-entry .timeline-entry-inner {
+    .timeline-centered .timeline-entry .timeline-entry-inner:not(:has(input)) {
         min-height: 58px;
-    }
-    .timeline-centered .timeline-entry .timeline-entry-inner .timeline-label {
-        box-sizing: border-box;
-        min-height: 40px;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        padding-top: 0;
-        padding-bottom: 0;
 
-        h2 {
-            margin-bottom: 0;
-            top: 0;
+        .timeline-label {
+            box-sizing: border-box;
+            min-height: 40px;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding-top: 0;
+            padding-bottom: 0;
+
+            h2 {
+                margin-bottom: 0;
+                top: 0;
+            }
         }
     }
 }
@@ -60,13 +61,6 @@
         font-size: 14pt;
         border: none;
     }
-}
-
-// Tab bar and the panel below share .col-lg-5 > .container; zero its padding so
-// both fill the column identically and the bar lines up with the panel.
-.col-lg-5 > .container {
-    padding-left: 0;
-    padding-right: 0;
 }
 
 .tab-container {

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -51,6 +51,10 @@
     }
 }
 
+.timeline-centered:has(input):before {
+    bottom: 45px;
+}
+
 .mod-tabs {
     position: relative;
     display: flex;

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -62,11 +62,20 @@
     }
 }
 
+// Tab bar and the panel below share .col-lg-5 > .container; zero its padding so
+// both fill the column identically and the bar lines up with the panel.
+.col-lg-5 > .container {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 .tab-container {
     position: relative;
+    width: 100%;
 
     .mod-tabs {
         z-index: 1;
+        width: 100%;
     }
 
     &.no-sides {

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -30,6 +30,24 @@
     background: #333;
     color: #fff;
     padding-top: 10px;
+
+    .timeline-centered .timeline-entry .timeline-entry-inner {
+        min-height: 58px;
+    }
+    .timeline-centered .timeline-entry .timeline-entry-inner .timeline-label {
+        box-sizing: border-box;
+        min-height: 40px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-top: 0;
+        padding-bottom: 0;
+
+        h2 {
+            margin-bottom: 0;
+            top: 0;
+        }
+    }
 }
 
 .mod-tabs {

--- a/frontend/styles/navigation.scss
+++ b/frontend/styles/navigation.scss
@@ -230,8 +230,7 @@
     float: left;
 }
 
-/* Dark mode toggle, just left of the navbar search box. The two icons are
-   stacked and cross-faded so the moon/sun swap animates. */
+/* Dark mode toggle; moon/sun stacked and cross-faded on swap */
 .dark-mode-toggle {
     position: relative;
     width: 22px;

--- a/frontend/styles/navigation.scss
+++ b/frontend/styles/navigation.scss
@@ -230,6 +230,48 @@
     float: left;
 }
 
+/* Dark mode toggle, just left of the navbar search box. The two icons are
+   stacked and cross-faded so the moon/sun swap animates. */
+.dark-mode-toggle {
+    position: relative;
+    width: 22px;
+    height: 22px;
+    display: inline-block;
+    /* line up with the search box (Bootstrap puts it on vertical-align: middle) */
+    vertical-align: middle;
+    background: none;
+    border: 0;
+    padding: 0;
+    margin-right: 10px;
+    color: #fff;
+    cursor: pointer;
+    opacity: 0.85;
+    transition: opacity 0.2s ease-in-out;
+
+    &:hover, &:focus {
+        opacity: 1;
+        outline: 0;
+    }
+
+    .dark-mode-icon {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 22px;
+        height: 22px;
+        transition: opacity 0.2s ease-in-out;
+    }
+
+    /* moon visible in light mode, sun in dark mode (flipped below) */
+    .icon-moon { opacity: 1; }
+    .icon-sun { opacity: 0; }
+}
+
+.dark-mode .dark-mode-toggle {
+    .icon-moon { opacity: 0; }
+    .icon-sun { opacity: 1; }
+}
+
 .search-tips-visible {
     visibility: visible;
     opacity: 1;
@@ -247,7 +289,8 @@
     .search-tips-button {
         display: none;
     }
-    #form-mod-search:focus-within .search-tips {
+    /* tie the tips to the search box, not the whole form (the toggle is in it too) */
+    .search-box:focus ~ .search-tips {
         visibility: visible;
         opacity: 1;
     }

--- a/frontend/styles/navigation.scss
+++ b/frontend/styles/navigation.scss
@@ -230,13 +230,11 @@
     float: left;
 }
 
-/* Dark mode toggle; moon/sun stacked and cross-faded on swap */
 .dark-mode-toggle {
     position: relative;
     width: 22px;
     height: 22px;
     display: inline-block;
-    /* line up with the search box (Bootstrap puts it on vertical-align: middle) */
     vertical-align: middle;
     background: none;
     border: 0;
@@ -261,7 +259,6 @@
         transition: opacity 0.2s ease-in-out;
     }
 
-    /* moon visible in light mode, sun in dark mode (flipped below) */
     .icon-moon { opacity: 1; }
     .icon-sun { opacity: 0; }
 }

--- a/frontend/styles/stylesheet.scss
+++ b/frontend/styles/stylesheet.scss
@@ -72,6 +72,22 @@ input[type="text"], input[type="password"], input[type="email"] {
 footer {
     padding-top: 20px;
     padding-bottom: 20px;
+    // Continues the home page's cyan bands (#register is #057893) so the
+    // bottom of the page reads as one piece. White links for contrast.
+    background-color: #057893;
+    color: #fff;
+
+    a {
+        color: #fff;
+
+        &:hover, &:focus {
+            color: #cdd6ee;
+        }
+    }
+
+    hr {
+        border-top-color: rgba(255, 255, 255, 0.25);
+    }
 }
 
 .error-banner {

--- a/frontend/styles/stylesheet.scss
+++ b/frontend/styles/stylesheet.scss
@@ -72,21 +72,14 @@ input[type="text"], input[type="password"], input[type="email"] {
 footer {
     padding-top: 20px;
     padding-bottom: 20px;
-    // Continues the home page's cyan bands (#register is #057893) so the
-    // bottom of the page reads as one piece. White links for contrast.
-    background-color: #057893;
-    color: #fff;
 
+    // dark links for the white page bg; home page overrides to cyan (index.scss)
     a {
-        color: #fff;
+        color: #057893;
 
         &:hover, &:focus {
-            color: #cdd6ee;
+            color: #04576c;
         }
-    }
-
-    hr {
-        border-top-color: rgba(255, 255, 255, 0.25);
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% block body_class %} home{% endblock %}
 {% block styles %}
 <link rel="stylesheet" type="text/css" href="/static/index.css" />
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -72,7 +72,7 @@
         <noscript><p><img src="//stats.52k.de/matomo.php?idsite=10&amp;rec=1" style="border:0;" alt="" /></p></noscript>
         <!-- End Piwik Code -->
     </head>
-    <body class="{% if user %}logged-in{% endif %}">
+    <body class="{% if user %}logged-in{% endif %}{% block body_class %}{% endblock %}">
         {% block nav %}
         <nav class="navbar navbar-default navbar-fixed-top {% if admin %}navbar-admin{% endif %}" role="navigation" >
             <div class="container">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -43,6 +43,17 @@
         <link href="/static/bootstrap-theme.css" rel="stylesheet">
         {% block styles %}
         {% endblock %}
+        <link href="/static/darkmode.css" rel="stylesheet">
+        <script>
+            // Set the saved theme before the page renders so it doesn't flash.
+            (function () {
+                try {
+                    if (localStorage.getItem('dark-mode') === 'true') {
+                        document.documentElement.classList.add('dark-mode');
+                    }
+                } catch (e) { /* localStorage unavailable (e.g. private mode) */ }
+            })();
+        </script>
         <!-- Piwik -->
           {% if admin %}
               {% set VisitorType = 'Admin' %}
@@ -128,6 +139,19 @@
                     {% block search %}
                     <form id="form-mod-search" class="navbar-form navbar-search" role="search" action="{% if ga %}/{{ ga.short }}{% endif %}/search" method="GET">
                         <div class="form-group vertical-centered">
+                            {# Dark mode toggle (moon/sun swapped via the dark-mode class) #}
+                            <button type="button" id="dark-mode-toggle" class="dark-mode-toggle"
+                                    title="Toggle dark mode" aria-label="Toggle dark mode" aria-pressed="false">
+                                <svg class="dark-mode-icon icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                    <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454l0 .008"/>
+                                </svg>
+                                <svg class="dark-mode-icon icon-sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                    <path d="M8 12a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"/>
+                                    <path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"/>
+                                </svg>
+                            </button>
                             <a href="#" class="search-tips-button">
                                 <span class="glyphicon glyphicon-question-sign"></span>
                             </a>

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -323,9 +323,6 @@
         <a data-toggle="tab" href="#stats" class="btn btn-info">Stats</a>
     </div>
 </div>
-</div>
-
-<div class="container">
     <div class="tab-content">
         <div class="tab-pane active space-left-right" id="info">
             {{ mod.description | markdown | bleach }}

--- a/templates/mod.html
+++ b/templates/mod.html
@@ -315,12 +315,14 @@
 </div>
 <div class="col-lg-5">
 
+<div class="container">
 <div class="tab-container">
-    <div class="mod-tabs container">
+    <div class="mod-tabs">
         <a data-toggle="tab" href="#info" class="btn btn-primary">Information</a>
         <a data-toggle="tab" href="#changelog" class="btn btn-warning">Changelog</a>
         <a data-toggle="tab" href="#stats" class="btn btn-info">Stats</a>
     </div>
+</div>
 </div>
 
 <div class="container">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,15 +1,15 @@
 {% extends "layout.html" %}
-{% block styles %}
-<link rel="stylesheet" type="text/css" href="/static/mod.css" />
-{% endblock %}
-{% block title %}
-<title>{{ profile.username }} on {{ site_name }}</title>
-{% endblock %}
-{% block body %}
-<form action="/profile/{{ profile.username }}/edit" method="POST">
-    <div class="header upload-well scrollable" id="header-well" style="
-        {% if background %}background-image: url({{ background }});{% endif %}
-        background-position: 0 {% if profile.bgOffsetY %}{{ profile.bgOffsetY }}px{% else %}0{% endif %};
+    {% block styles %}
+    <link rel="stylesheet" type="text/css" href="/static/mod.css" />
+    {% endblock %}
+    {% block title %}
+    <title>{{ profile.username }} on {{ site_name }}</title>
+    {% endblock %}
+    {% block body %}
+    <form action="/profile/{{ profile.username }}/edit" method="POST">
+        <div class="header upload-well scrollable" id="header-well" style="
+            {% if background %}background-image: url({{ background }});{% endif %}
+            background-position: 0 {% if profile.bgOffsetY %}{{ profile.bgOffsetY }}px{% else %}0{% endif %};
         background-color: #ddd;"
         data-event="upload_bg"
         data-scroll-y="bg-offset-y">
@@ -43,7 +43,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-6">
-                    <p>Let people know where to find you on other sites (optional):</p>
+                    <p style="margin-bottom: 30px;">Let people know where to find you on other sites (optional):</p>
                     <div class="timeline-centered">
                         <div class="timeline-entry">
                             <div class="timeline-entry-inner">
@@ -51,7 +51,7 @@
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
                                 <div class="timeline-label">
-                                    <h2 style="margin-bottom: -20px;" class="form-group">
+                                    <h2 style="margin-top: -20px; padding-bottom: 10px;" class="form-group">
                                         <span class="text-muted">
                                             KSP forum link:
                                         </span>
@@ -66,7 +66,7 @@
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
                                 <div class="timeline-label">
-                                    <h2 style="margin-bottom: -10px;" class="form-group">
+                                    <h2 style="margin-top: -20px; padding-bottom: 10px;" class="form-group">
                                         <span class="text-muted">
                                             KerbalX username:
                                         </span>
@@ -82,7 +82,7 @@
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
                                 <div class="timeline-label">
-                                    <h2 style="margin-bottom: -10px;" class="form-group">
+                                    <h2 style="margin-top: -20px; padding-bottom: 10px;" class="form-group">
                                         <span class="text-muted">
                                             GitHub username:
                                         </span>
@@ -98,7 +98,7 @@
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
                                 <div class="timeline-label">
-                                    <h2 style="margin-bottom: -10px;" class="form-group">
+                                    <h2 style="margin-top: -20px; padding-bottom: 10px;" class="form-group">
                                         <span class="text-muted">
                                             Twitter username:
                                         </span>
@@ -114,7 +114,7 @@
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
                                 <div class="timeline-label">
-                                    <h2 style="margin-top: -10px; margin-bottom: 0;" class="form-group">
+                                    <h2 style="margin-top: -20px; padding-bottom: 10px;" class="form-group">
                                         <span class="text-muted">
                                             Reddit username:
                                         </span>
@@ -126,7 +126,7 @@
                             </div>
                         </div>
                         <div class="timeline-entry">
-                            <div class="timeline-entry-inner" style="background: #F5F5F5;">
+                            <div class="timeline-entry-inner">
                                 <div class="timeline-icon">
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
@@ -142,7 +142,7 @@
                             </div>
                         </div>
                         <div class="timeline-entry">
-                            <div class="timeline-entry-inner" style="background: #F5F5F5;">
+                            <div class="timeline-entry-inner">
                                 <div class="timeline-icon">
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
@@ -159,7 +159,7 @@
                             </div>
                         </div>
                         <div class="timeline-entry">
-                            <div class="timeline-entry-inner" style="background: #F5F5F5;">
+                            <div class="timeline-entry-inner">
                                 <div class="timeline-icon">
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
@@ -176,7 +176,7 @@
                             </div>
                         </div>
                         <div class="timeline-entry">
-                            <div class="timeline-entry-inner" style="background: #F5F5F5;">
+                            <div class="timeline-entry-inner">
                                 <div class="timeline-icon">
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>
@@ -193,7 +193,7 @@
                             </div>
                         </div>
                         <div class="timeline-entry">
-                            <div class="timeline-entry-inner" style="background: #F5F5F5;">
+                            <div class="timeline-entry-inner">
                                 <div class="timeline-icon">
                                     <span class="glyphicon glyphicon-link"></span>
                                 </div>


### PR DESCRIPTION
## Motivation

Adds a moon/sun toggle to the navbar (left of the search box) that switches between the existing light theme and a new dark theme. The choice is saved in `localStorage` and applied before first paint to avoid a flash.

## Changes

`darkmode.scss` is a new file containing the dark colour scheme scoped under `html.dark-mode`. It covers Bootstrap components plus SpaceDock's panels, listing boxes, tables, forms, buttons, profile timeline, markdown editor, dropzone and chosen selects.

The toggle button lives inside the search form in `layout.html`, with moon and sun SVGs stacked on top of each other and cross faded via CSS when the class flips. A small inline script in the `<head>` reads `localStorage` and sets the class before the page renders so there's no flash. `localStorage` access is wrapped in try/catch throughout since it can be blocked in private browsing.

The home page bands (`#players`, `#modders`, `#register`) have been unified to the navbar's brand blue (`#1d3c8e`) since the three slightly different shades they had before looked a bit odd. The footer on the home page gets a cyan background in light mode, with overrides to keep links readable; on other pages the footer links default to the same cyan as a text colour instead.

The search tips behaviour had a subtle bug where clicking the dark mode toggle (which is inside the search form) would hide the tips. Fixed by scoping the focus rule to `.search-box:focus` rather than `#form-mod-search:focus-within`.

Timeline entries on the mod page got flexbox alignment so short entries don't look lopsided.

## Images

### Mod Page
<img width="2526" height="1217" alt="image" src="https://github.com/user-attachments/assets/8aed0531-9e03-4b9c-a3eb-126b0a159c0a" />

### Home Page
<img width="2546" height="1252" alt="image" src="https://github.com/user-attachments/assets/501a4392-2ff8-41c7-b32c-65bb68ec62e3" />
