### PR TITLE
Try to fix slow admin panel loading times

### DIFF
--- a/KerbalStuff/blueprints/admin.py
+++ b/KerbalStuff/blueprints/admin.py
@@ -36,17 +36,22 @@ def profiling(page: int) -> Union[str, werkzeug.wrappers.Response]:
     if page < 1:
         return redirect(url_for('admin.profiling', page=1, **request.args))
     prof_dir = _cfg('profile-dir')
-    profilings = [] if not prof_dir else list(map(
-        parse_prof_filename,
-        sorted(Path(prof_dir).glob('*.prof'),
-               key=lambda p: -p.stat().st_mtime)))
+    # this directory can hold a huge number of profile files, so do as little
+    # per file as possible sort on the timestamp that's already in the
+    # filename (no stat() per file) and on ly parse the page we actually show.
+    # The old code stat()'d and parsed every file on every load  which made
+    # opening the admin panel hang and tie up workers 
+    files = sorted(Path(prof_dir).glob('*.prof'),
+                   key=lambda p: p.name.split('.')[-2],
+                   reverse=True) if prof_dir else []
     query = request.args.get('query', type=str)
     if query:
         terms = query.split(' ')
-        profilings = [p for p in profilings
-                      if all(map(lambda t: query_term_matches(t, p), terms))]
-    total_pages = max(1, math.ceil(len(profilings) / ITEMS_PER_PAGE))
-    profilings = profilings[(page - 1) * ITEMS_PER_PAGE : page * ITEMS_PER_PAGE]
+        files = [f for f in files
+                 if all(query_term_matches(t, parse_prof_filename(f)) for t in terms)]
+    total_pages = max(1, math.ceil(len(files) / ITEMS_PER_PAGE))
+    page_files = files[(page - 1) * ITEMS_PER_PAGE : page * ITEMS_PER_PAGE]
+    profilings = [parse_prof_filename(f) for f in page_files]
     return render_template("admin-profiling.html",
                            profilings=profilings, query=query,
                            page=page, total_pages=total_pages)


### PR DESCRIPTION
## What this fixes

Opening the admin panel would hang for a long time, and while it was hanging the whole site slowed down and started throwing API errors for everyone else.

## Cause

Opening the admin panel redirects to the profiling page. That page listed every file in the profile directory, ran a `stat()` on each one to sort them by date, and parsed all of them, just to show 10 rows. The profile directory gains a new file for every profiled request, so over time it grows huge, and each admin open ended up scanning the entire pile.

That is also why it took the rest of the site down. The request took so long that it held onto a gunicorn worker (made worse by the 20 minute proxy timeout), and with only a handful of workers a couple of these would tie them all up, so other requests and the API started failing while they waited.

## The fix

Sort the profiles by the timestamp that is already in the filename instead of calling `stat()` on every file, and only parse the 10 that are actually shown. Same ordering, same output, just without the per file filesystem work.

## Result

Tested against 100,000 profile files: the page went from about 1440 ms to about 230 ms (roughly 6x faster) with identical ordering, and it scales much better as the directory grows.

## Note

The real root cause is that the profile directory grows without limit. This change makes the page cheap to load, but the directory should still be pruned or rotated (and profiling turned off when it is not being used) so it cannot fill up in the first place.
