### PR TITLE
Automatically set the theme based on OS theme settings

### DIFF
--- a/frontend/coffee/global.coffee
+++ b/frontend/coffee/global.coffee
@@ -63,7 +63,8 @@ $('#alert-error').on 'close.bs.alert', () ->
     $('#alert-error').addClass 'hidden'
     return false
 
-# Dark mode toggle choice saved in localStorage, aplied early in layout.html
+# Dark mode an explicit toggle choice is saved in localStorage (and applied
+# early in layout.html) with no saved choice we follow the OS theme
 darkModeToggle = document.getElementById('dark-mode-toggle')
 if darkModeToggle?
     root = document.documentElement
@@ -80,6 +81,23 @@ if darkModeToggle?
             # localStorage can be blocked (private mode)
         updateDarkModeButton()
     , false)
+
+    # Follow the OS theme live but only until the user makes an explicit choice
+    if window.matchMedia?
+        mq = window.matchMedia('(prefers-color-scheme: dark)')
+        applySystemTheme = (e) ->
+            explicit = false
+            try
+                explicit = localStorage.getItem('dark-mode') isnt null
+            catch error
+                explicit = false
+            unless explicit
+                root.classList.toggle('dark-mode', e.matches)
+                updateDarkModeButton()
+        if mq.addEventListener?
+            mq.addEventListener('change', applySystemTheme)
+        else if mq.addListener?
+            mq.addListener(applySystemTheme)
 
 $('.search-tips-button').on 'click', (e) ->
     $('.search-tips').addClass 'search-tips-visible'

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -45,10 +45,15 @@
         {% endblock %}
         <link href="/static/darkmode.css" rel="stylesheet">
         <script>
-            // Set the saved theme before the page renders so it doesn't flash.
+            // Set the theme before the page renders so it doesn't flash
+            // An explicit toggle choice wins otherwise follow the OS theme
             (function () {
                 try {
-                    if (localStorage.getItem('dark-mode') === 'true') {
+                    var stored = localStorage.getItem('dark-mode');
+                    var dark = stored === null
+                        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+                        : stored === 'true';
+                    if (dark) {
                         document.documentElement.classList.add('dark-mode');
                     }
                 } catch (e) { /* localStorage unavailable (e.g. private mode) */ }


### PR DESCRIPTION
This pull request updates the application's dark mode behavior to better respect user preferences and the system (OS) theme. 

**Dark mode preference improvements:**

* In `templates/layout.html`, the logic for setting the initial theme now prioritizes an explicit user choice stored in `localStorage`; if no choice exists, it checks the OS theme using `window.matchMedia` and applies dark mode accordingly.
* In `frontend/coffee/global.coffee`, added code to listen for changes to the OS theme (`prefers-color-scheme: dark`) and automatically update the site's theme live, but only if the user hasn't made an explicit choice. 