### PR TITLE
Fix 500 error when removing a mod from a pack

### DIFF
--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -367,7 +367,8 @@ class ModListItem(Base):  # type: ignore
     mod = relationship('Mod', backref=backref('mod_list_items', passive_deletes=True))
     mod_list_id = Column(Integer, ForeignKey('modlist.id', ondelete='CASCADE'), nullable=False)
     mod_list = relationship('ModList',
-                            backref=backref('mods', passive_deletes=True, order_by="asc(ModListItem.sort_index)"))
+                            backref=backref('mods', passive_deletes=True, cascade="all, delete-orphan",
+                                            order_by="asc(ModListItem.sort_index)"))
     sort_index = Column(Integer, default=0, nullable=False)
 
     def __repr__(self) -> str:

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -79,6 +79,8 @@
         flex: 1 1 auto;
         min-width: 0;
 
+        // Drop the default h2 margins so the caption + input block is the
+        // full height of the row
         h2 {
             margin: 0;
         }

--- a/frontend/styles/mod.scss
+++ b/frontend/styles/mod.scss
@@ -79,9 +79,6 @@
         flex: 1 1 auto;
         min-width: 0;
 
-        // Drop the default h2 margins so the caption + input block is the
-        // full height of the row; align-items:center then centers the icon
-        // against it (caption above, input below, icon level with input).
         h2 {
             margin: 0;
         }


### PR DESCRIPTION
## Fix 500 error when removing a mod from a pack

Fixes #516

Removing a mod from a pack threw a 500 every time, so the only workaround was deleting the pack and rebuilding it.

The cause: `edit_list()` removes items with `mod_list.mods.remove(mod)`, but the `mods` relationship had no `delete-orphan` cascade. SQLAlchemy tried to set `mod_list_id` to NULL instead of deleting the row, and that column is NOT NULL, so the change failed.

Fix: add `cascade="all, delete-orphan"` to the `mods` backref so the item is deleted on removal. No `lists.py` change and no migration needed.

Tested locally by running the removal path directly: fails with the NOT NULL violation before, succeeds after. Adding mods and deleting packs still work.
